### PR TITLE
Add BloomFilter64 to support large Bloom filters

### DIFF
--- a/ProbabilisticDataStructures/BloomFilter64.cs
+++ b/ProbabilisticDataStructures/BloomFilter64.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ProbabilisticDataStructures;
+using System.Security.Cryptography;
+
+namespace ProbabilisticDataStructures
+{
+    /// <summary>
+    /// BloomFilter64 implements a classic Bloom filter. A bloom filter has a non-zero
+    /// probability of false positives and a zero probability of false negatives.
+    /// </summary>
+    public class BloomFilter64 : IFilter
+    {
+        /// <summary>
+        /// Filter data
+        /// </summary>
+        internal Buckets64 Buckets { get; set; }
+        /// <summary>
+        /// Hash algorithm
+        /// </summary>
+        private HashAlgorithm Hash { get; set; }
+        /// <summary>
+        /// Filter size
+        /// </summary>
+        private ulong m { get; set; }
+        /// <summary>
+        /// Number of hash functions
+        /// </summary>
+        private uint k { get; set; }
+        /// <summary>
+        /// Number of items added
+        /// </summary>
+        private ulong count { get; set; }
+
+        /// <summary>
+        /// Creates a new Bloom filter optimized to store n items with a specified target
+        /// false-positive rate.
+        /// </summary>
+        /// <param name="n">Number of items to store.</param>
+        /// <param name="fpRate">Desired false positive rate.</param>
+        public BloomFilter64(ulong n, double fpRate)
+        {
+            var m = Utils.OptimalM64(n, fpRate);
+            var k = Utils.OptimalK(fpRate);
+            Buckets = new Buckets64(m, 1);
+            Hash = Defaults.GetDefaultHashAlgorithm();
+            this.m = m;
+            this.k = k;
+        }
+
+        /// <summary>
+        /// Returns the Bloom filter capacity, m.
+        /// </summary>
+        /// <returns>The Bloom filter capacity, m.</returns>
+        public ulong Capacity()
+        {
+            return this.m;
+        }
+
+        /// <summary>
+        /// Returns the number of hash functions.
+        /// </summary>
+        /// <returns>The number of hash functions.</returns>
+        public uint K()
+        {
+            return this.k;
+        }
+
+        /// <summary>
+        /// Returns the number of items in the filter.
+        /// </summary>
+        /// <returns></returns>
+        public ulong Count()
+        {
+            return this.count;
+        }
+
+        /// <summary>
+        /// Returns the current estimated ratio of set bits.
+        /// </summary>
+        /// <returns>The current estimated ratio of set bits.</returns>
+        public double EstimatedFillRatio()
+        {
+            return 1 - Math.Exp((-(double)this.count * (double)this.k) / (double)this.m);
+        }
+
+        /// <summary>
+        /// Returns the ratio of set bits.
+        /// </summary>
+        /// <returns>The ratio of set bits.</returns>
+        public double FillRatio()
+        {
+            ulong sum = 0;
+            for (ulong i = 0; i < this.Buckets.count; i++)
+            {
+                sum += this.Buckets.Get(i);
+            }
+            return (double)sum / (double)this.m;
+        }
+
+        /// <summary>
+        /// Will test for membership of the data and returns true if it is a member,
+        /// false if not. This is a probabilistic test, meaning there is a non-zero
+        /// probability of false positives but a zero probability of false negatives.
+        /// </summary>
+        /// <param name="data">The data to search for.</param>
+        /// <returns>Whether or not the data is maybe contained in the filter.</returns>
+        public bool Test(byte[] data)
+        {
+            var hashKernel = Utils.HashKernel128(data, this.Hash);
+            var lower = hashKernel.LowerBaseHash;
+            var upper = hashKernel.UpperBaseHash;
+
+            // If any of the K bits are not set, then it's not a member.
+            for (uint i = 0; i < this.k; i++)
+            {
+                if (this.Buckets.Get((lower + upper * i) % this.m) == 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Will add the data to the Bloom filter. It returns the filter to allow
+        /// for chaining.
+        /// </summary>
+        /// <param name="data">The data to add.</param>
+        /// <returns>The filter.</returns>
+        public IFilter Add(byte[] data)
+        {
+            var hashKernel = Utils.HashKernel128(data, this.Hash);
+            var lower = hashKernel.LowerBaseHash;
+            var upper = hashKernel.UpperBaseHash;
+
+            // Set the K bits.
+            for (uint i = 0; i < this.k; i++)
+            {
+                this.Buckets.Set((lower + upper * i) % this.m, 1);
+            }
+
+            this.count++;
+            return this;
+        }
+
+        /// <summary>
+        /// Is equivalent to calling Test followed by Add. It returns true if the data is
+        /// a member, false if not.
+        /// </summary>
+        /// <param name="data">The data to test for and add if it doesn't exist.</param>
+        /// <returns>Whether or not the data was probably contained in the filter.</returns>
+        public bool TestAndAdd(byte[] data)
+        {
+            var hashKernel = Utils.HashKernel128(data, this.Hash);
+            var lower = hashKernel.LowerBaseHash;
+            var upper = hashKernel.UpperBaseHash;
+            var member = true;
+
+            // If any of the K bits are not set, then it's not a member.
+            for (uint i = 0; i < this.k; i++)
+            {
+                var idx = (lower + upper * i) % this.m;
+                if (this.Buckets.Get(idx) == 0)
+                {
+                    member = false;
+                }
+                this.Buckets.Set(idx, 1);
+            }
+
+            this.count++;
+            return member;
+        }
+
+        /// <summary>
+        /// Restores the Bloom filter to its original state. It returns the filter to
+        /// allow for chaining.
+        /// </summary>
+        /// <returns>The reset bloom filter.</returns>
+        public BloomFilter64 Reset()
+        {
+            this.Buckets.Reset();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the hashing function used in the filter.
+        /// </summary>
+        /// <param name="h">The HashAlgorithm to use.</param>
+        // TODO: Add SetHash to the IFilter interface?
+        public void SetHash(HashAlgorithm h)
+        {
+            this.Hash = h;
+        }
+    }
+}

--- a/ProbabilisticDataStructures/Buckets64.cs
+++ b/ProbabilisticDataStructures/Buckets64.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProbabilisticDataStructures
+{
+    /// <summary>
+    /// Buckets64 is a fast, space-efficient array of buckets where each bucket can store
+    /// up to a configured maximum value.
+    /// </summary>
+    public class Buckets64
+    {
+        // The largest C# array to create; the largest power of 2 that C# can support.
+        private const uint maxArraySize = 1U << 30;
+        private byte[][] Data { get; set; }
+        private int arrayCount { get; set; }
+        private byte bucketSize { get; set; }
+        private byte _max;
+        private int Max
+        {
+            get
+            {
+                return _max;
+            }
+            set
+            {
+                // TODO: Figure out this truncation thing.
+                // I'm not sure if MaxValue is always supposed to be capped at 255 via
+                // a byte conversion or not...
+                if (value > byte.MaxValue)
+                    _max = byte.MaxValue;
+                else
+                    _max = (byte)value;
+            }
+        }
+        internal ulong count { get; set; }
+
+        /// <summary>
+        /// Creates a new Buckets64 with the provided number of buckets where each bucket
+        /// is the specified number of bits.
+        /// </summary>
+        /// <param name="count">Number of buckets.</param>
+        /// <param name="bucketSize">Number of bits per bucket.</param>
+        internal Buckets64(ulong count, byte bucketSize)
+        {
+            this.count = count;
+            this.bucketSize = bucketSize;
+            AllocateArray(count, bucketSize);
+            this.Max = (1 << bucketSize) - 1;
+        }
+
+        private void AllocateArray(ulong count, byte bucketSize)
+        {
+            this.arrayCount = (int)(count / maxArraySize + 1);
+            this.Data = new byte[this.arrayCount][];
+            var bytesToAllocate = (count * bucketSize + 7) / 8;
+            for (int i = 0; i < this.arrayCount; i++)
+            {
+                var arraySize = Math.Min(bytesToAllocate, maxArraySize);
+                this.Data[i] = new byte[arraySize];
+                bytesToAllocate -= arraySize;
+            }
+        }
+
+        /// <summary>
+        /// Returns the maximum value that can be stored in a bucket.
+        /// </summary>
+        /// <returns>The bucket max value.</returns>
+        internal byte MaxBucketValue()
+        {
+            return this._max;
+        }
+
+        /// <summary>
+        /// Increment the value in the specified bucket by the provided delta. A bucket
+        /// can be decremented by providing a negative delta.
+        /// <para>
+        ///     The value is clamped to zero and the maximum bucket value. Returns itself
+        ///     to allow for chaining.
+        /// </para>
+        /// </summary>
+        /// <param name="bucket">The bucket to increment.</param>
+        /// <param name="delta">The amount to increment the bucket by.</param>
+        /// <returns>The modified bucket.</returns>
+        internal Buckets64 Increment(uint bucket, int delta)
+        {
+            int val = (int)(GetBits(bucket * this.bucketSize, this.bucketSize) + delta);
+
+            if (val > this.Max)
+                val = this.Max;
+            else if (val < 0)
+                val = 0;
+
+            SetBits((uint)bucket * (uint)this.bucketSize, this.bucketSize, (uint)val);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the bucket value. The value is clamped to zero and the maximum bucket
+        /// value. Returns itself to allow for chaining.
+        /// </summary>
+        /// <param name="bucket">The bucket to change the value of.</param>
+        /// <param name="value">The value to set.</param>
+        /// <returns>The modified bucket.</returns>
+        internal Buckets64 Set(ulong bucket, byte value)
+        {
+            if (value > this._max)
+                value = this._max;
+
+            SetBits(bucket * this.bucketSize, this.bucketSize, value);
+            return this;
+        }
+
+        /// <summary>
+        /// Returns the value in the specified bucket.
+        /// </summary>
+        /// <param name="bucket">The bucket to get.</param>
+        /// <returns>The specified bucket.</returns>
+        internal uint Get(ulong bucket)
+        {
+            return GetBits(bucket * this.bucketSize, this.bucketSize);
+        }
+
+        /// <summary>
+        /// Restores the Buckets64 to the original state. Returns itself to allow for
+        /// chaining.
+        /// </summary>
+        /// <returns>The Buckets64 object the reset operation was performed on.</returns>
+        internal Buckets64 Reset()
+        {
+            AllocateArray(this.count, this.bucketSize);
+            return this;
+        }
+
+        /// <summary>
+        /// Returns the bits at the specified offset and length.
+        /// </summary>
+        /// <param name="offset">The position to start reading at.</param>
+        /// <param name="length">The distance to read from the offset.</param>
+        /// <returns>The bits at the specified offset and length.</returns>
+        internal uint GetBits(ulong offset, int length)
+        {
+            ulong byteIndex = offset / 8;
+            int byteOffset = (int)(offset % 8);
+
+            if ((byteOffset + length) > 8)
+            {
+                int rem = 8 - byteOffset;
+                return GetBits(offset, rem)
+                    | (GetBits(offset + (ulong)rem, length - rem) << rem);
+            }
+
+            var dataArray = this.Data[byteIndex / maxArraySize];
+            var dataArrayByteIndex = byteIndex % maxArraySize;
+            int bitMask = (1 << length) - 1;
+            return (uint)((dataArray[dataArrayByteIndex] & (bitMask << byteOffset)) >> byteOffset);
+        }
+
+        /// <summary>
+        /// Sets bits at the specified offset and length.
+        /// </summary>
+        /// <param name="offset">The position to start writing at.</param>
+        /// <param name="length">The distance to write from the offset.</param>
+        /// <param name="bits">The bits to write.</param>
+        internal void SetBits(ulong offset, int length, uint bits)
+        {
+            ulong byteIndex = offset / 8;
+            int byteOffset = (int)(offset % 8);
+
+            if ((byteOffset + length) > 8)
+            {
+                int rem = 8 - byteOffset;
+                SetBits(offset, (byte)rem, bits);
+                SetBits(offset + (ulong)rem, length - rem, bits >> rem);
+                return;
+            }
+
+            var dataArray = this.Data[(uint)(byteIndex / maxArraySize)];
+            var dataArrayByteIndex = (uint)(byteIndex % maxArraySize);
+            int bitMask = (1 << length) - 1;
+            dataArray[dataArrayByteIndex] =
+                (byte)((dataArray[dataArrayByteIndex]) & ~(bitMask << byteOffset));
+            dataArray[dataArrayByteIndex] =
+                (byte)((dataArray[dataArrayByteIndex]) | ((bits & bitMask) << byteOffset));
+        }
+    }
+}

--- a/ProbabilisticDataStructures/Hash128.cs
+++ b/ProbabilisticDataStructures/Hash128.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProbabilisticDataStructures
+{
+    public class Hash128
+    {
+        internal HashAlgorithm HashAlgorithm { get; private set; }
+
+        /// <summary>
+        /// Create a new Hash object that will use the specified hashing algorithm.
+        /// </summary>
+        /// <param name="hashAlgorithm">The desired
+        /// System.Security.Cryptography.HashAlgorithm.</param>
+        public Hash128(HashAlgorithm hashAlgorithm)
+        {
+            HashAlgorithm = hashAlgorithm;
+        }
+
+        /// <summary>
+        /// Compute the hash for the provided bytes.
+        /// </summary>
+        /// <param name="inputBytes">The bytes to hash.</param>
+        /// <returns>The hash string of the bytes.</returns>
+        public string ComputeHash(byte[] inputBytes)
+        {
+            // Compute the hash of the input byte array.
+            byte[] data = HashAlgorithm.ComputeHash(inputBytes);
+
+            // Create a new StringBuilder to collect the bytes and create a string.
+            StringBuilder sb = new StringBuilder();
+
+            // Loop through each byte of the hashed data and format each one as a
+            // hexadecimal string.
+            for (int i = 0; i < data.Length; i++)
+            {
+                sb.Append(data[i].ToString("X2"));
+            }
+
+            // Return the hexadecimal string.
+            return sb.ToString();
+        }
+
+        public byte[] Sum(string hashString)
+        {
+            var bytes = StringToByteArray(hashString);
+            return SumHashByte(bytes);
+        }
+
+        public byte[] ComputeHashAndSum(byte[] inputBytes)
+        {
+            // Compute the hash of the input byte array.
+            var bytes = HashAlgorithm.ComputeHash(inputBytes);
+            return SumHashByte(bytes);
+        }
+
+        private byte[] SumHashByte(byte[] hashBytes)
+        {
+            var uint64 = BitConverter.ToUInt64(hashBytes, 0);
+            var uint64_2 = BitConverter.ToUInt64(hashBytes, 8);
+            return new byte[]{
+                ShiftRight(uint64, 56),
+                ShiftRight(uint64, 48),
+                ShiftRight(uint64, 40),
+                ShiftRight(uint64, 32),
+                ShiftRight(uint64, 24),
+                ShiftRight(uint64, 16),
+                ShiftRight(uint64, 8),
+                ShiftRight(uint64, 0),
+                ShiftRight(uint64_2, 56),
+                ShiftRight(uint64_2, 48),
+                ShiftRight(uint64_2, 40),
+                ShiftRight(uint64_2, 32),
+                ShiftRight(uint64_2, 24),
+                ShiftRight(uint64_2, 16),
+                ShiftRight(uint64_2, 8),
+                ShiftRight(uint64_2, 0)
+                };
+        }
+
+        private byte ShiftRight(UInt64 n, int amount)
+        {
+            return (byte)(n >> amount);
+        }
+
+        private byte[] StringToByteArray(String hex)
+        {
+            // http://stackoverflow.com/questions/311165/how-do-you-convert-byte-array-to-hexadecimal-string-and-vice-versa
+            int NumberChars = hex.Length;
+            byte[] bytes = new byte[NumberChars / 2];
+            for (int i = 0; i < NumberChars; i += 2)
+                bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+            return bytes;
+        }
+    }
+}

--- a/ProbabilisticDataStructures/Utils.cs
+++ b/ProbabilisticDataStructures/Utils.cs
@@ -21,6 +21,20 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Calculates the optimal Bloom filter size, m, based on the number of items and
+        /// the desired rate of false positives.
+        /// </summary>
+        /// <param name="n">Number of items.</param>
+        /// <param name="fpRate">Desired false positive rate.</param>
+        /// <returns>The optimal BloomFilter size, m.</returns>
+        public static ulong OptimalM64(ulong n, double fpRate)
+        {
+            var optimalM = Math.Ceiling((double)n / ((Math.Log(Defaults.FILL_RATIO) *
+                Math.Log(1 - Defaults.FILL_RATIO)) / Math.Abs(Math.Log(fpRate))));
+            return Convert.ToUInt64(optimalM);
+        }
+
+        /// <summary>
         /// Calculates the optimal number of hash functions to use for a Bloom filter
         /// based on the desired rate of false positives.
         /// </summary>
@@ -50,12 +64,38 @@ namespace ProbabilisticDataStructures
                 );
         }
 
+        /// <summary>
+        /// Returns the upper and lower base hash values from which the k hashes are
+        /// derived.
+        /// </summary>
+        /// <param name="data">The data bytes to hash.</param>
+        /// <param name="algorithm">The hashing algorithm to use.</param>
+        /// <returns>A HashKernel</returns>
+        public static HashKernel128ReturnValue HashKernel128(byte[] data, HashAlgorithm algorithm)
+        {
+            var hash = new Hash128(algorithm);
+            var sum = hash.ComputeHashAndSum(data);
+            return HashKernel128ReturnValue.Create(
+                ToBigEndianUInt64(sum, 8),
+                ToBigEndianUInt64(sum, 0)
+                );
+        }
+
         public static uint ToBigEndianUInt32(byte[] bytes)
         {
             if (BitConverter.IsLittleEndian)
                 Array.Reverse(bytes);
 
             uint i = BitConverter.ToUInt32(bytes, 0);
+            return i;
+        }
+
+        public static ulong ToBigEndianUInt64(byte[] bytes, int offset)
+        {
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(bytes, offset, 8);
+
+            ulong i = BitConverter.ToUInt64(bytes, offset);
             return i;
         }
     }
@@ -71,6 +111,20 @@ namespace ProbabilisticDataStructures
             {
                 UpperBaseHash = upperBaseHash,
                 LowerBaseHash = lowerBaseHash
+            };
+        }
+    }
+
+    public struct HashKernel128ReturnValue
+    {
+        public ulong UpperBaseHash { get; private set; }
+        public ulong LowerBaseHash { get; private set; }
+        public static HashKernel128ReturnValue Create(ulong lowerBaseHash, ulong upperBaseHash)
+        {
+            return new HashKernel128ReturnValue
+            {
+                UpperBaseHash = upperBaseHash,
+                LowerBaseHash = lowerBaseHash,
             };
         }
     }

--- a/TestProbabilisticDataStructures/TestBloomFilter64.cs
+++ b/TestProbabilisticDataStructures/TestBloomFilter64.cs
@@ -1,0 +1,235 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+using System.Text;
+using System.Collections.Generic;
+
+namespace TestProbabilisticDataStructures
+{
+    [TestClass]
+    public class TestBloomFilter64
+    {
+        private static byte[] A_BYTES = Encoding.ASCII.GetBytes("a");
+        private static byte[] B_BYTES = Encoding.ASCII.GetBytes("b");
+        private static byte[] C_BYTES = Encoding.ASCII.GetBytes("c");
+        private static byte[] X_BYTES = Encoding.ASCII.GetBytes("x");
+
+        /// <summary>
+        /// Ensures that Capacity() returns the number of bits, m, in the Bloom filter.
+        /// </summary>
+        [TestMethod]
+        public void TestBloomCapacity()
+        {
+            var f = new BloomFilter64(100, 0.1);
+            var capacity = f.Capacity();
+
+            Assert.AreEqual(480u, capacity);
+        }
+
+        /// <summary>
+        /// Ensures that K() returns the number of hash functions in the Bloom Filter.
+        /// </summary>
+        [TestMethod]
+        public void TestBloom64K()
+        {
+            var f = new BloomFilter64(100, 0.1);
+            var k = f.K();
+
+            Assert.AreEqual(4u, k);
+        }
+
+        /// <summary>
+        /// Ensures that Count returns the number of items added to the filter.
+        /// </summary>
+        [TestMethod]
+        public void TestBloom64Count()
+        {
+            var f = new BloomFilter64(100, 0.1);
+            for (uint i = 0; i < 10; i++)
+            {
+                f.Add(Encoding.ASCII.GetBytes(i.ToString()));
+            }
+
+            var count = f.Count();
+            Assert.AreEqual(10u, count);
+        }
+
+        /// <summary>
+        /// Ensures that EstimatedFillRatio returns the correct approximation.
+        /// </summary>
+        [TestMethod]
+        public void TestBloom64EstimatedFillRatio()
+        {
+            var f = new BloomFilter64(100, 0.5);
+            for (uint i = 0; i < 100; i++)
+            {
+                f.Add(Encoding.ASCII.GetBytes(i.ToString()));
+            }
+
+            var ratio = f.EstimatedFillRatio();
+            if (ratio > 0.5)
+            {
+                Assert.Fail("Expected less than or equal to 0.5, got {0}", ratio);
+            }
+        }
+
+        /// <summary>
+        /// Ensures that FillRatio returns the ratio of set bits.
+        /// </summary>
+        [TestMethod]
+        public void TestBloom64FillRatio()
+        {
+            var f = new BloomFilter64(100, 0.1);
+            f.Add(A_BYTES);
+            f.Add(B_BYTES);
+            f.Add(C_BYTES);
+
+            var ratio = f.FillRatio();
+            Assert.AreEqual(0.025, ratio);
+        }
+
+        /// <summary>
+        /// Ensures that Test, Add, and TestAndAdd behave correctly.
+        /// </summary>
+        [TestMethod]
+        public void TestBloom64TestAndAdd()
+        {
+            var f = new BloomFilter64(100, 0.01);
+
+            // 'a' is not in the filter.
+            if (f.Test(A_BYTES))
+            {
+                Assert.Fail("'a' should not be a member");
+            }
+
+            var addedF = f.Add(A_BYTES);
+            Assert.AreSame(f, addedF, "Returned BloomFilter64 should be the same instance");
+
+            // 'a' is now in the filter.
+            if (!f.Test(A_BYTES))
+            {
+                Assert.Fail("'a' should be a member");
+            }
+
+            // 'a' is still in the filter.
+            if (!f.TestAndAdd(A_BYTES))
+            {
+                Assert.Fail("'a' should be a member");
+            }
+
+            // 'b' is not in the filter.
+            if (f.TestAndAdd(B_BYTES))
+            {
+                Assert.Fail("'b' should not be a member");
+            }
+
+            // 'a' is still in the filter.
+            if (!f.Test(A_BYTES))
+            {
+                Assert.Fail("'a' should be a member");
+            }
+
+            // 'b' is now in the filter.
+            if (!f.Test(B_BYTES))
+            {
+                Assert.Fail("'b' should be a member");
+            }
+
+            // 'c' is not in the filter.
+            if (f.Test(C_BYTES))
+            {
+                Assert.Fail("'c' should not be a member");
+            }
+
+            for (int i = 0; i < 1000000; i++)
+            {
+                f.TestAndAdd(Encoding.ASCII.GetBytes(i.ToString()));
+            }
+
+            // 'x' should be a false positive.
+            if (!f.Test(X_BYTES))
+            {
+                Assert.Fail("'x' should be a member");
+            }
+        }
+
+        /// <summary>
+        /// Ensures that Reset sets every bit to zero.
+        /// </summary>
+        [TestMethod]
+        public void TestBloom64Reset()
+        {
+            var f = new BloomFilter64(100, 0.1);
+            for (int i = 0; i < 1000; i++)
+            {
+                f.Add(Encoding.ASCII.GetBytes(i.ToString()));
+            }
+
+            var resetF = f.Reset();
+            Assert.AreSame(f, resetF, "Returned BloomFilter64 should be the same instance");
+
+            for (uint i = 0; i < f.Buckets.count; i++)
+            {
+                if (f.Buckets.Get(i) != 0)
+                {
+                    Assert.Fail("Expected all bits to be unset");
+                }
+            }
+        }
+    }
+
+    [TestClass]
+    public class BenchmarkBloomFilter64
+    {
+        private BloomFilter64 f;
+        private int n;
+        private byte[][] data;
+
+        [TestInitialize()]
+        public void Testinitialize()
+        {
+            n = 100000;
+            f = new BloomFilter64(100000, 0.1);
+            data = new byte[n][];
+            for (int i = 0; i < n; i++)
+            {
+                data[i] = Encoding.ASCII.GetBytes(i.ToString());
+            }
+        }
+
+        [TestCleanup()]
+        public void TestCleanup()
+        {
+            f = null;
+            n = 0;
+            data = null;
+        }
+
+        [TestMethod]
+        public void BenchmarkBloom64Add()
+        {
+            for (int i = 0; i < n; i++)
+            {
+                f.Add(data[i]);
+            }
+        }
+
+        [TestMethod]
+        public void BenchmarkBloom64Test()
+        {
+            for (int i = 0; i < n; i++)
+            {
+                f.Test(data[i]);
+            }
+        }
+
+        [TestMethod]
+        public void BenchmarkBloom64TestAndAdd()
+        {
+            for (int i = 0; i < n; i++)
+            {
+                f.TestAndAdd(data[i]);
+            }
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestBuckets64.cs
+++ b/TestProbabilisticDataStructures/TestBuckets64.cs
@@ -1,0 +1,120 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    [TestClass]
+    public class TestBuckets64
+    {
+        /// <summary>
+        /// Ensures that Max returns the correct maximum based on the bucket
+        /// size.
+        /// </summary>
+        [TestMethod]
+        public void TestMaxBucketValue()
+        {
+            var b = new Buckets64(10, 2);
+
+            var max = b.MaxBucketValue();
+            Assert.AreEqual(3, max);
+        }
+
+        /// <summary>
+        /// Ensures that Count returns the number of buckets.
+        /// </summary>
+        [TestMethod]
+        public void TestBuckets64Count()
+        {
+            var b = new Buckets64(10, 2);
+
+            var count = b.count;
+            Assert.AreEqual(10u, count);
+        }
+
+        /// <summary>
+        /// Ensures that Increment increments the bucket value by the correct delta and
+        /// clamps to zero and the maximum, Get returns the correct bucket value, and Set
+        /// sets the bucket value correctly.
+        /// </summary>
+        [TestMethod]
+        public void TestBuckets64IncrementAndGetAndSet()
+        {
+            var b = new Buckets64(5, 2);
+
+            var incrementedB = b.Increment(0, 1);
+            Assert.AreSame(b, incrementedB, "Returned Buckets64 should be the same instance");
+
+            var v = b.Get(0);
+            Assert.AreEqual(1u, v);
+
+            b.Increment(1u, -1);
+
+            v = b.Get(1);
+            Assert.AreEqual(0u, v);
+
+            var setB = b.Set(2u, 100);
+            Assert.AreSame(b, setB, "Returned Buckets64 should be the same instance");
+
+            v = b.Get(2);
+            Assert.AreEqual(3u, v);
+
+            b.Increment(3, 2);
+
+            v = b.Get(3);
+            Assert.AreEqual(2u, v);
+        }
+
+        /// <summary>
+        /// Ensures that Reset restores the Buckets64 to the original state.
+        /// </summary>
+        [TestMethod]
+        public void TestBuckets64Reset()
+        {
+            var b = new Buckets64(5, 2);
+
+            for (uint i = 0; i < 5; i++)
+            {
+                b.Increment(i, 1);
+            }
+
+            var resetB = b.Reset();
+            Assert.AreSame(b, resetB, "Returned Buckets64 should be the same instance");
+
+            for (uint i = 0; i < 5; i++)
+            {
+                var c = b.Get(i);
+                Assert.AreEqual(0u, c);
+            }
+        }
+
+        [TestMethod]
+        public void BenchmarkBuckets64Increment()
+        {
+            var buckets = new Buckets64(10000, 10);
+            for (uint i = 0; i < buckets.count; i++)
+            {
+                buckets.Increment(i % 10000, 1);
+            }
+        }
+
+        [TestMethod]
+        public void BenchmarkBuckets64Set()
+        {
+            var buckets = new Buckets64(10000, 10);
+            for (uint i = 0; i < buckets.count; i++)
+            {
+                buckets.Set(i % 10000, 1);
+            }
+        }
+
+        [TestMethod]
+        public void BenchmarkBuckets64Get()
+        {
+            var buckets = new Buckets64(10000, 10);
+            for (uint i = 0; i < buckets.count; i++)
+            {
+                buckets.Get(i % 10000);
+            }
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestHash128.cs
+++ b/TestProbabilisticDataStructures/TestHash128.cs
@@ -1,0 +1,98 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+using System.Security.Cryptography;
+
+namespace TestProbabilisticDataStructures
+{
+    [TestClass]
+    public class TestHash128
+    {
+        [TestMethod]
+        public void TestConstructor()
+        {
+            var hashingAlgorithm = ProbabilisticDataStructures.Defaults.GetDefaultHashAlgorithm();
+            var hash = new Hash128(hashingAlgorithm);
+
+            Assert.AreEqual(HashAlgorithm.Create("MD5").GetType(), hash.HashAlgorithm.GetType());
+        }
+
+        [TestMethod]
+        public void TestComputeHashMD5()
+        {
+            var data = new byte[] { 0, 1, 2, 3 };
+            var hashingAlgorithm = HashAlgorithm.Create("MD5");
+            var hash = new Hash128(hashingAlgorithm);
+
+            var hashString = hash.ComputeHash(data);
+            Assert.AreEqual("37B59AFD592725F9305E484A5D7F5168", hashString);
+        }
+
+        [TestMethod]
+        public void TestComputeHashSHA256()
+        {
+            var data = new byte[] { 0, 1, 2, 3 };
+            var hashingAlgorithm = HashAlgorithm.Create("SHA256");
+            var hash = new Hash128(hashingAlgorithm);
+
+            var hashString = hash.ComputeHash(data);
+            Assert.AreEqual("054EDEC1D0211F624FED0CBCA9D4F9400B0E491C43742AF2C5B0ABEBF0C990D8", hashString);
+        }
+
+        [TestMethod]
+        public void TestSumMD5()
+        {
+            var data = new byte[] { 0, 1, 2, 3 };
+            var expectedSum = new byte[] {
+                249,
+                37,
+                39,
+                89,
+                253,
+                154,
+                181,
+                55,
+                104,
+                81,
+                127,
+                93,
+                74,
+                72,
+                94,
+                48
+            };
+            var hashingAlgorithm = HashAlgorithm.Create("MD5");
+            var hash = new Hash128(hashingAlgorithm);
+            var sum = hash.Sum(hash.ComputeHash(data));
+            CollectionAssert.AreEqual(expectedSum, sum);
+        }
+
+        [TestMethod]
+        public void TestSHA256()
+        {
+            var data = new byte[] { 0, 1, 2, 3 };
+            var expectedSum = new byte[] {
+                98,
+                31,
+                33,
+                208,
+                193,
+                222,
+                78,
+                5,
+                64,
+                249,
+                212,
+                169,
+                188,
+                12,
+                237,
+                79
+            };
+            var hashingAlgorithm = HashAlgorithm.Create("SHA256");
+            var hash = new Hash128(hashingAlgorithm);
+            var sum = hash.Sum(hash.ComputeHash(data));
+            CollectionAssert.AreEqual(expectedSum, sum);
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestProbabilisticDataStructures.cs
+++ b/TestProbabilisticDataStructures/TestProbabilisticDataStructures.cs
@@ -20,6 +20,22 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Ensures that correct math is performed for OptimalM64().
+        /// </summary>
+        [TestMethod]
+        public void TestOptimalM64()
+        {
+            var optimalM = OptimalM64(100, 0.01);
+            Assert.AreEqual(959ul, optimalM);
+
+            optimalM = OptimalM64(100, 0.5);
+            Assert.AreEqual(145ul, optimalM);
+
+            optimalM = OptimalM64(8589934592ul, 0.0001);
+            Assert.AreEqual(164670049045ul, optimalM);
+        }
+
+        /// <summary>
         /// Ensures that correct math is performed for OptimalK().
         /// </summary>
         [TestMethod]
@@ -65,6 +81,38 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Ensures that HashKernel() returns the proper upper and lower base when using
+        /// MD5.
+        /// </summary>
+        [TestMethod]
+        public void TestHashKerne128lMD5()
+        {
+            var data = new byte[] { 0, 1, 2, 3 };
+            var hashAlgorithm = HashAlgorithm.Create("MD5");
+            var hashKernel = ProbabilisticDataStructures
+                .Utils.HashKernel128(data, hashAlgorithm);
+
+            Assert.AreEqual(7516929291713011248ul, hashKernel.LowerBaseHash);
+            Assert.AreEqual(17952798757042697527ul, hashKernel.UpperBaseHash);
+        }
+
+        /// <summary>
+        /// Ensures that HashKernel() returns the proper upper and lower base when using
+        /// SHA256.
+        /// </summary>
+        [TestMethod]
+        public void TestHashKernel128SHA256()
+        {
+            var data = new byte[] { 0, 1, 2, 3 };
+            var hashAlgorithm = HashAlgorithm.Create("SHA256");
+            var hashKernel = ProbabilisticDataStructures
+                .Utils.HashKernel128(data, hashAlgorithm);
+
+            Assert.AreEqual(4682007113097866575ul, hashKernel.LowerBaseHash);
+            Assert.AreEqual(7070407120484453893ul, hashKernel.UpperBaseHash);
+        }
+
+        /// <summary>
         /// Helper method to get OptimalM().
         /// </summary>
         /// <param name="n"></param>
@@ -74,6 +122,18 @@ namespace TestProbabilisticDataStructures
         {
             return ProbabilisticDataStructures
                 .Utils.OptimalM(n, fpRate);
+        }
+
+        /// <summary>
+        /// Helper method to get OptimalM64().
+        /// </summary>
+        /// <param name="n"></param>
+        /// <param name="fpRate"></param>
+        /// <returns></returns>
+        private ulong OptimalM64(ulong n, double fpRate)
+        {
+            return ProbabilisticDataStructures
+                .Utils.OptimalM64(n, fpRate);
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestProbabilisticDataStructures.csproj
+++ b/TestProbabilisticDataStructures/TestProbabilisticDataStructures.csproj
@@ -51,8 +51,11 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="TestBloomFilter64.cs" />
     <Compile Include="TestBuckets.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestBuckets64.cs" />
+    <Compile Include="TestHash128.cs" />
     <Compile Include="TestProbabilisticDataStructures.cs" />
     <Compile Include="TestHash.cs" />
     <Compile Include="TestBloomFilter.cs" />


### PR DESCRIPTION
Add BloomFilter64 that is like BloomFilter, but uses ulong to
represent m and count, and uses Buckets64 and Hash128.

Add Buckets64 that is like Buckets, but uses ulong to represent count
and uses multiple arrays to overcome the C# array size limit of
approximately 2^31 elements and the default .NET limit of 2^31 bytes
per object.

Add Hash128 that is like Hash, but provides 128 bits of hash material.
Also, add Hash128.ComputeHashAndSum() to improve performance by
avoiding the conversion of bytes to string, then string to bytes.

Add Utils.OptimalM64() that takes a ulong n and calculates a ulong m.

Add Utils.HashKernel128() and Utils.HashKernel128ReturnValue for
working with 128 bits of hash material.  In Utils.HashKernel128(),
avoid the use of Skip() and Take() to improve performance.

Add TestBloomFilter64.cs, TestBuckets64.cs, TestHash128.cs to test
the new classes.