### PR TITLE
Feature/serialization

### DIFF
--- a/ProbabilisticDataStructures.Serialization/Binary/BinarySerializationSurrogateAttribute.cs
+++ b/ProbabilisticDataStructures.Serialization/Binary/BinarySerializationSurrogateAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ProbabilisticDataStructures.Serialization.Binary
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class BinarySerializationSurrogateAttribute : Attribute
+    {
+        public Type SurrogateFor { get; }
+
+        public BinarySerializationSurrogateAttribute(Type surrogateFor)
+        {
+            SurrogateFor = surrogateFor;
+        }
+    }
+}

--- a/ProbabilisticDataStructures.Serialization/Binary/CountMinSketchBinaryConverter.cs
+++ b/ProbabilisticDataStructures.Serialization/Binary/CountMinSketchBinaryConverter.cs
@@ -1,0 +1,42 @@
+﻿using System.Runtime.Serialization;
+using System.Security.Cryptography;
+
+namespace ProbabilisticDataStructures.Serialization.Binary
+{
+    [BinarySerializationSurrogate(typeof(CountMinSketch))]
+    public class CountMinSketchBinaryConverter : ISerializationSurrogate
+    {
+        public void GetObjectData(object obj, SerializationInfo info, StreamingContext context)
+        {
+            var countMinSketch = (CountMinSketch) obj;
+
+            info.AddValue("width", countMinSketch.Width);
+            info.AddValue("depth", countMinSketch.Depth);
+            info.AddValue("delta", countMinSketch.delta);
+            info.AddValue("epsilon", countMinSketch.epsilon);
+            info.AddValue("count", countMinSketch.count);
+            info.AddValue("hashAlgorithm", countMinSketch.HashAlgorithmName);
+            info.AddValue("matrix", countMinSketch.Matrix);
+        }
+
+        public object SetObjectData(object obj, SerializationInfo info, StreamingContext context,
+            ISurrogateSelector selector)
+        {
+            var countMinSketch = (CountMinSketch) obj;
+
+            countMinSketch.Width = info.GetUInt32("width");
+            countMinSketch.Depth = info.GetUInt32("depth");
+            countMinSketch.delta = info.GetDouble("delta");
+            countMinSketch.epsilon = info.GetDouble("epsilon");
+            countMinSketch.count = info.GetUInt64("count");
+
+            var hashAlgorithmName = info.GetString("hashAlgorithm");
+            countMinSketch.Hash = HashAlgorithm.Create(hashAlgorithmName);
+            countMinSketch.HashAlgorithmName = hashAlgorithmName;
+            
+            countMinSketch.Matrix = (ulong[][]) info.GetValue("matrix", typeof(ulong[][]));
+
+            return countMinSketch;
+        }
+    }
+}

--- a/ProbabilisticDataStructures.Serialization/ExpressionExtensions.cs
+++ b/ProbabilisticDataStructures.Serialization/ExpressionExtensions.cs
@@ -6,20 +6,20 @@ namespace ProbabilisticDataStructures.Serialization
 {
     public static class ExpressionExtensions<T>
     {
-        private static readonly ConcurrentDictionary<Type, Func<T, object>> Cached =
+        private static readonly ConcurrentDictionary<Type, Func<T, object>> CachedDelegatesTo =
             new ConcurrentDictionary<Type, Func<T, object>>();
 
-        private static readonly ConcurrentDictionary<Type, Func<object, T>> Cached2 =
+        private static readonly ConcurrentDictionary<Type, Func<object, T>> CachedDelegatesFrom =
             new ConcurrentDictionary<Type, Func<object, T>>();
 
         private static readonly ConcurrentDictionary<Type, Func<T>> CachedInstanceFunc =
             new ConcurrentDictionary<Type, Func<T>>();
 
-        public static Func<T, object> GetCastDelegate(Type to)
-            => Cached.GetOrAdd(to, MakeCastDelegateTo);
+        public static Func<T, object> GetCastDelegateTo(Type to)
+            => CachedDelegatesTo.GetOrAdd(to, MakeCastDelegateTo);
 
-        public static Func<object, T> GetCastDelegate2(Type to)
-            => Cached2.GetOrAdd(to, MakeCastDelegateFrom);
+        public static Func<object, T> GetCastDelegateFrom(Type to)
+            => CachedDelegatesFrom.GetOrAdd(to, MakeCastDelegateFrom);
         
         public static Func<T> GetInstanceDelegate(Type typeToCreate)
             => CachedInstanceFunc.GetOrAdd(typeToCreate, CreateInstance);

--- a/ProbabilisticDataStructures.Serialization/ExpressionExtensions.cs
+++ b/ProbabilisticDataStructures.Serialization/ExpressionExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+
+namespace ProbabilisticDataStructures.Serialization
+{
+    public static class ExpressionExtensions<T>
+    {
+        private static readonly ConcurrentDictionary<Type, Func<T, object>> Cached =
+            new ConcurrentDictionary<Type, Func<T, object>>();
+
+        private static readonly ConcurrentDictionary<Type, Func<object, T>> Cached2 =
+            new ConcurrentDictionary<Type, Func<object, T>>();
+
+        private static readonly ConcurrentDictionary<Type, Func<T>> CachedInstanceFunc =
+            new ConcurrentDictionary<Type, Func<T>>();
+
+        public static Func<T, object> GetCastDelegate(Type to)
+            => Cached.GetOrAdd(to, MakeCastDelegateTo);
+
+        public static Func<object, T> GetCastDelegate2(Type to)
+            => Cached2.GetOrAdd(to, MakeCastDelegateFrom);
+        
+        public static Func<T> GetInstanceDelegate(Type typeToCreate)
+            => CachedInstanceFunc.GetOrAdd(typeToCreate, CreateInstance);
+
+        private static Func<T> CreateInstance(Type type)
+        {
+            return Expression.Lambda<Func<T>>(
+                Expression.Convert(Expression.New(type), typeof(T))).Compile();
+        }
+
+        private static Func<T, object> MakeCastDelegateTo(Type to)
+        {
+            var p = Expression.Parameter(typeof(T));
+
+            return Expression.Lambda<Func<T, object>>(
+                Expression.Convert(Expression.Convert(p, to), typeof(object)),
+                p).Compile();
+        }
+
+        private static Func<object, T> MakeCastDelegateFrom(Type to)
+        {
+            var p = Expression.Parameter(typeof(object));
+
+            return Expression.Lambda<Func<object, T>>(
+                Expression.Convert(Expression.Convert(p, to), typeof(T)),
+                p).Compile();
+        }
+    }
+}

--- a/ProbabilisticDataStructures.Serialization/Json/CountMinSketchJsonConverter.cs
+++ b/ProbabilisticDataStructures.Serialization/Json/CountMinSketchJsonConverter.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ProbabilisticDataStructures.Serialization.Json
+{
+    public class CountMinSketchJsonConverter : JsonConverter<CountMinSketch>
+    {
+        public override CountMinSketch Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            var countMinSketch = new CountMinSketch();
+            var parsed = JsonDocument.ParseValue(ref reader).RootElement;
+
+            countMinSketch.Width = parsed.GetProperty("width").GetUInt32();
+            countMinSketch.Depth = parsed.GetProperty("depth").GetUInt32();
+            countMinSketch.delta = parsed.GetProperty("delta").GetDouble();
+            countMinSketch.epsilon = parsed.GetProperty("epsilon").GetDouble();
+            countMinSketch.count = parsed.GetProperty("count").GetUInt64();
+
+            var hashAlgorithmName = parsed.GetProperty("hashAlgorithm").GetString();
+            countMinSketch.Hash = HashAlgorithm.Create(hashAlgorithmName);
+            countMinSketch.HashAlgorithmName = hashAlgorithmName;
+            
+            var rowsCount = parsed.GetProperty("Matrix").GetArrayLength();
+            countMinSketch.Matrix = new ulong[rowsCount][];
+
+            var enumerator = parsed.GetProperty("Matrix").EnumerateArray();
+
+            var currentRow = 0;
+            var currentElement = 0;
+
+            foreach (var row in enumerator)
+            {
+                countMinSketch.Matrix[currentRow] = new ulong[row.GetArrayLength()];
+                
+                foreach (var el in row.EnumerateArray())
+                {
+                    countMinSketch.Matrix[currentRow][currentElement++] = el.GetUInt64();
+                }
+
+                currentRow++;
+                currentElement = 0;
+            }
+
+            return countMinSketch;
+        }
+
+        public override void Write(Utf8JsonWriter writer, CountMinSketch value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+
+            writer.WriteNumber("width", value.Width);
+            writer.WriteNumber("depth", value.Depth);
+            writer.WriteNumber("delta", value.delta);
+            writer.WriteNumber("epsilon", value.epsilon);
+            writer.WriteNumber("count", value.count);
+            writer.WriteString("hashAlgorithm", value.HashAlgorithmName);
+
+            writer.WriteStartArray("Matrix");
+
+            foreach (var row in value.Matrix)
+            {
+                writer.WriteStartArray();
+
+                foreach (var val in row)
+                {
+                    writer.WriteNumberValue(val);
+                }
+
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/ProbabilisticDataStructures.Serialization/ProbabilisticDataStructures.Serialization.csproj
+++ b/ProbabilisticDataStructures.Serialization/ProbabilisticDataStructures.Serialization.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ProbabilisticDataStructures\ProbabilisticDataStructures.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Text.Json" Version="6.0.0-preview.3.21201.4" />
+    </ItemGroup>
+
+</Project>

--- a/ProbabilisticDataStructures.Serialization/ProbabilisticDataStructuresExtensions.cs
+++ b/ProbabilisticDataStructures.Serialization/ProbabilisticDataStructuresExtensions.cs
@@ -58,7 +58,7 @@ namespace ProbabilisticDataStructures.Serialization
             var xmlSerializer = new XmlSerializer(surrogateType);
             using (var stringWriter = new StringWriter())
             {
-                var castFunc = ExpressionExtensions<T>.GetCastDelegate(surrogateType);
+                var castFunc = ExpressionExtensions<T>.GetCastDelegateTo(surrogateType);
 
                 xmlSerializer.Serialize(stringWriter, castFunc(value));
 
@@ -74,7 +74,7 @@ namespace ProbabilisticDataStructures.Serialization
             var xmlSerializer = new XmlSerializer(surrogateType);
             var reader = new StringReader(value);
 
-            var castFunc = ExpressionExtensions<T>.GetCastDelegate2(surrogateType);
+            var castFunc = ExpressionExtensions<T>.GetCastDelegateFrom(surrogateType);
 
             return castFunc(xmlSerializer.Deserialize(reader));
         }

--- a/ProbabilisticDataStructures.Serialization/ProbabilisticDataStructuresExtensions.cs
+++ b/ProbabilisticDataStructures.Serialization/ProbabilisticDataStructuresExtensions.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using ProbabilisticDataStructures.Serialization.Binary;
+using ProbabilisticDataStructures.Serialization.XML;
+
+namespace ProbabilisticDataStructures.Serialization
+{
+    public static class ProbabilisticDataStructuresExtensions
+    {
+        private static Dictionary<Type, Type> _jsonConverters = new Dictionary<Type, Type>();
+        private static Dictionary<Type, Type> _xmlSurrogates = new Dictionary<Type, Type>();
+        private static Dictionary<Type, Type> _binarySurrogates = new Dictionary<Type, Type>();
+
+        static ProbabilisticDataStructuresExtensions()
+        {
+            var typesInAssembly = typeof(ProbabilisticDataStructuresExtensions).Assembly.GetTypes();
+
+            FindAllJsonConverters(typesInAssembly);
+            FindAllXmlSurrogates(typesInAssembly);
+            FindAllBinarySurrogates(typesInAssembly);
+        }
+
+        public static string ToJson<T>(this T value)
+        {
+            if (!_jsonConverters.TryGetValue(value.GetType(), out var converterType))
+                throw new NotSupportedException($"Json converter for {typeof(T)} does not exist!");
+
+            var createConverterFunc = ExpressionExtensions<JsonConverter>.GetInstanceDelegate(converterType);
+
+            return JsonSerializer.Serialize(value,
+                options: new JsonSerializerOptions {Converters = {createConverterFunc()}});
+        }
+
+        public static T FromJson<T>(string value)
+        {
+            if (!_jsonConverters.TryGetValue(typeof(T), out var converterType))
+                throw new NotSupportedException();
+
+            var createConverterFunc = ExpressionExtensions<JsonConverter>.GetInstanceDelegate(converterType);
+
+            return JsonSerializer.Deserialize<T>(value,
+                options: new JsonSerializerOptions {Converters = {createConverterFunc()}});
+        }
+
+        public static string ToXml<T>(this T value)
+        {
+            if (!_xmlSurrogates.TryGetValue(value.GetType(), out var surrogateType))
+                throw new NotSupportedException($"Xml surrogate for {typeof(T)} does not exist!");
+
+            var xmlSerializer = new XmlSerializer(surrogateType);
+            using (var stringWriter = new StringWriter())
+            {
+                var castFunc = ExpressionExtensions<T>.GetCastDelegate(surrogateType);
+
+                xmlSerializer.Serialize(stringWriter, castFunc(value));
+
+                return stringWriter.ToString();
+            }
+        }
+
+        public static T FromXml<T>(string value)
+        {
+            if (!_xmlSurrogates.TryGetValue(typeof(T), out var surrogateType))
+                throw new NotSupportedException($"Xml surrogate for {typeof(T)} does not exist!");
+
+            var xmlSerializer = new XmlSerializer(surrogateType);
+            var reader = new StringReader(value);
+
+            var castFunc = ExpressionExtensions<T>.GetCastDelegate2(surrogateType);
+
+            return castFunc(xmlSerializer.Deserialize(reader));
+        }
+
+        public static byte[] ToBinary<T>(this T value)
+        {
+            if (!_binarySurrogates.TryGetValue(value.GetType(), out var surrogateType))
+                throw new NotSupportedException($"Binary surrogate for {typeof(T)} does not exist!");
+
+            var surrogateSelector = new SurrogateSelector();
+
+            var surrogateFunc = ExpressionExtensions<ISerializationSurrogate>.GetInstanceDelegate(surrogateType);
+
+            surrogateSelector.AddSurrogate(typeof(T), new StreamingContext(StreamingContextStates.All),
+                surrogateFunc());
+
+            var formatter = new BinaryFormatter() {SurrogateSelector = surrogateSelector};
+
+            using (var stream = new MemoryStream())
+            {
+                formatter.Serialize(stream, value);
+                stream.Seek(0, SeekOrigin.Begin);
+
+                return stream.ToArray();
+            }
+        }
+
+        public static T FromBinary<T>(byte[] data)
+        {
+            if (!_binarySurrogates.TryGetValue(typeof(T), out var surrogateType))
+                throw new NotSupportedException($"Binary surrogate for {typeof(T)} does not exist!");
+
+            var surrogateSelector = new SurrogateSelector();
+
+            var surrogateFunc = ExpressionExtensions<ISerializationSurrogate>.GetInstanceDelegate(surrogateType);
+
+            surrogateSelector.AddSurrogate(typeof(T), new StreamingContext(StreamingContextStates.All),
+                surrogateFunc());
+
+            var formatter = new BinaryFormatter() {SurrogateSelector = surrogateSelector};
+
+            using (var stream = new MemoryStream(data))
+            {
+                return (T) formatter.Deserialize(stream);
+            }
+        }
+
+        private static void FindAllXmlSurrogates(IEnumerable<Type> types)
+        {
+            _xmlSurrogates = types
+                .Where(t => t.GetCustomAttribute(typeof(XmlSerializationSurrogateAttribute)) != null)
+                .ToDictionary(
+                    type => type.GetCustomAttribute<XmlSerializationSurrogateAttribute>().SurrogateFor);
+        }
+
+        private static void FindAllJsonConverters(IEnumerable<Type> types)
+        {
+            _jsonConverters = types
+                .Where(t => t.BaseType != null
+                            && t.BaseType.IsGenericType
+                            && t.BaseType.GetGenericTypeDefinition() == typeof(JsonConverter<>))
+                .ToDictionary(x => x.BaseType.GetGenericArguments()[0]);
+        }
+
+        private static void FindAllBinarySurrogates(IEnumerable<Type> types)
+        {
+            _binarySurrogates = types
+                .Where(t => t.GetCustomAttribute(typeof(BinarySerializationSurrogateAttribute)) != null)
+                .ToDictionary(
+                    type => type.GetCustomAttribute<BinarySerializationSurrogateAttribute>().SurrogateFor);
+        }
+    }
+}

--- a/ProbabilisticDataStructures.Serialization/XML/CountMinSketchXMLConverter.cs
+++ b/ProbabilisticDataStructures.Serialization/XML/CountMinSketchXMLConverter.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace ProbabilisticDataStructures.Serialization.XML
+{
+    [XmlRoot("CountMinSketch")]
+    [XmlSerializationSurrogate(typeof(CountMinSketch))]
+    public class CountMinSketchXmlConverter : IXmlSerializable
+    {
+        public CountMinSketch CountMinSketch;
+
+        public XmlSchema GetSchema()
+        {
+            return null;
+        }
+
+        public void ReadXml(XmlReader reader)
+        {
+            CountMinSketch = new CountMinSketch();
+
+            reader.MoveToContent();
+
+            reader.ReadStartElement(); // skip <CountMinSketch>
+
+            CountMinSketch.Width = Convert.ToUInt32(reader.ReadElementString("Width"));
+            CountMinSketch.Depth = Convert.ToUInt32(reader.ReadElementString("Depth"));
+            CountMinSketch.delta = Convert.ToDouble(reader.ReadElementString("Delta"), CultureInfo.InvariantCulture);
+            CountMinSketch.epsilon =
+                Convert.ToDouble(reader.ReadElementString("Epsilon"), CultureInfo.InvariantCulture);
+            CountMinSketch.count = Convert.ToUInt64(reader.ReadElementString("Count"));
+
+            var hashAlgorithmName = reader.ReadElementString("HashAlgorithm");
+            CountMinSketch.Hash = HashAlgorithm.Create(hashAlgorithmName);
+            CountMinSketch.HashAlgorithmName = hashAlgorithmName;
+
+            reader.Read(); // skip <Matrix>
+
+            var matrix = new List<List<ulong>>();
+
+            while (reader.Name == "MatrixRow")
+            {
+                reader.ReadStartElement(); // skip <MatrixRow>
+
+                var currentRow = new List<ulong>();
+                matrix.Add(currentRow);
+
+                while (reader.Name == "MatrixItem")
+                {
+                    var current = Convert.ToUInt64(reader.ReadElementString("MatrixItem"));
+
+                    currentRow.Add(current);
+                }
+
+                reader.ReadEndElement(); // skip </MatrixRow>
+            }
+
+            CountMinSketch.Matrix = new ulong[matrix.Count][];
+
+            for (var i = 0; i < matrix.Count; i++)
+            {
+                CountMinSketch.Matrix[i] = new ulong[matrix.ElementAt(i).Count];
+
+                for (var j = 0; j < matrix.ElementAt(i).Count; j++)
+                {
+                    CountMinSketch.Matrix[i][j] = matrix.ElementAt(i).ElementAt(j);
+                }
+            }
+
+            reader.ReadEndElement(); // skip </Matrix>
+            reader.ReadEndElement(); // skip </CountMinSketch>
+        }
+
+        public void WriteXml(XmlWriter writer)
+        {
+            writer.WriteElementString("Width", CountMinSketch.Width.ToString());
+            writer.WriteElementString("Depth", CountMinSketch.Depth.ToString());
+            writer.WriteElementString("Delta", CountMinSketch.delta.ToString(CultureInfo.InvariantCulture));
+            writer.WriteElementString("Epsilon", CountMinSketch.epsilon.ToString(CultureInfo.InvariantCulture));
+            writer.WriteElementString("Count", CountMinSketch.count.ToString());
+            writer.WriteElementString("HashAlgorithm", CountMinSketch.HashAlgorithmName);
+
+            writer.WriteStartElement("Matrix");
+
+            foreach (var row in CountMinSketch.Matrix)
+            {
+                writer.WriteStartElement("MatrixRow");
+
+                foreach (var el in row)
+                {
+                    writer.WriteElementString("MatrixItem", el.ToString());
+                }
+
+                writer.WriteEndElement();
+            }
+
+            writer.WriteEndElement();
+        }
+
+        public static implicit operator CountMinSketch(CountMinSketchXmlConverter converter)
+        {
+            return converter.CountMinSketch;
+        }
+
+        public static implicit operator CountMinSketchXmlConverter(CountMinSketch countMinSketch)
+        {
+            return new CountMinSketchXmlConverter() {CountMinSketch = countMinSketch};
+        }
+    }
+}

--- a/ProbabilisticDataStructures.Serialization/XML/XmlSerializationSurrogateAttribute.cs
+++ b/ProbabilisticDataStructures.Serialization/XML/XmlSerializationSurrogateAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ProbabilisticDataStructures.Serialization.XML
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class XmlSerializationSurrogateAttribute : Attribute
+    {
+        public Type SurrogateFor { get; }
+
+        public XmlSerializationSurrogateAttribute(Type surrogateFor)
+        {
+            SurrogateFor = surrogateFor;
+        }
+    }
+}

--- a/ProbabilisticDataStructures.sln
+++ b/ProbabilisticDataStructures.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProbabilisticDataStructures
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProbabilisticDataStructures", "TestProbabilisticDataStructures\TestProbabilisticDataStructures.csproj", "{8212EFDE-5134-4914-96D3-C550FD9432F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProbabilisticDataStructures.Serialization", "ProbabilisticDataStructures.Serialization\ProbabilisticDataStructures.Serialization.csproj", "{AE15DD78-22E8-4A7E-830A-862F3B64ECFE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE15DD78-22E8-4A7E-830A-862F3B64ECFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE15DD78-22E8-4A7E-830A-862F3B64ECFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE15DD78-22E8-4A7E-830A-862F3B64ECFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE15DD78-22E8-4A7E-830A-862F3B64ECFE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ProbabilisticDataStructures/CountMinSketch.cs
+++ b/ProbabilisticDataStructures/CountMinSketch.cs
@@ -41,19 +41,25 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Number of items added
         /// </summary>
-        private UInt64 count { get; set; }
+        internal UInt64 count { get; set; }
         /// <summary>
         /// Relative-accuracy factor
         /// </summary>
-        private double epsilon { get; set; }
+        internal double epsilon { get; set; }
         /// <summary>
         /// Relative-accuracy probability
         /// </summary>
-        private double delta { get; set; }
+        internal double delta { get; set; }
         /// <summary>
         /// Hash function
         /// </summary>
-        private HashAlgorithm Hash { get; set; }
+        internal HashAlgorithm Hash { get; set; }
+        
+        /// <summary>
+        /// The name of the hash algorithm.
+        /// Used for serialization/deserialization
+        /// </summary>
+        internal string HashAlgorithmName { get; set; }
 
         /// <summary>
         /// Creates a new Count-Min Sketch whose relative accuracy is within a factor of
@@ -77,7 +83,16 @@ namespace ProbabilisticDataStructures
             this.Depth = depth;
             this.epsilon = epsilon;
             this.delta = delta;
+            HashAlgorithmName = Defaults.DefaultHashAlgorithm;
             this.Hash = Defaults.GetDefaultHashAlgorithm();
+        }
+
+        /// <summary>
+        /// Used for deserialization
+        /// </summary>
+        internal CountMinSketch()
+        {
+            
         }
 
         /// <summary>
@@ -200,10 +215,11 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
-        public void SetHash(HashAlgorithm h)
+        /// <param name="hashAlgorithmName">The name of the hash algorithm to use.</param>
+        public void SetHash(string hashAlgorithmName)
         {
-            this.Hash = h;
+            HashAlgorithmName = hashAlgorithmName;
+            this.Hash = HashAlgorithm.Create(hashAlgorithmName);
         }
 
         // TODO: Implement these later.

--- a/ProbabilisticDataStructures/Defaults.cs
+++ b/ProbabilisticDataStructures/Defaults.cs
@@ -1,12 +1,14 @@
 ﻿using System.Security.Cryptography;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("TestProbabilisticDataStructures")]
+[assembly: InternalsVisibleTo("ProbabilisticDataStructures.Serialization")]
 
 namespace ProbabilisticDataStructures
 {
     public static class Defaults
     {
         public const double FILL_RATIO = 0.5;
+        public const string DefaultHashAlgorithm = "MD5";
 
         /// <summary>
         /// Returns the default hashing algorithm for the library.
@@ -14,7 +16,7 @@ namespace ProbabilisticDataStructures
         /// <returns>The default hashing algorithm for the library</returns>
         internal static HashAlgorithm GetDefaultHashAlgorithm()
         {
-            return HashAlgorithm.Create("MD5");
+            return HashAlgorithm.Create(DefaultHashAlgorithm);
         }
     }
 }


### PR DESCRIPTION
### What is this PR?
Added ability to serialize/deserialize the data structures (currently only Count-Min-Sketch is supported).
This pull request should lay the foundation for supporting other data structures in this repository.
Link to the issue: #2 

### How it works?

I created a separate assembly for serialization/deserialization purposes, so this feature can be treated as an optional add-on.
In assembly we can find 3 main folders:
XML
JSON
Binary

In each folder there is a converter or serialization surrogate which handles the serialization and deserialization. 
Extension methods for serialization and deserialization were created, all follow the same naming convention: "ToXXX/FromXXX",
for example: "ToBinary/FromBinary".

### Things to know

All binary and XML serialization surrogates need to be marked with the attributes: BinarySerializationSurrogateAttribute and XMLSerializationSurrogateAttribute accordingly. This is required for finding the correct surrogate for the requested type prior to serialization and deserialization.