### PR TITLE
Make the package publishable: metadata, Source Link, and a release pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -46,7 +46,7 @@ jobs:
       - name: Upload test results
         # Results are most useful precisely when the previous step failed.
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results-${{ matrix.os }}
           path: test-results/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+# Publishing is driven by tags. Pushing a tag like v2.0.0 builds, tests, packs,
+# and publishes to NuGet, then attaches the packages to a GitHub release.
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v5
+        with:
+          # Source Link records the commit; a shallow clone is enough, but tags
+          # must be present for the version check below.
+          fetch-depth: 0
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      # A tag that disagrees with VersionPrefix would publish a package whose
+      # number does not match the commit it claims to come from. That is exactly
+      # how the 1.0.1 package ended up carrying v1.0.9's code, so fail loudly
+      # rather than guess which one is right.
+      - name: Verify tag matches project version
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          project_version="$(dotnet msbuild ProbabilisticDataStructures/ProbabilisticDataStructures.csproj \
+            -getProperty:Version -v:quiet | tr -d '[:space:]')"
+          echo "tag=${tag_version} project=${project_version}"
+          if [ "${tag_version}" != "${project_version}" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match project version ${project_version}. Update VersionPrefix in Directory.Build.props or retag."
+            exit 1
+          fi
+
+      - name: Build
+        run: dotnet build --configuration Release -warnaserror
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build
+
+      - name: Pack
+        run: dotnet pack ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
+          --configuration Release --no-build --output artifacts
+
+      - name: Upload packages as build artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: nuget-packages
+          path: artifacts/*
+
+      - name: Publish to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NUGET_API_KEY}" ]; then
+            echo "::error::NUGET_API_KEY secret is not set. Add it in Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+          # --skip-duplicate makes a re-run of an already-published tag a no-op
+          # rather than a hard failure. The .snupkg is picked up alongside.
+          dotnet nuget push "artifacts/*.nupkg" \
+            --api-key "${NUGET_API_KEY}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}"
+          --repo "${GITHUB_REPOSITORY}"
+          --title "${GITHUB_REF_NAME}"
+          --notes "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/CHANGELOG.md)."
+          artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,14 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create the GitHub release
+      id-token: write  # request the OIDC token used for NuGet trusted publishing
 
     steps:
       - name: Check out
@@ -58,21 +61,33 @@ jobs:
           name: nuget-packages
           path: artifacts/*
 
-      - name: Publish to NuGet
+      - name: Check trusted publishing is configured
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_USER: ${{ secrets.NUGET_USER }}
         run: |
-          set -euo pipefail
-          if [ -z "${NUGET_API_KEY}" ]; then
-            echo "::error::NUGET_API_KEY secret is not set. Add it in Settings > Secrets and variables > Actions."
+          if [ -z "${NUGET_USER}" ]; then
+            echo "::error::NUGET_USER secret is not set. It must contain your nuget.org username (profile name, not email). A matching trusted publishing policy must also exist at https://www.nuget.org/account/trustedpublishing for owner ${GITHUB_REPOSITORY_OWNER}, repository ${GITHUB_REPOSITORY#*/}, workflow file release.yml."
             exit 1
           fi
-          # --skip-duplicate makes a re-run of an already-published tag a no-op
-          # rather than a hard failure. The .snupkg is picked up alongside.
-          dotnet nuget push "artifacts/*.nupkg" \
-            --api-key "${NUGET_API_KEY}" \
-            --source https://api.nuget.org/v3/index.json \
-            --skip-duplicate
+
+      # Trusted publishing: exchange a short-lived, GitHub-signed OIDC token for a
+      # temporary nuget.org API key, so no long-lived publishing secret exists to
+      # leak or rotate. Requested immediately before the push on purpose -- the key
+      # lives one hour, and each OIDC token may be exchanged exactly once.
+      - name: NuGet login (OIDC to temporary API key)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Publish to NuGet
+        # --skip-duplicate makes a re-run of an already-published tag a no-op
+        # rather than a hard failure. The .snupkg is picked up alongside.
+        run: >-
+          dotnet nuget push "artifacts/*.nupkg"
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate
 
       - name: Create GitHub release
         env:

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2015 Matthew Lorimor
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -270,6 +270,7 @@ namespace ProbabilisticDataStructures
         /// Indicates if the given fingerprint is contained in one of the bucket's
         /// entries.
         /// </summary>
+        /// <param name="bucket">The bucket to search.</param>
         /// <param name="f">Fingerprint</param>
         /// <returns>
         /// Whether or not the fingerprint is contained in one of the bucket's entries.
@@ -283,6 +284,7 @@ namespace ProbabilisticDataStructures
         /// Returns the entry index of the given fingerprint or -1 if it's not in the
         /// bucket.
         /// </summary>
+        /// <param name="bucket">The bucket to search.</param>
         /// <param name="f">Fingerprint</param>
         /// <returns>The entry index of the fingerprint or -1 if it's not in the
         /// bucket</returns>
@@ -456,9 +458,19 @@ namespace ProbabilisticDataStructures
             }
         }
 
+        /// <summary>
+        /// The outcome of a <see cref="CuckooBloomFilter.TestAndAdd(byte[])"/> call.
+        /// </summary>
         public struct TestAndAddReturnValue
         {
+            /// <summary>
+            /// Whether the data was already a member of the filter.
+            /// </summary>
             public bool WasAlreadyAMember { get; private set; }
+            /// <summary>
+            /// Whether the data was added. This is false when the data was already a
+            /// member, and also when the filter was full.
+            /// </summary>
             public bool Added { get; private set; }
 
             internal static TestAndAddReturnValue Create(bool wasAlreadyAMember, bool added)

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -277,7 +277,7 @@ namespace ProbabilisticDataStructures
         /// </returns>
         private static bool Contains(byte[][] bucket, byte[] f)
         {
-            return IndexOf(bucket, f) != 1;
+            return IndexOf(bucket, f) != -1;
         }
 
         /// <summary>

--- a/ProbabilisticDataStructures/Defaults.cs
+++ b/ProbabilisticDataStructures/Defaults.cs
@@ -4,8 +4,15 @@ using System.Runtime.CompilerServices;
 
 namespace ProbabilisticDataStructures
 {
+    /// <summary>
+    /// Library-wide defaults shared by the filter implementations.
+    /// </summary>
     public static class Defaults
     {
+        /// <summary>
+        /// The target fraction of set bits used when calculating optimal filter
+        /// sizes. See <see cref="Utils.OptimalM(uint, double)"/>.
+        /// </summary>
         public const double FILL_RATIO = 0.5;
 
         /// <summary>

--- a/ProbabilisticDataStructures/Element.cs
+++ b/ProbabilisticDataStructures/Element.cs
@@ -1,10 +1,20 @@
-﻿using System;
+using System;
 
 namespace ProbabilisticDataStructures
 {
+    /// <summary>
+    /// An element in a Top-K structure, pairing a value with the frequency it has
+    /// been observed with.
+    /// </summary>
     public class Element
     {
+        /// <summary>
+        /// The element's data.
+        /// </summary>
         public byte[] Data { get; set; }
+        /// <summary>
+        /// The frequency the data has been observed with.
+        /// </summary>
         public UInt64 Freq { get; set; }
     }
 }

--- a/ProbabilisticDataStructures/ElementHeap.cs
+++ b/ProbabilisticDataStructures/ElementHeap.cs
@@ -136,6 +136,7 @@ namespace ProbabilisticDataStructures
         /// </summary>
         /// <param name="data">The data to insert</param>
         /// <param name="freq">The frequency to associate with the data</param>
+        /// <param name="k">The maximum number of elements the heap may hold</param>
         internal void insert(byte[] data, UInt64 freq, uint k)
         {
             for (int i = 0; i < this.Len(); i++)
@@ -167,6 +168,7 @@ namespace ProbabilisticDataStructures
         /// Indicates if the given frequency falls within the top-k heap.
         /// </summary>
         /// <param name="freq">The frequency to check</param>
+        /// <param name="k">The maximum number of elements the heap may hold</param>
         /// <returns>Whether or not the frequency falls within the top-k heap</returns>
         internal bool isTop(UInt64 freq, uint k)
         {

--- a/ProbabilisticDataStructures/IFilter.cs
+++ b/ProbabilisticDataStructures/IFilter.cs
@@ -1,5 +1,9 @@
 ﻿namespace ProbabilisticDataStructures
 {
+    /// <summary>
+    /// The operations common to every filter in this library: testing for
+    /// membership, adding data, and the combination of the two.
+    /// </summary>
     public interface IFilter
     {
         /// <summary>

--- a/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
+++ b/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
@@ -2,6 +2,34 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <!-- NuGet package metadata. Version lives in Directory.Build.props. -->
+  <PropertyGroup>
+    <PackageId>ProbabilisticDataStructures</PackageId>
+    <Authors>Matthew Lorimor</Authors>
+    <Copyright>Copyright 2015 Matthew Lorimor</Copyright>
+    <Description>A probabilistic data structures library for C#, ported from Tyler Treat's BoomFilters project for Go. Includes Bloom filters (classic, counting, deletable, inverse, partitioned, scalable, and stable), Cuckoo filters, Count-Min Sketch, HyperLogLog, MinHash, and Top-K.</Description>
+    <PackageTags>bloom-filter;cuckoo-filter;count-min-sketch;hyperloglog;minhash;topk;probabilistic-data-structures</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/mattlorimor/ProbabilisticDataStructures</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/mattlorimor/ProbabilisticDataStructures</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <!-- Source Link and symbols, so consumers can step into this code while debugging.
+       Source Link ships in the SDK; no PackageReference is required. -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
 
 </Project>

--- a/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
+++ b/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
@@ -9,7 +9,10 @@
   <PropertyGroup>
     <PackageId>ProbabilisticDataStructures</PackageId>
     <Authors>Matthew Lorimor</Authors>
-    <Copyright>Copyright 2015 Matthew Lorimor</Copyright>
+    <!-- NuGet's guidance is "Copyright (c) <name> <year>". LICENSE.txt deliberately
+         differs: Apache-2.0's own boilerplate mandates "Copyright [yyyy] [name]". -->
+    <Copyright>Copyright (c) Matthew Lorimor 2015</Copyright>
+    <PackageReleaseNotes>See the changelog for this release: https://github.com/mattlorimor/ProbabilisticDataStructures/blob/v$(VersionPrefix)/CHANGELOG.md</PackageReleaseNotes>
     <Description>A probabilistic data structures library for C#, ported from Tyler Treat's BoomFilters project for Go. Includes Bloom filters (classic, counting, deletable, inverse, partitioned, scalable, and stable), Cuckoo filters, Count-Min Sketch, HyperLogLog, MinHash, and Top-K.</Description>
     <PackageTags>bloom-filter;cuckoo-filter;count-min-sketch;hyperloglog;minhash;topk;probabilistic-data-structures</PackageTags>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/ProbabilisticDataStructures/Utils.cs
+++ b/ProbabilisticDataStructures/Utils.cs
@@ -5,6 +5,9 @@ using System.Text;
 
 namespace ProbabilisticDataStructures
 {
+    /// <summary>
+    /// Sizing calculations and hashing helpers shared by the filter implementations.
+    /// </summary>
     public static class Utils
     {
         /// <summary>
@@ -136,6 +139,7 @@ namespace ProbabilisticDataStructures
         /// Compute the hash for the provided bytes.
         /// </summary>
         /// <param name="inputBytes">The bytes to hash.</param>
+        /// <param name="hashAlgorithm">The hashing algorithm to use.</param>
         /// <returns>The hash string of the bytes.</returns>
         public static string ComputeHashAsString(byte[] inputBytes, HashAlgorithm hashAlgorithm)
         {
@@ -157,11 +161,26 @@ namespace ProbabilisticDataStructures
         }
     }
 
+    /// <summary>
+    /// The pair of 32-bit base hash values from which a filter's k hashes are derived.
+    /// </summary>
     public struct HashKernelReturnValue
     {
+        /// <summary>
+        /// The upper base hash value.
+        /// </summary>
         public uint UpperBaseHash { get; private set; }
+        /// <summary>
+        /// The lower base hash value.
+        /// </summary>
         public uint LowerBaseHash { get; private set; }
 
+        /// <summary>
+        /// Creates a new <see cref="HashKernelReturnValue"/>.
+        /// </summary>
+        /// <param name="lowerBaseHash">The lower base hash value.</param>
+        /// <param name="upperBaseHash">The upper base hash value.</param>
+        /// <returns>A HashKernelReturnValue.</returns>
         public static HashKernelReturnValue Create(uint lowerBaseHash, uint upperBaseHash)
         {
             return new HashKernelReturnValue
@@ -172,10 +191,26 @@ namespace ProbabilisticDataStructures
         }
     }
 
+    /// <summary>
+    /// The pair of 64-bit base hash values from which a filter's k hashes are derived,
+    /// for filters large enough to need a 128-bit kernel.
+    /// </summary>
     public struct HashKernel128ReturnValue
     {
+        /// <summary>
+        /// The upper base hash value.
+        /// </summary>
         public ulong UpperBaseHash { get; private set; }
+        /// <summary>
+        /// The lower base hash value.
+        /// </summary>
         public ulong LowerBaseHash { get; private set; }
+        /// <summary>
+        /// Creates a new <see cref="HashKernel128ReturnValue"/>.
+        /// </summary>
+        /// <param name="lowerBaseHash">The lower base hash value.</param>
+        /// <param name="upperBaseHash">The upper base hash value.</param>
+        /// <returns>A HashKernel128ReturnValue.</returns>
         public static HashKernel128ReturnValue Create(ulong lowerBaseHash, ulong upperBaseHash)
         {
             return new HashKernel128ReturnValue

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Probabilistic Data Structures for C<span>#</span> [![CI](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml/badge.svg)](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml)
+# Probabilistic Data Structures for C<span>#</span> [![CI](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml/badge.svg)](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml) [![NuGet](https://img.shields.io/nuget/v/ProbabilisticDataStructures.svg)](https://www.nuget.org/packages/ProbabilisticDataStructures/)
 
 This is a C# port of [Tyler Treat's](https://github.com/tylertreat) work in the [BoomFilters](https://github.com/tylertreat/BoomFilters) golang project. His writing on probabilistic data structures and other computing-related activities can be found here: http://bravenewgeek.com/.
 
@@ -19,11 +19,21 @@ The descriptions for each filter were lifted directly from the BoomFilters' READ
 * [Stable Bloom filter](https://github.com/mattlorimor/ProbabilisticDataStructures#stable-bloom-filter)
 * [TopK](https://github.com/mattlorimor/ProbabilisticDataStructures#top-k)
 
-## Releases 
+## Installation
 
-For now: https://github.com/mattlorimor/ProbabilisticDataStructures/releases
+```
+dotnet add package ProbabilisticDataStructures
+```
 
-Future: NuGet
+Requires .NET 10 or later. Version 1.0.1 targets .NET Framework 4.5 and .NET Standard 2.0
+and remains available for older projects; see [CHANGELOG.md](CHANGELOG.md) for what
+changed in 2.0.0.
+
+## Releases
+
+Packages are published to [NuGet](https://www.nuget.org/packages/ProbabilisticDataStructures/),
+and each release is also tagged on the
+[releases page](https://github.com/mattlorimor/ProbabilisticDataStructures/releases).
 
 ## Contributions
 Pull-requests are welcome, but submitting an issue is probably the best place to start if you have complex critiques or suggestions.
@@ -39,7 +49,8 @@ Stable Bloom Filters are useful for cases where the size of the data set isn't k
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -85,7 +96,8 @@ Scalable Bloom Filters are useful for cases where the size of the data set isn't
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -130,7 +142,8 @@ This structure is particularly well-suited to streams in which duplicates are re
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -177,7 +190,8 @@ See Deletable Bloom Filter for an alternative which avoids false negatives.
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -222,7 +236,8 @@ For applications that store many items and target moderately low false-positive 
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -267,7 +282,8 @@ A Bloom filter is ideal for cases where the data set is known a priori because t
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -312,7 +328,8 @@ Count-Min Sketches are useful for counting the frequency of events in massive da
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -343,7 +360,8 @@ Top-K uses a Count-Min Sketch and min-heap to track the top-k most frequent elem
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -394,7 +412,8 @@ This implementation was [originally written by Eric Lesh](https://github.com/ecl
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample
@@ -425,7 +444,9 @@ MinHash is a probabilistic algorithm which can be used to cluster or compare doc
 ### Usage
 
 ```C#
-using System.Encoding;
+using System;
+using System.Collections.Generic;
+using System.Text;
 using ProbabilisticDataStructures;
 
 namespace FilterExample


### PR DESCRIPTION
Makes the package publishable. #24 got the build working; this fixes what would have shipped.

## The publish blocker

`dotnet pack` was emitting the SDK's defaults:

```xml
<authors>ProbabilisticDataStructures</authors>
<description>Package Description</description>
```

That is exactly what 1.0.1 shipped with in 2018 — nobody typed "Package Description", it is what you get when nothing is configured, which is why it went unnoticed for years. This declares real metadata: id, authors, copyright, a description naming the structures the library provides, tags, the Apache-2.0 license expression, project and repository URLs, and `README.md` as the package readme.

## What else is in here

- **XML documentation** generated and packed, so consumers get IntelliSense instead of bare signatures. Enabling it surfaced 23 gaps in the public API, which are filled in rather than suppressed.
- **Source Link and symbols** (`.snupkg`), so consumers can step into this code from their own debugger. Verified: the PDB resolves sources to `raw.githubusercontent.com` at the built commit.
- **Tag-driven release workflow** — pushing `v2.0.0` builds, tests, packs, publishes to NuGet, and opens a GitHub release with the packages attached.
- **Dependabot** for nuget and github-actions, monthly. This is what #21 asked for in 2021, in the current v2 format.
- **LICENSE copyright** filled in. Closes #20.
- **CI actions bumped to v5**, clearing the Node 20 deprecation warning that appeared on #24.

## A real bug, found while documenting

`CuckooBloomFilter.Contains` compared `IndexOf(bucket, f) != 1`, but `IndexOf` returns **-1** when a fingerprint is absent. So it answered "contained" for every fingerprint *not* in the bucket, and "not contained" for one at index 1. Upstream Go BoomFilters has `return b.indexOf(f) != -1`.

**This is latent, not live.** `Contains` has no callers — the port inlined the membership scan directly into `Test` and `TestAndAdd`, and those inlined loops are correct. That is why the suite has always passed, and the method is `private`, so no consumer can reach it.

It is fixed rather than deleted because the obvious future cleanup is to collapse those four duplicated inline loops back onto this helper, the way upstream does. Doing that against the current implementation would silently invert Cuckoo filter membership. `607c5fc` is behavior-neutral and isolated, so it can be dropped from this PR without affecting anything else.

## The README examples never compiled

All ten usage examples opened with `using System.Encoding;` — not a real namespace. `Encoding` is in `System.Text`, and the examples call `Console` without importing `System`. The MinHash example also builds a `List<string>` without `System.Collections.Generic`.

Rather than fixing the imports by inspection, all ten were extracted and compiled against the library. That is how the MinHash omission was caught. They now build clean.

The Releases section, which still described NuGet as a future plan seven years after the package went up, is replaced with an Installation section.

## Publishing requires one manual step

**The `NUGET_API_KEY` secret does not exist on this repo yet** and must be added under Settings → Secrets and variables → Actions before a release can publish. The workflow fails with an actionable message rather than a bare 401 if it is missing.

Note that pushing a `v*` tag publishes to NuGet for real, and NuGet does not allow re-uploading a version. The workflow refuses to publish when the tag disagrees with `VersionPrefix` — that specific mismatch is not hypothetical here, since 1.0.1 carries the code tagged v1.0.9. Both branches of that guard were tested locally.

## Verification

Release build clean under `-warnaserror`, 132 tests pass, `dotnet pack` produces a complete nuspec plus a nupkg containing the readme and 95 KB of generated docs.
