### PR TITLE
Publish under the MattLorimor.ProbabilisticDataStructures package ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This release modernizes the entire build. The library had not been touched since June
 2018 and could no longer be built or tested with current .NET tooling.
 
+### Changed — package identity
+
+- **The package ID is now `MattLorimor.ProbabilisticDataStructures`.**
+
+  Releases from this repository previously had no package of their own. The unprefixed
+  `ProbabilisticDataStructures` ID on nuget.org was registered in 2018 by an account
+  unaffiliated with this project, which published this project's source; that package is
+  not maintained here and will not receive these releases.
+
+  Rather than contest the name, this project ships under an owner-identifying prefix.
+  The prefix also makes `MattLorimor.*` eligible for
+  [ID prefix reservation](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation),
+  which prevents anyone else from publishing under it.
+
+  **Only the package ID changed.** The assembly and namespace remain
+  `ProbabilisticDataStructures`, so `using ProbabilisticDataStructures;` and every type
+  name are unaffected. Updating means changing the `PackageReference` include, nothing
+  more.
+
 ### Removed
 
 - **Dropped `net45` and `netstandard2.0`. The library now targets `net10.0` only.**
 
-  This is a hard break, and it is deliberate. If you consume this package from .NET
+  This is a hard break, and it is deliberate. If you consume this library from .NET
   Framework, from Unity, from Xamarin/Mono, or from any .NET Core or .NET 5–9
   application — including .NET 8, which remains in support until November 2026 —
-  **you cannot upgrade to 2.0.0**. Stay on 1.0.1, which continues to work and is not
-  being withdrawn.
+  **2.0.0 will not install**. The older, unaffiliated 1.0.1 package targets `net45` and
+  `netstandard2.0` and remains on nuget.org, but it is not published by this project and
+  nothing here governs it.
 
   Note that this costs no operating-system coverage. `netstandard2.0` is an API
   specification, not a runtime, and `net10.0` runs on Windows, Linux, and macOS across

--- a/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
+++ b/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
@@ -7,7 +7,13 @@
 
   <!-- NuGet package metadata. Version lives in Directory.Build.props. -->
   <PropertyGroup>
-    <PackageId>ProbabilisticDataStructures</PackageId>
+    <!-- The unprefixed ProbabilisticDataStructures ID on nuget.org is owned by an
+         unrelated account that published this code in 2018. This package therefore
+         ships under an owner-identifying prefix, which also makes MattLorimor.*
+         eligible for ID prefix reservation. Only the package ID changes: the
+         assembly and namespace remain ProbabilisticDataStructures, so consuming
+         code is unaffected. -->
+    <PackageId>MattLorimor.ProbabilisticDataStructures</PackageId>
     <Authors>Matthew Lorimor</Authors>
     <!-- NuGet's guidance is "Copyright (c) <name> <year>". LICENSE.txt deliberately
          differs: Apache-2.0's own boilerplate mandates "Copyright [yyyy] [name]". -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Probabilistic Data Structures for C<span>#</span> [![CI](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml/badge.svg)](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml) [![NuGet](https://img.shields.io/nuget/v/ProbabilisticDataStructures.svg)](https://www.nuget.org/packages/ProbabilisticDataStructures/)
+# Probabilistic Data Structures for C<span>#</span> [![CI](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml/badge.svg)](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml) [![NuGet](https://img.shields.io/nuget/v/MattLorimor.ProbabilisticDataStructures.svg)](https://www.nuget.org/packages/MattLorimor.ProbabilisticDataStructures/)
 
 This is a C# port of [Tyler Treat's](https://github.com/tylertreat) work in the [BoomFilters](https://github.com/tylertreat/BoomFilters) golang project. His writing on probabilistic data structures and other computing-related activities can be found here: http://bravenewgeek.com/.
 
@@ -22,17 +22,28 @@ The descriptions for each filter were lifted directly from the BoomFilters' READ
 ## Installation
 
 ```
-dotnet add package ProbabilisticDataStructures
+dotnet add package MattLorimor.ProbabilisticDataStructures
 ```
 
-Requires .NET 10 or later. Version 1.0.1 targets .NET Framework 4.5 and .NET Standard 2.0
-and remains available for older projects; see [CHANGELOG.md](CHANGELOG.md) for what
-changed in 2.0.0.
+Requires .NET 10 or later. See [CHANGELOG.md](CHANGELOG.md) for what changed in 2.0.0.
+
+The package ID carries a prefix, but the assembly and namespace do not — your code
+still uses `ProbabilisticDataStructures`:
+
+```C#
+using ProbabilisticDataStructures;
+```
+
+> **Note on package naming.** An unprefixed `ProbabilisticDataStructures` package also
+> exists on nuget.org. It was published in 2018 from this project's source by an account
+> unaffiliated with this repository, is not maintained here, and will not receive these
+> releases. Current releases ship under the `MattLorimor.` prefix above.
 
 ## Releases
 
-Packages are published to [NuGet](https://www.nuget.org/packages/ProbabilisticDataStructures/),
-and each release is also tagged on the
+Packages are published to
+[NuGet](https://www.nuget.org/packages/MattLorimor.ProbabilisticDataStructures/), and each
+release is also tagged on the
 [releases page](https://github.com/mattlorimor/ProbabilisticDataStructures/releases).
 
 ## Contributions


### PR DESCRIPTION
The unprefixed `ProbabilisticDataStructures` ID on nuget.org is owned by an unaffiliated account that published this project's source in 2018. A trusted publishing policy cannot authorize a package its owner does not own, so releasing under that ID is not possible from here regardless of pipeline configuration.

This ships under an owner-identifying prefix rather than contesting the name.

## Why this prefix

`MattLorimor` matches the nuget.org profile name exactly, which is the strongest case against the first [ID prefix reservation](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation) criterion ("does the package ID prefix properly and clearly identify the reservation owner?"). The alternatives scored worse: `Lorimor.*` identifies less specifically, `ProbabilisticDataStructures.Net` reads as a knockoff of the disputed ID, `BoomFilters.*` appropriates Tyler Treat's project name, and `Probabilistic.*` is the kind of generic prefix the criteria explicitly warn against.

Reserving `MattLorimor.*` is also the durable fix for how this arose: once reserved, nuget.org **rejects** packages under that prefix from anyone else.

## Consumer impact is limited to one line

**Only the package ID changed.** `AssemblyName` still resolves to `ProbabilisticDataStructures.dll`, so the namespace and every type name are untouched:

```C#
using ProbabilisticDataStructures;  // unchanged
```

Verified by packing — the nuspec `<id>` is prefixed while the assembly inside `lib/net10.0/` is not.

## Documentation corrected

The README and changelog previously offered 1.0.1 as a fallback for older frameworks. That advice is withdrawn: it pointed readers at a package this project does not control and cannot vouch for. Both now state the naming situation plainly and neutrally, without disparaging the other package.

## Verification

`-warnaserror` build clean, 132 tests pass, pack produces `MattLorimor.ProbabilisticDataStructures.2.0.0.nupkg` plus symbols.