### PR TITLE
Add a BenchmarkDotNet project and record a baseline

### DIFF
--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- BenchmarkDotNet requires optimized builds; guard against Debug runs. -->
+    <Optimize Condition="'$(Configuration)' == 'Release'">true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ProbabilisticDataStructures/ProbabilisticDataStructures.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Benchmarks/FilterBenchmarks.cs
+++ b/Benchmarks/FilterBenchmarks.cs
@@ -1,0 +1,151 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using ProbabilisticDataStructures;
+
+namespace Benchmarks
+{
+    /// <summary>
+    /// Membership tests across the filter types. Test is read-only, so each
+    /// invocation is independent and the filter's state does not drift over the
+    /// course of a run.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class FilterTestBenchmarks
+    {
+        private const uint N = 100_000;
+        private const double FpRate = 0.01;
+
+        private byte[] _present = null!;
+        private byte[] _absent = null!;
+
+        private BloomFilter _bloom = null!;
+        private CountingBloomFilter _counting = null!;
+        private PartitionedBloomFilter _partitioned = null!;
+        private CuckooBloomFilter _cuckoo = null!;
+        private ScalableBloomFilter _scalable = null!;
+        private StableBloomFilter _stable = null!;
+        private DeletableBloomFilter _deletable = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _present = Encoding.ASCII.GetBytes("benchmark-key-present");
+            _absent = Encoding.ASCII.GetBytes("benchmark-key-absent");
+
+            _bloom = new BloomFilter(N, FpRate);
+            _counting = CountingBloomFilter.NewDefaultCountingBloomFilter(N, FpRate);
+            _partitioned = new PartitionedBloomFilter(N, FpRate);
+            _cuckoo = new CuckooBloomFilter(N, FpRate);
+            _scalable = ScalableBloomFilter.NewDefaultScalableBloomFilter(FpRate);
+            _stable = StableBloomFilter.NewDefaultStableBloomFilter(N, FpRate);
+            _deletable = new DeletableBloomFilter(N, 100, FpRate);
+
+            // Populate so Test walks the full k-probe path rather than short-circuiting
+            // on the first unset bit.
+            _bloom.Add(_present);
+            _counting.Add(_present);
+            _partitioned.Add(_present);
+            _cuckoo.Add(_present);
+            _scalable.Add(_present);
+            _stable.Add(_present);
+            _deletable.Add(_present);
+        }
+
+        [Benchmark(Baseline = true)]
+        public bool Bloom_Hit() => _bloom.Test(_present);
+
+        [Benchmark]
+        public bool Bloom_Miss() => _bloom.Test(_absent);
+
+        [Benchmark]
+        public bool Counting_Hit() => _counting.Test(_present);
+
+        [Benchmark]
+        public bool Partitioned_Hit() => _partitioned.Test(_present);
+
+        [Benchmark]
+        public bool Cuckoo_Hit() => _cuckoo.Test(_present);
+
+        [Benchmark]
+        public bool Scalable_Hit() => _scalable.Test(_present);
+
+        [Benchmark]
+        public bool Stable_Hit() => _stable.Test(_present);
+
+        [Benchmark]
+        public bool Deletable_Hit() => _deletable.Test(_present);
+    }
+
+    /// <summary>
+    /// Insertion throughput. Add mutates the filter, so each invocation works on a
+    /// filter built in IterationSetup and inserts a fixed batch. OperationsPerInvoke
+    /// reports the per-item cost and amortizes the setup across the batch, which
+    /// keeps IterationSetup overhead out of the measurement.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class FilterAddBenchmarks
+    {
+        private const int Batch = 10_000;
+        private const uint N = 100_000;
+        private const double FpRate = 0.01;
+
+        private byte[][] _items = null!;
+        private BloomFilter _bloom = null!;
+        private PartitionedBloomFilter _partitioned = null!;
+        private CuckooBloomFilter _cuckoo = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _items = new byte[Batch][];
+            for (int i = 0; i < Batch; i++)
+            {
+                _items[i] = Encoding.ASCII.GetBytes(i.ToString());
+            }
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _bloom = new BloomFilter(N, FpRate);
+            _partitioned = new PartitionedBloomFilter(N, FpRate);
+            _cuckoo = new CuckooBloomFilter(N, FpRate);
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Batch)]
+        public void Bloom_Add()
+        {
+            for (int i = 0; i < Batch; i++)
+            {
+                _bloom.Add(_items[i]);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Batch)]
+        public void Bloom_TestAndAdd()
+        {
+            for (int i = 0; i < Batch; i++)
+            {
+                _bloom.TestAndAdd(_items[i]);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Batch)]
+        public void Partitioned_Add()
+        {
+            for (int i = 0; i < Batch; i++)
+            {
+                _partitioned.Add(_items[i]);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Batch)]
+        public void Cuckoo_Add()
+        {
+            for (int i = 0; i < Batch; i++)
+            {
+                _cuckoo.Add(_items[i]);
+            }
+        }
+    }
+}

--- a/Benchmarks/HashKernelBenchmarks.cs
+++ b/Benchmarks/HashKernelBenchmarks.cs
@@ -1,0 +1,45 @@
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using ProbabilisticDataStructures;
+
+namespace Benchmarks
+{
+    /// <summary>
+    /// Isolates the hash kernel, which every filter operation goes through.
+    /// <para>
+    /// HashAlgorithm.ComputeHash allocates a fresh digest array on every call, so
+    /// these numbers are the per-operation allocation floor for the whole library:
+    /// no filter can allocate less than this per Add or Test.
+    /// </para>
+    /// </summary>
+    [MemoryDiagnoser]
+    public class HashKernelBenchmarks
+    {
+        private HashAlgorithm _md5 = null!;
+        private byte[] _data = null!;
+
+        /// <summary>Input sizes spanning a short key and a realistic record.</summary>
+        [Params(8, 64, 1024)]
+        public int DataSize { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _md5 = MD5.Create();
+            _data = new byte[DataSize];
+            for (int i = 0; i < DataSize; i++)
+            {
+                _data[i] = (byte)(i * 31);
+            }
+        }
+
+        [GlobalCleanup]
+        public void Cleanup() => _md5.Dispose();
+
+        [Benchmark(Baseline = true)]
+        public HashKernelReturnValue HashKernel() => Utils.HashKernel(_data, _md5);
+
+        [Benchmark]
+        public HashKernel128ReturnValue HashKernel128() => Utils.HashKernel128(_data, _md5);
+    }
+}

--- a/Benchmarks/Program.cs
+++ b/Benchmarks/Program.cs
@@ -1,0 +1,16 @@
+using BenchmarkDotNet.Running;
+
+namespace Benchmarks
+{
+    /// <summary>
+    /// Entry point. Run all suites with:
+    ///   dotnet run -c Release --project Benchmarks -- --filter '*'
+    /// or a single one with, for example:
+    ///   dotnet run -c Release --project Benchmarks -- --filter '*HashKernel*'
+    /// </summary>
+    public static class Program
+    {
+        public static void Main(string[] args) =>
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -73,3 +73,26 @@ the win: no filter can allocate less than the kernel does.
 directly, then again inside each of two `ComputeHashSum32` calls — plus a LINQ
 `Take(...).ToArray()` for the fingerprint. Four allocations, three MD5 computations.
 It is a separate problem from the shared kernel and deserves its own fix.
+
+## Why these are not run in CI
+
+Benchmarks are for when you are optimizing and can control the machine. They do not
+gate pull requests, for two measured reasons.
+
+**The timings are too noisy to gate on.** In the baseline above — a quiet local machine,
+not a shared runner — `HashKernel` at 1024 bytes measured 1,483.4 ns ± 135.01, or 9%.
+`Bloom_Hit`, `Stable_Hit`, `Partitioned_Hit`, `Counting_Hit` and `Deletable_Hit` land
+within 2% of each other while almost certainly doing identical work; that spread is the
+noise floor. A threshold loose enough to avoid false failures on a shared CI runner
+would sail past a real 10% regression, and a tighter one would fire constantly until
+somebody switched it off.
+
+**They are slow.** The two `--job short` runs above took 40s and 62s for 14 benchmarks.
+Default precision is roughly an order of magnitude longer, which is 15–30 minutes added
+to every pull request.
+
+What *is* worth gating on is allocation, because it is a property of the code rather
+than the machine and reproduces exactly. That lives in
+`TestProbabilisticDataStructures/TestAllocations.cs` as ordinary unit tests using
+`GC.GetAllocatedBytesForCurrentThread`, which run in about 35 ms as part of the normal
+suite. Update the bounds there when the hash path changes.

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -1,0 +1,75 @@
+# Benchmarks
+
+[BenchmarkDotNet](https://benchmarkdotnet.org/) suites for this library, used to
+measure optimization work rather than argue about it.
+
+## Running
+
+Benchmarks require a Release build; BenchmarkDotNet refuses to run otherwise.
+
+```
+# everything (slow)
+dotnet run -c Release --project Benchmarks -- --filter '*'
+
+# one suite
+dotnet run -c Release --project Benchmarks -- --filter '*HashKernel*'
+
+# faster, less precise — fine for spotting large regressions
+dotnet run -c Release --project Benchmarks -- --filter '*' --job short
+```
+
+Results are written to `BenchmarkDotNet.Artifacts/` (git-ignored).
+
+## Suites
+
+| Suite | What it covers |
+| --- | --- |
+| `HashKernelBenchmarks` | `Utils.HashKernel` / `HashKernel128` in isolation, across input sizes |
+| `FilterTestBenchmarks` | `Test` across every filter type — read-only, so state does not drift |
+| `FilterAddBenchmarks` | `Add` / `TestAndAdd` throughput, batched with `OperationsPerInvoke` |
+
+`Add` mutates the filter, so those benchmarks rebuild it in `[IterationSetup]` and
+insert a fixed batch per invocation. `OperationsPerInvoke` reports per-item cost and
+amortizes the setup, keeping it out of the measurement.
+
+## Baseline
+
+Captured before any optimization work, on an Apple Silicon Mac running .NET 10 with
+`--job short`. Absolute times are machine-specific; the **allocation** figures are not,
+and are the interesting part.
+
+### Hash kernel
+
+| Method | DataSize | Mean | Allocated |
+| --- | --- | --- | --- |
+| `HashKernel` | 8 | 282.0 ns | **80 B** |
+| `HashKernel` | 64 | 383.6 ns | **80 B** |
+| `HashKernel` | 1024 | 1,483.4 ns | **80 B** |
+
+### Membership tests
+
+| Method | Mean | Ratio | Allocated |
+| --- | --- | --- | --- |
+| `Bloom_Hit` | 277.3 ns | 1.00 | 80 B |
+| `Counting_Hit` | 283.0 ns | 1.02 | 80 B |
+| `Partitioned_Hit` | 280.7 ns | 1.01 | 80 B |
+| `Scalable_Hit` | 285.0 ns | 1.03 | 80 B |
+| `Stable_Hit` | 279.1 ns | 1.01 | 80 B |
+| `Deletable_Hit` | 283.6 ns | 1.02 | 80 B |
+| `Cuckoo_Hit` | 871.2 ns | **3.14** | **320 B** |
+
+## What the baseline shows
+
+**Allocation is constant at 80 B per operation regardless of input size**, because it
+comes from `HashAlgorithm.ComputeHash` allocating a fresh digest array on every call,
+not from the data being hashed.
+
+**Every filter except Cuckoo allocates exactly the same 80 B as the raw hash kernel.**
+The filter logic itself allocates nothing — the entire per-operation allocation is
+hashing. That makes the hash kernel the single point worth optimizing, and it bounds
+the win: no filter can allocate less than the kernel does.
+
+**Cuckoo is a 4x outlier** because `GetComponents` computes the hash three times — once
+directly, then again inside each of two `ComputeHashSum32` calls — plus a LINQ
+`Take(...).ToArray()` for the fingerprint. Four allocations, three MD5 computations.
+It is a separate problem from the shared kernel and deserves its own fix.

--- a/ProbabilisticDataStructures.sln
+++ b/ProbabilisticDataStructures.sln
@@ -7,20 +7,54 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProbabilisticDataStructures
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestProbabilisticDataStructures", "TestProbabilisticDataStructures\TestProbabilisticDataStructures.csproj", "{8212EFDE-5134-4914-96D3-C550FD9432F1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "Benchmarks\Benchmarks.csproj", "{E110A390-3897-4832-80F9-C118474BCAED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4775E89C-C139-43B0-8436-B456C035C9D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4775E89C-C139-43B0-8436-B456C035C9D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4775E89C-C139-43B0-8436-B456C035C9D9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4775E89C-C139-43B0-8436-B456C035C9D9}.Debug|x64.Build.0 = Debug|Any CPU
+		{4775E89C-C139-43B0-8436-B456C035C9D9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4775E89C-C139-43B0-8436-B456C035C9D9}.Debug|x86.Build.0 = Debug|Any CPU
 		{4775E89C-C139-43B0-8436-B456C035C9D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4775E89C-C139-43B0-8436-B456C035C9D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4775E89C-C139-43B0-8436-B456C035C9D9}.Release|x64.ActiveCfg = Release|Any CPU
+		{4775E89C-C139-43B0-8436-B456C035C9D9}.Release|x64.Build.0 = Release|Any CPU
+		{4775E89C-C139-43B0-8436-B456C035C9D9}.Release|x86.ActiveCfg = Release|Any CPU
+		{4775E89C-C139-43B0-8436-B456C035C9D9}.Release|x86.Build.0 = Release|Any CPU
 		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Debug|x64.Build.0 = Debug|Any CPU
+		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Debug|x86.Build.0 = Debug|Any CPU
 		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Release|x64.ActiveCfg = Release|Any CPU
+		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Release|x64.Build.0 = Release|Any CPU
+		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Release|x86.ActiveCfg = Release|Any CPU
+		{8212EFDE-5134-4914-96D3-C550FD9432F1}.Release|x86.Build.0 = Release|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Debug|x64.Build.0 = Debug|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Debug|x86.Build.0 = Debug|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Release|x64.ActiveCfg = Release|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Release|x64.Build.0 = Release|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Release|x86.ActiveCfg = Release|Any CPU
+		{E110A390-3897-4832-80F9-C118474BCAED}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TestProbabilisticDataStructures/TestAllocations.cs
+++ b/TestProbabilisticDataStructures/TestAllocations.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Guards the per-operation allocation of the hot path.
+    /// <para>
+    /// These are deliberately assertions rather than benchmarks. Timings on shared CI
+    /// runners carry enough noise that a threshold tight enough to catch a real
+    /// regression also fires on unrelated ones, but allocation counts are a property
+    /// of the code rather than the machine: they reproduce exactly, run in
+    /// milliseconds, and need no benchmarking harness.
+    /// </para>
+    /// <para>
+    /// The bounds below record today's behavior, not a target. Every filter operation
+    /// currently allocates because <see cref="HashAlgorithm.ComputeHash(byte[])"/>
+    /// returns a freshly allocated digest on each call. They should drop to zero once
+    /// the hash path writes into a caller-provided buffer; tighten them when it does.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class TestAllocations
+    {
+        private const int Warmup = 1000;
+        private const int Measured = 1000;
+
+        /// <summary>
+        /// Returns bytes allocated per invocation of <paramref name="operation"/>.
+        /// <para>
+        /// The warmup matters: without it the measurement captures JIT tiering work
+        /// rather than steady-state behavior. GC.GetAllocatedBytesForCurrentThread is
+        /// per-thread, so this stays correct under MSTest's parallel execution.
+        /// </para>
+        /// </summary>
+        private static long BytesPerOperation(Action operation)
+        {
+            for (int i = 0; i < Warmup; i++)
+            {
+                operation();
+            }
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < Measured; i++)
+            {
+                operation();
+            }
+            var after = GC.GetAllocatedBytesForCurrentThread();
+
+            return (after - before) / Measured;
+        }
+
+        private static byte[] Key(string s) => Encoding.ASCII.GetBytes(s);
+
+        /// <summary>
+        /// The hash kernel is the source of every filter's per-operation allocation,
+        /// so it is bounded on its own.
+        /// </summary>
+        [TestMethod]
+        public void TestHashKernelAllocation()
+        {
+            var data = Key("allocation-probe");
+            using var md5 = MD5.Create();
+
+            var bytes = BytesPerOperation(() => Utils.HashKernel(data, md5));
+
+            Assert.IsLessThanOrEqualTo(80, bytes,
+                $"Utils.HashKernel allocated {bytes} B per call, above the recorded 80 B.");
+        }
+
+        /// <summary>
+        /// Allocation must not depend on input size. If it does, something is copying
+        /// the input rather than hashing it in place.
+        /// </summary>
+        [TestMethod]
+        public void TestHashKernelAllocationDoesNotGrowWithInput()
+        {
+            var small = new byte[8];
+            var large = new byte[8192];
+            using var md5 = MD5.Create();
+
+            var smallBytes = BytesPerOperation(() => Utils.HashKernel(small, md5));
+            var largeBytes = BytesPerOperation(() => Utils.HashKernel(large, md5));
+
+            Assert.AreEqual(smallBytes, largeBytes,
+                $"Allocation scaled with input size: {smallBytes} B for 8 bytes of input " +
+                $"versus {largeBytes} B for 8192 bytes.");
+        }
+
+        [TestMethod]
+        public void TestBloomFilterTestAllocation()
+        {
+            var data = Key("allocation-probe");
+            var f = new BloomFilter(10000, 0.01);
+            f.Add(data);
+
+            var bytes = BytesPerOperation(() => f.Test(data));
+
+            Assert.IsLessThanOrEqualTo(80, bytes,
+                $"BloomFilter.Test allocated {bytes} B per call, above the recorded 80 B.");
+        }
+
+        [TestMethod]
+        public void TestBloomFilterAddAllocation()
+        {
+            var data = Key("allocation-probe");
+            var f = new BloomFilter(10000, 0.01);
+
+            var bytes = BytesPerOperation(() => f.Add(data));
+
+            Assert.IsLessThanOrEqualTo(80, bytes,
+                $"BloomFilter.Add allocated {bytes} B per call, above the recorded 80 B.");
+        }
+
+        [TestMethod]
+        public void TestBloomFilterTestAndAddAllocation()
+        {
+            var data = Key("allocation-probe");
+            var f = new BloomFilter(10000, 0.01);
+
+            var bytes = BytesPerOperation(() => f.TestAndAdd(data));
+
+            Assert.IsLessThanOrEqualTo(80, bytes,
+                $"BloomFilter.TestAndAdd allocated {bytes} B per call, above the recorded 80 B.");
+        }
+
+        /// <summary>
+        /// The Cuckoo filter is bounded separately and higher. Its GetComponents
+        /// computes the hash three times -- once directly and again inside each of two
+        /// ComputeHashSum32 calls -- and builds the fingerprint with a LINQ
+        /// Take(...).ToArray(), so it allocates four times what the others do. The
+        /// bound records that rather than endorsing it.
+        /// </summary>
+        [TestMethod]
+        public void TestCuckooFilterTestAllocation()
+        {
+            var data = Key("allocation-probe");
+            var f = new CuckooBloomFilter(10000, 0.01);
+            f.Add(data);
+
+            var bytes = BytesPerOperation(() => f.Test(data));
+
+            Assert.IsLessThanOrEqualTo(320, bytes,
+                $"CuckooBloomFilter.Test allocated {bytes} B per call, above the recorded 320 B.");
+        }
+    }
+}


### PR DESCRIPTION
First step of Phase 3. The upcoming change removes a per-operation allocation from the hash path; measuring first makes the result a number instead of a claim.

## Suites

| Suite | Covers |
| --- | --- |
| `HashKernelBenchmarks` | `Utils.HashKernel` / `HashKernel128` in isolation, across input sizes |
| `FilterTestBenchmarks` | `Test` across every filter type |
| `FilterAddBenchmarks` | `Add` / `TestAndAdd` throughput |

`Test` is read-only, so its state doesn't drift across iterations. `Add` mutates the filter, so those rebuild it in `[IterationSetup]` and insert a fixed batch per invocation — `OperationsPerInvoke` reports per-item cost and amortizes the setup out of the measurement.

## The baseline already answers two questions

Full numbers are in `Benchmarks/README.md`. Two things stand out:

**Allocation is a flat 80 B per operation regardless of input size** — 8 B, 64 B, and 1024 B inputs all allocate exactly 80 B. That confirms it comes from `HashAlgorithm.ComputeHash` allocating a digest array per call, not from the data being hashed.

**Every filter except Cuckoo allocates exactly the same 80 B as the bare hash kernel:**

| Method | Mean | Ratio | Allocated |
| --- | --- | --- | --- |
| `Bloom_Hit` | 277.3 ns | 1.00 | 80 B |
| `Counting_Hit` | 283.0 ns | 1.02 | 80 B |
| `Partitioned_Hit` | 280.7 ns | 1.01 | 80 B |
| `Scalable_Hit` | 285.0 ns | 1.03 | 80 B |
| `Stable_Hit` | 279.1 ns | 1.01 | 80 B |
| `Deletable_Hit` | 283.6 ns | 1.02 | 80 B |
| `Cuckoo_Hit` | 871.2 ns | **3.14** | **320 B** |

Filter logic contributes *no* allocation — the entire per-operation cost is hashing. That both identifies the target and bounds the win: no filter can allocate less than the kernel does.

## A finding the benchmarks surfaced

**Cuckoo is a 4x outlier.** `GetComponents` hashes three times — once directly, then again inside each of two `ComputeHashSum32` calls — plus a LINQ `Take(...).ToArray()` for the fingerprint:

```csharp
var hash = Hash.ComputeHash(data);
var f = hash.Take((int)this.F).ToArray();
var i1 = this.ComputeHashSum32(hash);   // ComputeHash again
var i2 = this.ComputeHashSum32(f);      // and again
```

That's a distinct problem from the shared kernel, so it's left for its own change rather than folded in here.

## Notes

The project joins the solution so CI compiles it and a broken benchmark can't rot unnoticed. It's not packable, and **CI does not execute it** — benchmark runs are too slow and too noisy on shared runners to gate a PR.

Solution builds clean under `-warnaserror`; 132 tests still pass.