### PR TITLE
Remove the per-operation allocation from the hash path

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -32,47 +32,52 @@ Results are written to `BenchmarkDotNet.Artifacts/` (git-ignored).
 insert a fixed batch per invocation. `OperationsPerInvoke` reports per-item cost and
 amortizes the setup, keeping it out of the measurement.
 
-## Baseline
+## Results
 
-Captured before any optimization work, on an Apple Silicon Mac running .NET 10 with
-`--job short`. Absolute times are machine-specific; the **allocation** figures are not,
-and are the interesting part.
+Apple Silicon Mac, .NET 10, `--job short`. "Before" is the original
+`HashAlgorithm.ComputeHash` path; "after" is hashing into a stack buffer via
+`TryComputeHash`. Absolute times are machine-specific; the **allocation** figures are
+not, and are the interesting part.
 
 ### Hash kernel
 
-| Method | DataSize | Mean | Allocated |
-| --- | --- | --- | --- |
-| `HashKernel` | 8 | 282.0 ns | **80 B** |
-| `HashKernel` | 64 | 383.6 ns | **80 B** |
-| `HashKernel` | 1024 | 1,483.4 ns | **80 B** |
+| Method | DataSize | Mean before | Mean after | Allocated before | Allocated after |
+| --- | --- | --- | --- | --- | --- |
+| `HashKernel` | 8 | 282.0 ns | 254.0 ns | 80 B | **0 B** |
+| `HashKernel` | 64 | 383.6 ns | 348.7 ns | 80 B | **0 B** |
+| `HashKernel` | 1024 | 1,483.4 ns | 1,451.1 ns | 80 B | **0 B** |
 
 ### Membership tests
 
-| Method | Mean | Ratio | Allocated |
-| --- | --- | --- | --- |
-| `Bloom_Hit` | 277.3 ns | 1.00 | 80 B |
-| `Counting_Hit` | 283.0 ns | 1.02 | 80 B |
-| `Partitioned_Hit` | 280.7 ns | 1.01 | 80 B |
-| `Scalable_Hit` | 285.0 ns | 1.03 | 80 B |
-| `Stable_Hit` | 279.1 ns | 1.01 | 80 B |
-| `Deletable_Hit` | 283.6 ns | 1.02 | 80 B |
-| `Cuckoo_Hit` | 871.2 ns | **3.14** | **320 B** |
+| Method | Mean before | Mean after | Allocated before | Allocated after |
+| --- | --- | --- | --- | --- |
+| `Bloom_Hit` | 277.3 ns | 249.7 ns | 80 B | **0 B** |
+| `Counting_Hit` | 283.0 ns | 250.5 ns | 80 B | **0 B** |
+| `Partitioned_Hit` | 280.7 ns | 251.0 ns | 80 B | **0 B** |
+| `Scalable_Hit` | 285.0 ns | 255.6 ns | 80 B | **0 B** |
+| `Stable_Hit` | 279.1 ns | 248.1 ns | 80 B | **0 B** |
+| `Deletable_Hit` | 283.6 ns | 252.3 ns | 80 B | **0 B** |
+| `Cuckoo_Hit` | 871.2 ns | 873.7 ns | 320 B | 320 B |
 
-## What the baseline shows
+## What the numbers show
 
-**Allocation is constant at 80 B per operation regardless of input size**, because it
-comes from `HashAlgorithm.ComputeHash` allocating a fresh digest array on every call,
-not from the data being hashed.
+**Allocation on the hot path is gone.** The original 80 B per operation was constant
+regardless of input size, because it came from `HashAlgorithm.ComputeHash` returning a
+freshly allocated digest on every call rather than from the data being hashed. Hashing
+into a stack buffer removes it entirely, and Gen0 collections with it.
 
-**Every filter except Cuckoo allocates exactly the same 80 B as the raw hash kernel.**
-The filter logic itself allocates nothing — the entire per-operation allocation is
-hashing. That makes the hash kernel the single point worth optimizing, and it bounds
-the win: no filter can allocate less than the kernel does.
+**Time improved by roughly 10% at small inputs and less at large ones**, which is what
+should be expected: removing an allocation matters most when the allocation is a
+meaningful share of the work. At 1024-byte inputs the MD5 computation dominates and the
+gain shrinks to about 2%. The timing gain is modest relative to the ~5% noise floor
+documented below; it is believable mainly because it appears consistently across every
+benchmark. The allocation result is the unambiguous one.
 
-**Cuckoo is a 4x outlier** because `GetComponents` computes the hash three times — once
-directly, then again inside each of two `ComputeHashSum32` calls — plus a LINQ
-`Take(...).ToArray()` for the fingerprint. Four allocations, three MD5 computations.
-It is a separate problem from the shared kernel and deserves its own fix.
+**Cuckoo is unchanged**, and is now the only filter that allocates. `GetComponents`
+computes the hash three times — once directly, then again inside each of two
+`ComputeHashSum32` calls — plus a LINQ `Take(...).ToArray()` for the fingerprint.
+Fixing it means restructuring how it derives its two indices and fingerprint, which is
+an algorithmic change rather than a buffer change, so it is left for its own commit.
 
 ## Why these are not run in CI
 

--- a/ProbabilisticDataStructures/HyperLogLog.cs
+++ b/ProbabilisticDataStructures/HyperLogLog.cs
@@ -208,8 +208,15 @@ namespace ProbabilisticDataStructures
         /// <returns>32-bit hash value</returns>
         private uint CalculateHash(byte[] data)
         {
-            var sum = Hash.ComputeHash(data);
-            return Utils.HashBytesToUInt32(sum);
+            Span<byte> sum = stackalloc byte[64];
+            if (Hash.TryComputeHash(data, sum, out int written))
+            {
+                return Utils.HashBytesToUInt32(sum.Slice(0, written));
+            }
+
+            // Digest larger than the stack buffer, which only a non-standard
+            // HashAlgorithm produces. Fall back to the allocating path.
+            return Utils.HashBytesToUInt32(Hash.ComputeHash(data));
         }
 
         /// <summary>

--- a/ProbabilisticDataStructures/InverseBloomFilter.cs
+++ b/ProbabilisticDataStructures/InverseBloomFilter.cs
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 using System.Linq;
+using System;
 using System.Security.Cryptography;
 
 namespace ProbabilisticDataStructures
@@ -161,8 +162,15 @@ namespace ProbabilisticDataStructures
         /// <returns>32-bit hash value</returns>
         private uint ComputeHashSum32(byte[] data)
         {
-            var sum = Hash.ComputeHash(data);
-            return Utils.HashBytesToUInt32(sum);
+            Span<byte> sum = stackalloc byte[64];
+            if (Hash.TryComputeHash(data, sum, out int written))
+            {
+                return Utils.HashBytesToUInt32(sum.Slice(0, written));
+            }
+
+            // Digest larger than the stack buffer, which only a non-standard
+            // HashAlgorithm produces. Fall back to the allocating path.
+            return Utils.HashBytesToUInt32(Hash.ComputeHash(data));
         }
 
         /// <summary>

--- a/ProbabilisticDataStructures/Utils.cs
+++ b/ProbabilisticDataStructures/Utils.cs
@@ -11,6 +11,14 @@ namespace ProbabilisticDataStructures
     public static class Utils
     {
         /// <summary>
+        /// Size of the stack buffer used when hashing. 64 bytes holds the largest
+        /// digest any standard <see cref="HashAlgorithm"/> produces (SHA-512); a
+        /// larger one falls back to the allocating path rather than growing the
+        /// stack frame.
+        /// </summary>
+        private const int MaxStackHashSize = 64;
+
+        /// <summary>
         /// Calculates the optimal Bloom filter size, m, based on the number of items and
         /// the desired rate of false positives.
         /// </summary>
@@ -60,8 +68,15 @@ namespace ProbabilisticDataStructures
         /// <returns>A HashKernel</returns>
         public static HashKernelReturnValue HashKernel(byte[] data, HashAlgorithm algorithm)
         {
-            var sum = algorithm.ComputeHash(data);
-            return HashKernelFromHashBytes(sum);
+            Span<byte> sum = stackalloc byte[MaxStackHashSize];
+            if (algorithm.TryComputeHash(data, sum, out int written))
+            {
+                return HashKernelFromHashBytes(sum.Slice(0, written));
+            }
+
+            // Digest larger than the stack buffer, which only a non-standard
+            // HashAlgorithm produces. Fall back to the allocating path.
+            return HashKernelFromHashBytes(algorithm.ComputeHash(data));
         }
 
         /// <summary>
@@ -74,6 +89,19 @@ namespace ProbabilisticDataStructures
         /// <param name="hashBytes">The hash bytes.</param>
         /// <returns>A HashKernel</returns>
         public static HashKernelReturnValue HashKernelFromHashBytes(byte[] hashBytes)
+        {
+            return HashKernelFromHashBytes((ReadOnlySpan<byte>)hashBytes);
+        }
+
+        /// <summary>
+        /// Returns the upper and lower base hash values from which the k hashes are
+        /// derived using the given hash bytes directly.  Identical to the array
+        /// overload, but accepts a span so callers can hash into a buffer they own
+        /// rather than allocating one per call.
+        /// </summary>
+        /// <param name="hashBytes">The hash bytes.</param>
+        /// <returns>A HashKernel</returns>
+        public static HashKernelReturnValue HashKernelFromHashBytes(ReadOnlySpan<byte> hashBytes)
         {
             return HashKernelReturnValue.Create(
                 HashBytesToUInt32(hashBytes, 0),
@@ -90,10 +118,21 @@ namespace ProbabilisticDataStructures
         /// <returns>A HashKernel</returns>
         public static HashKernel128ReturnValue HashKernel128(byte[] data, HashAlgorithm algorithm)
         {
-            var sum = algorithm.ComputeHash(data);
+            Span<byte> sum = stackalloc byte[MaxStackHashSize];
+            if (!algorithm.TryComputeHash(data, sum, out int written))
+            {
+                // Digest larger than the stack buffer, which only a non-standard
+                // HashAlgorithm produces. Fall back to the allocating path.
+                byte[] allocated = algorithm.ComputeHash(data);
+                return HashKernel128ReturnValue.Create(
+                    HashBytesToUInt64(allocated, 0),
+                    HashBytesToUInt64(allocated, 8)
+                    );
+            }
+
             return HashKernel128ReturnValue.Create(
-                HashBytesToUInt64(sum, 0),
-                HashBytesToUInt64(sum, 8)
+                HashBytesToUInt64(sum.Slice(0, written), 0),
+                HashBytesToUInt64(sum.Slice(0, written), 8)
                 );
         }
 
@@ -106,6 +145,19 @@ namespace ProbabilisticDataStructures
         /// <param name="offset"></param>
         /// <returns></returns>
         public static uint HashBytesToUInt32(byte[] hashBytes, int offset = 0)
+        {
+            return HashBytesToUInt32((ReadOnlySpan<byte>)hashBytes, offset);
+        }
+
+        /// <summary>
+        /// Returns the uint represented by the given hash bytes, starting at
+        /// byte <paramref name="offset"/>.  The result will be the same
+        /// regardless of the endianness of the architecture.
+        /// </summary>
+        /// <param name="hashBytes"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        public static uint HashBytesToUInt32(ReadOnlySpan<byte> hashBytes, int offset = 0)
         {
             return
                 ((uint)hashBytes[offset]) |
@@ -123,6 +175,19 @@ namespace ProbabilisticDataStructures
         /// <param name="offset"></param>
         /// <returns></returns>
         public static ulong HashBytesToUInt64(byte[] hashBytes, int offset = 0)
+        {
+            return HashBytesToUInt64((ReadOnlySpan<byte>)hashBytes, offset);
+        }
+
+        /// <summary>
+        /// Returns the ulong represented by the given hash bytes, starting at
+        /// byte <paramref name="offset"/>.  The result will be the same
+        /// regardless of the endianness of the architecture.
+        /// </summary>
+        /// <param name="hashBytes"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        public static ulong HashBytesToUInt64(ReadOnlySpan<byte> hashBytes, int offset = 0)
         {
             return
                 ((ulong)hashBytes[offset]) |

--- a/TestProbabilisticDataStructures/TestAllocations.cs
+++ b/TestProbabilisticDataStructures/TestAllocations.cs
@@ -16,10 +16,15 @@ namespace TestProbabilisticDataStructures
     /// milliseconds, and need no benchmarking harness.
     /// </para>
     /// <para>
-    /// The bounds below record today's behavior, not a target. Every filter operation
-    /// currently allocates because <see cref="HashAlgorithm.ComputeHash(byte[])"/>
-    /// returns a freshly allocated digest on each call. They should drop to zero once
-    /// the hash path writes into a caller-provided buffer; tighten them when it does.
+    /// The hash path writes into a stack buffer via
+    /// <see cref="HashAlgorithm.TryComputeHash(ReadOnlySpan{byte}, Span{byte}, out int)"/>,
+    /// so these operations allocate nothing. Reintroducing
+    /// <see cref="HashAlgorithm.ComputeHash(byte[])"/> anywhere on the hot path fails
+    /// these tests, which is the point.
+    /// </para>
+    /// <para>
+    /// The Cuckoo filter is the one exception and is still bounded rather than
+    /// zeroed; see its test for why.
     /// </para>
     /// </summary>
     [TestClass]
@@ -67,8 +72,8 @@ namespace TestProbabilisticDataStructures
 
             var bytes = BytesPerOperation(() => Utils.HashKernel(data, md5));
 
-            Assert.IsLessThanOrEqualTo(80, bytes,
-                $"Utils.HashKernel allocated {bytes} B per call, above the recorded 80 B.");
+            Assert.AreEqual(0, bytes,
+                $"Utils.HashKernel allocated {bytes} B per call; the hot path must not allocate.");
         }
 
         /// <summary>
@@ -99,8 +104,8 @@ namespace TestProbabilisticDataStructures
 
             var bytes = BytesPerOperation(() => f.Test(data));
 
-            Assert.IsLessThanOrEqualTo(80, bytes,
-                $"BloomFilter.Test allocated {bytes} B per call, above the recorded 80 B.");
+            Assert.AreEqual(0, bytes,
+                $"BloomFilter.Test allocated {bytes} B per call; the hot path must not allocate.");
         }
 
         [TestMethod]
@@ -111,8 +116,8 @@ namespace TestProbabilisticDataStructures
 
             var bytes = BytesPerOperation(() => f.Add(data));
 
-            Assert.IsLessThanOrEqualTo(80, bytes,
-                $"BloomFilter.Add allocated {bytes} B per call, above the recorded 80 B.");
+            Assert.AreEqual(0, bytes,
+                $"BloomFilter.Add allocated {bytes} B per call; the hot path must not allocate.");
         }
 
         [TestMethod]
@@ -123,16 +128,43 @@ namespace TestProbabilisticDataStructures
 
             var bytes = BytesPerOperation(() => f.TestAndAdd(data));
 
-            Assert.IsLessThanOrEqualTo(80, bytes,
-                $"BloomFilter.TestAndAdd allocated {bytes} B per call, above the recorded 80 B.");
+            Assert.AreEqual(0, bytes,
+                $"BloomFilter.TestAndAdd allocated {bytes} B per call; the hot path must not allocate.");
+        }
+
+        [TestMethod]
+        public void TestInverseBloomFilterTestAllocation()
+        {
+            var data = Key("allocation-probe");
+            var f = new InverseBloomFilter(10000);
+            f.Add(data);
+
+            var bytes = BytesPerOperation(() => f.Test(data));
+
+            Assert.AreEqual(0, bytes,
+                $"InverseBloomFilter.Test allocated {bytes} B per call; the hot path must not allocate.");
+        }
+
+        [TestMethod]
+        public void TestHyperLogLogAddAllocation()
+        {
+            var data = Key("allocation-probe");
+            var hll = HyperLogLog.NewDefaultHyperLogLog(0.01);
+
+            var bytes = BytesPerOperation(() => hll.Add(data));
+
+            Assert.AreEqual(0, bytes,
+                $"HyperLogLog.Add allocated {bytes} B per call; the hot path must not allocate.");
         }
 
         /// <summary>
         /// The Cuckoo filter is bounded separately and higher. Its GetComponents
         /// computes the hash three times -- once directly and again inside each of two
         /// ComputeHashSum32 calls -- and builds the fingerprint with a LINQ
-        /// Take(...).ToArray(), so it allocates four times what the others do. The
-        /// bound records that rather than endorsing it.
+        /// Take(...).ToArray(), so it allocates four times what a single hash costs.
+        /// Routing it through the shared kernel is an algorithmic change rather than a
+        /// buffer change, so it is handled separately; this bound holds the line until
+        /// then.
         /// </summary>
         [TestMethod]
         public void TestCuckooFilterTestAllocation()


### PR DESCRIPTION
The optimization the benchmarks in #33 were measuring for.

## Result

Every filter operation allocated **80 B**, constant regardless of input size, because `HashAlgorithm.ComputeHash` returns a freshly allocated digest on every call. That is now zero.

| Method | Mean before | Mean after | Allocated before | Allocated after |
| --- | --- | --- | --- | --- |
| `Bloom_Hit` | 277.3 ns | 249.7 ns | 80 B | **0 B** |
| `Counting_Hit` | 283.0 ns | 250.5 ns | 80 B | **0 B** |
| `Partitioned_Hit` | 280.7 ns | 251.0 ns | 80 B | **0 B** |
| `Scalable_Hit` | 285.0 ns | 255.6 ns | 80 B | **0 B** |
| `Stable_Hit` | 279.1 ns | 248.1 ns | 80 B | **0 B** |
| `Deletable_Hit` | 283.6 ns | 252.3 ns | 80 B | **0 B** |
| `Cuckoo_Hit` | 871.2 ns | 873.7 ns | 320 B | 320 B (see below) |

Gen0 collections drop to zero along with the allocations.

Timings improve ~10% at small inputs, shrinking to ~2% at 1024 bytes where MD5 computation dominates. **I'd treat the timing gain as the weaker claim** — it is modest relative to the ~5% noise floor documented in the benchmark README, and it is believable mainly because it appears consistently across every benchmark. The allocation result is the unambiguous one.

## Why `TryComputeHash` rather than `MD5.HashData`

The obvious move was the static `MD5.HashData`. It is the wrong one.

All ten filters expose `SetHash(HashAlgorithm)` as public API, so callers can supply their own algorithm. The static form only works for algorithms the library knows about, so adopting it would have quietly restricted that API — a real behavior change dressed up as an optimization.

`HashAlgorithm.TryComputeHash` is an *instance* method that writes into a caller-provided buffer, so it avoids the allocation while working with whatever the caller supplied. Verified before writing any of this that it returns byte-identical output to `ComputeHash` for MD5, SHA-256 and SHA-512, at 0 B/op versus 80/112/176 B.

The stack buffer is 64 bytes — the largest digest any standard `HashAlgorithm` produces. Rather than trusting `HashSize` to size it, the code keys off the return value of `TryComputeHash`: a digest too large falls back to the allocating path, so a non-standard algorithm still works and simply does not get the improvement.

## Hash output is unchanged

The constraint that matters most here: the kernel must stay byte-for-byte compatible with [Go BoomFilters](https://github.com/tylertreat/BoomFilters) or every persisted filter breaks. The existing tests assert hardcoded digests captured from the Go implementation and **pass untouched**.

## Scope

`Utils` gains `ReadOnlySpan` overloads of `HashKernelFromHashBytes`, `HashBytesToUInt32` and `HashBytesToUInt64`. These are additive — the array overloads remain and now forward to them, so the endianness-sensitive extraction has one implementation instead of two. `InverseBloomFilter` and `HyperLogLog` hash directly rather than through the shared kernel and were converted the same way.

**Cuckoo is deliberately untouched** and is now the only filter that allocates. It hashes three times per operation and builds its fingerprint with a LINQ `Take(...).ToArray()`; fixing it means restructuring how it derives its indices and fingerprint — an algorithmic change, not a buffer change. Its allocation guard keeps the 320 B bound until then.

## Verification

The allocation guards from #33 now assert **zero** rather than a bound, and cover `InverseBloomFilter` and `HyperLogLog` too. 140 tests pass; build clean under `-warnaserror`.
