### PR TITLE
Cut the Cuckoo filter's per-operation allocation from 320 B to 32 B

### DIFF
--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -57,7 +57,7 @@ not, and are the interesting part.
 | `Scalable_Hit` | 285.0 ns | 255.6 ns | 80 B | **0 B** |
 | `Stable_Hit` | 279.1 ns | 248.1 ns | 80 B | **0 B** |
 | `Deletable_Hit` | 283.6 ns | 252.3 ns | 80 B | **0 B** |
-| `Cuckoo_Hit` | 871.2 ns | 873.7 ns | 320 B | 320 B |
+| `Cuckoo_Hit` | 871.2 ns | 755.1 ns | 320 B | **32 B** |
 
 ## What the numbers show
 
@@ -73,11 +73,11 @@ gain shrinks to about 2%. The timing gain is modest relative to the ~5% noise fl
 documented below; it is believable mainly because it appears consistently across every
 benchmark. The allocation result is the unambiguous one.
 
-**Cuckoo is unchanged**, and is now the only filter that allocates. `GetComponents`
-computes the hash three times — once directly, then again inside each of two
-`ComputeHashSum32` calls — plus a LINQ `Take(...).ToArray()` for the fingerprint.
-Fixing it means restructuring how it derives its two indices and fingerprint, which is
-an algorithmic change rather than a buffer change, so it is left for its own commit.
+**Cuckoo still allocates, but far less.** Its digests now go into stack buffers and the
+LINQ `Take(...).ToArray()` is a direct copy, taking it from 320 B to 32 B. What remains
+is the fingerprint array itself, which cannot go away while it is stored in a bucket.
+It continues to compute three hashes per operation; reducing that would change the
+index values it derives, so it is not a performance question alone.
 
 ## Why these are not run in CI
 

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -23,6 +23,12 @@ namespace ProbabilisticDataStructures
     public class CuckooBloomFilter
     {
         /// <summary>
+        /// Size of the stack buffer used when hashing. 64 bytes holds the largest
+        /// digest any standard <see cref="HashAlgorithm"/> produces (SHA-512).
+        /// </summary>
+        private const int MaxStackHashSize = 64;
+
+        /// <summary>
         /// The maximum number of relocations to attempt when inserting an element before
         /// considering the filter full.
         /// </summary>
@@ -386,12 +392,40 @@ namespace ProbabilisticDataStructures
         /// fingerprint for the given data</returns>
         private Components GetComponents(byte[] data)
         {
-            var hash = Hash.ComputeHash(data);
-            var f = hash.Take((int)this.F).ToArray();
-            var i1 = this.ComputeHashSum32(hash);
+            Span<byte> hash = stackalloc byte[MaxStackHashSize];
+            if (!Hash.TryComputeHash(data, hash, out int written))
+            {
+                // Digest larger than the stack buffer, which only a non-standard
+                // HashAlgorithm produces. Fall back to the allocating path.
+                byte[] allocated = Hash.ComputeHash(data);
+                byte[] allocatedF = Slice(allocated, (int)this.F);
+                return Components.Create(
+                    allocatedF,
+                    this.ComputeHashSum32(allocated),
+                    this.ComputeHashSum32(allocatedF));
+            }
+
+            ReadOnlySpan<byte> digest = hash.Slice(0, written);
+
+            // The fingerprint is stored in a bucket, so this array is genuinely
+            // needed. Take(...).ToArray() built it through a LINQ enumerator; a
+            // direct copy of the same bytes avoids that without changing the value.
+            byte[] f = Slice(digest, (int)this.F);
+
+            var i1 = this.ComputeHashSum32(digest);
             var i2 = this.ComputeHashSum32(f);
 
             return Components.Create(f, i1, i2);
+        }
+
+        /// <summary>
+        /// Copies the first <paramref name="length"/> bytes of <paramref name="source"/>,
+        /// clamped to its length. Matches what Take(length).ToArray() produced, which
+        /// returned a short array rather than throwing when the source was smaller.
+        /// </summary>
+        private static byte[] Slice(ReadOnlySpan<byte> source, int length)
+        {
+            return source.Slice(0, Math.Min(length, source.Length)).ToArray();
         }
 
         /// <summary>
@@ -401,8 +435,26 @@ namespace ProbabilisticDataStructures
         /// <returns>32-bit hash value</returns>
         private uint ComputeHashSum32(byte[] data)
         {
-            var sum = Hash.ComputeHash(data);
-            return Utils.HashBytesToUInt32(sum);
+            return this.ComputeHashSum32((ReadOnlySpan<byte>)data);
+        }
+
+        /// <summary>
+        /// Returns the sum of the hash, hashing into a caller-owned buffer so the
+        /// digest does not have to be allocated per call.
+        /// </summary>
+        /// <param name="data">Data</param>
+        /// <returns>32-bit hash value</returns>
+        private uint ComputeHashSum32(ReadOnlySpan<byte> data)
+        {
+            Span<byte> sum = stackalloc byte[MaxStackHashSize];
+            if (Hash.TryComputeHash(data, sum, out int written))
+            {
+                return Utils.HashBytesToUInt32(sum.Slice(0, written));
+            }
+
+            // Digest larger than the stack buffer, which only a non-standard
+            // HashAlgorithm produces. Fall back to the allocating path.
+            return Utils.HashBytesToUInt32(Hash.ComputeHash(data.ToArray()));
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestAllocations.cs
+++ b/TestProbabilisticDataStructures/TestAllocations.cs
@@ -161,10 +161,9 @@ namespace TestProbabilisticDataStructures
         /// The Cuckoo filter is bounded separately and higher. Its GetComponents
         /// computes the hash three times -- once directly and again inside each of two
         /// ComputeHashSum32 calls -- and builds the fingerprint with a LINQ
-        /// Take(...).ToArray(), so it allocates four times what a single hash costs.
-        /// Routing it through the shared kernel is an algorithmic change rather than a
-        /// buffer change, so it is handled separately; this bound holds the line until
-        /// then.
+        /// Take(...).ToArray(). The digests now go into stack buffers, but the
+        /// fingerprint remains a real allocation because it is stored in a bucket, so
+        /// this filter is bounded rather than zeroed.
         /// </summary>
         [TestMethod]
         public void TestCuckooFilterTestAllocation()
@@ -175,8 +174,8 @@ namespace TestProbabilisticDataStructures
 
             var bytes = BytesPerOperation(() => f.Test(data));
 
-            Assert.IsLessThanOrEqualTo(320, bytes,
-                $"CuckooBloomFilter.Test allocated {bytes} B per call, above the recorded 320 B.");
+            Assert.IsLessThanOrEqualTo(32, bytes,
+                $"CuckooBloomFilter.Test allocated {bytes} B per call, above the recorded 32 B.");
         }
     }
 }


### PR DESCRIPTION
Finishes the allocation work from #34. Cuckoo was the only filter still allocating.

## Result

| Method | Before | After |
| --- | --- | --- |
| `Cuckoo_Hit` | 871.2 ns, 320 B | **755.1 ns, 32 B** |

`GetComponents` allocated four times per operation: the digest, a LINQ `Take(...).ToArray()` for the fingerprint, and a digest inside each of two `ComputeHashSum32` calls. Three are now stack buffers, and the fingerprint is a direct copy rather than going through a LINQ enumerator.

The remaining 32 B is the fingerprint array itself, which cannot go away while it is stored in a bucket. The allocation guard is tightened from 320 B to 32 B accordingly.

## Behavior is unchanged

The fingerprint copy clamps to the digest length, so it still returns a short array rather than throwing when the digest is smaller than the configured fingerprint size — which is what `Take` did. `ComputeHashSum32` keeps its array overload forwarding to a span version, so the eviction path in `Insert` benefits too. All 140 tests pass.

This deliberately does **not** reduce the three hash computations per operation. That is not purely a performance question: the second and third feed the index values the filter derives, so removing one changes where elements land.

## Two correctness bugs found while doing this — not fixed here

Comparing against upstream Go turned up two defects that are unrelated to allocation and change behavior, so they are reported rather than folded in.

**The second bucket is never used for insertion.** In `Insert`:

```csharp
var idx = GetEmptyEntry(b1);
if (idx != -1) { b1[idx] = f; this.count++; return true; }

var b2 = this.Buckets[i2 % this.M];
var ids = GetEmptyEntry(b2);   // assigned...
if (idx != -1)                 // ...but this tests idx, which is -1 here
{
    b2[idx] = f;               // unreachable
```

Reaching the second block means `idx == -1`, so `if (idx != -1)` is provably always false and `ids` is never read. Every element that does not fit in its first bucket skips the second entirely and goes straight to eviction, which wastes roughly half the filter's capacity and causes avoidable relocations. No compiler warning fires because `ids` is assigned from a method call.

**`i2` is missing its XOR with `i1`.** Upstream Go derives the pair as:

```go
i1 = uint(binary.BigEndian.Uint32(hash))
i2 = i1 ^ uint(binary.BigEndian.Uint32(c.computeHash(f)))
```

This port computes `i2 = ComputeHashSum32(f)` with no `i1 ^`. The eviction loop *does* rely on the partial-key invariant — it computes an item's alternate bucket as `i = i ^ ComputeHashSum32(f)` — so without that XOR established up front, `i2` is not the partner of `i1`, and a relocated element can land in a bucket `Test` never examines. That is a false negative, which a cuckoo filter is otherwise supposed to avoid.

Fixing either changes where elements are stored, so both invalidate persisted filters and warrant their own change and a version bump. Happy to take them next.
