### PR TITLE
Fix two Cuckoo filter correctness defects (3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,45 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.1] - Unreleased
+## [3.0.0] - Unreleased
+
+### Fixed
+
+- **The Cuckoo filter could report false negatives.** `GetComponents` derived the second
+  candidate bucket as `hash(fingerprint)` rather than `i1 XOR hash(fingerprint)`.
+
+  The two candidate buckets in a cuckoo filter are a pair: either index must recover the
+  other by XOR with the fingerprint hash. The relocation loop already relied on that,
+  computing an element's alternate bucket as `i ^ ComputeHashSum32(f)`, but the pairing
+  was never established, so an element moved during relocation could land in a bucket
+  that `Test` does not examine. Filling a filter to 5,000 insertions reproduced eight
+  elements that were reported as added and then could not be found. A cuckoo filter is
+  supposed to avoid false negatives entirely.
+
+- **The Cuckoo filter never used its second bucket for insertion.** `Insert` computed the
+  second bucket's free slot into a variable named `ids`, then tested `idx` — the result
+  from the *first* bucket, which is always `-1` at that point. The condition could never
+  be true, so the write was unreachable and every element that did not fit in its first
+  bucket went straight to relocation. Measured impact on capacity is small; the cost is
+  wasted relocation work rather than lost slots. No compiler warning fires because `ids`
+  is assigned from a method call.
+
+### Changed
+
+- **Cuckoo filter element placement has changed**, which is why this is a major release.
+  Both fixes alter which buckets an element occupies. Filters persisted by 2.x cannot be
+  read correctly by 3.0.0, and a 3.0.0 filter will not agree with a 2.x one. Nothing else
+  in the library is affected: the Bloom-family hash kernel is untouched and remains
+  byte-for-byte compatible with Go BoomFilters.
+
+### Added
+
+- A regression test that fills a Cuckoo filter well past the point where relocation
+  begins and asserts that every element it accepted can still be found. The existing
+  Cuckoo tests all used filters small enough that relocation never happened, which is
+  why both defects survived.
+
+## [2.0.1] - 2026-08-08
 
 ### Added
 
@@ -138,7 +176,8 @@ This release modernizes the entire build. The library had not been touched since
 - Initial release: a C# port of [Tyler Treat's](https://github.com/tylertreat)
   [BoomFilters](https://github.com/tylertreat/BoomFilters) Go project.
 
-[2.0.1]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v2.0.0...HEAD
+[3.0.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v1.0.9...v2.0.0
 [1.0.9]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v1.0.7...v1.0.8

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          lived nowhere in the repo: AppVeyor patched AssemblyInfo.cs at build time from
          its own build counter, which is how the published package version (1.0.1) and
          the GitHub release tags (v1.0.9) drifted apart. -->
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -351,10 +351,10 @@ namespace ProbabilisticDataStructures
 
             // Try to insert into bucket[i2].
             var b2 = this.Buckets[i2 % this.M];
-            var ids = GetEmptyEntry(b2);
-            if (idx != -1)
+            var idx2 = GetEmptyEntry(b2);
+            if (idx2 != -1)
             {
-                b2[idx] = f;
+                b2[idx2] = f;
                 this.count++;
                 return true;
             }
@@ -399,10 +399,11 @@ namespace ProbabilisticDataStructures
                 // HashAlgorithm produces. Fall back to the allocating path.
                 byte[] allocated = Hash.ComputeHash(data);
                 byte[] allocatedF = Slice(allocated, (int)this.F);
+                var fallbackI1 = this.ComputeHashSum32(allocated);
                 return Components.Create(
                     allocatedF,
-                    this.ComputeHashSum32(allocated),
-                    this.ComputeHashSum32(allocatedF));
+                    fallbackI1,
+                    fallbackI1 ^ this.ComputeHashSum32(allocatedF));
             }
 
             ReadOnlySpan<byte> digest = hash.Slice(0, written);
@@ -413,7 +414,12 @@ namespace ProbabilisticDataStructures
             byte[] f = Slice(digest, (int)this.F);
 
             var i1 = this.ComputeHashSum32(digest);
-            var i2 = this.ComputeHashSum32(f);
+
+            // The two candidate buckets form a pair: i2 must be i1 XOR the
+            // fingerprint hash, so either index recovers the other. The relocation
+            // loop in Insert depends on it, computing an element's alternate bucket
+            // as i ^ ComputeHashSum32(f).
+            var i2 = i1 ^ this.ComputeHashSum32(f);
 
             return Components.Create(f, i1, i2);
         }

--- a/TestProbabilisticDataStructures/TestCuckooBloomFilter.cs
+++ b/TestProbabilisticDataStructures/TestCuckooBloomFilter.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
+using System.Collections.Generic;
 using System.Text;
 
 namespace TestProbabilisticDataStructures
@@ -255,6 +256,43 @@ namespace TestProbabilisticDataStructures
             {
                 f.TestAndRemove(data[i]);
             }
+        }
+
+        /// <summary>
+        /// A cuckoo filter may refuse an insert when it is full, but anything it
+        /// reports as added must remain findable. Relocation is the path where that
+        /// can break, and it only happens once buckets start colliding, so this fills
+        /// the filter well past the point where kicks begin.
+        /// </summary>
+        [TestMethod]
+        public void TestCuckooNoFalseNegativesAfterEviction()
+        {
+            var f = new CuckooBloomFilter(1000, 0.01);
+            var added = new List<byte[]>();
+
+            for (int i = 0; i < 5000; i++)
+            {
+                var data = Encoding.ASCII.GetBytes("evict-" + i.ToString());
+                if (f.TestAndAdd(data).Added)
+                {
+                    added.Add(data);
+                }
+            }
+
+            Assert.IsGreaterThan(0, added.Count, "Nothing was inserted; the test proves nothing.");
+
+            var missing = 0;
+            foreach (var data in added)
+            {
+                if (!f.Test(data))
+                {
+                    missing++;
+                }
+            }
+
+            Assert.AreEqual(0, missing,
+                $"{missing} of {added.Count} elements reported as added could not be found. " +
+                "A cuckoo filter must not produce false negatives for elements it accepted.");
         }
     }
 }


### PR DESCRIPTION
Fixes the two defects reported in #35. **The Cuckoo filter could report false negatives** — the one failure mode a cuckoo filter is supposed to rule out.

Releases as **3.0.0**: both fixes change which buckets an element occupies.

## The false negative

`GetComponents` derived the second candidate bucket as `hash(fingerprint)` instead of `i1 XOR hash(fingerprint)`.

Those two buckets are a pair — either index must recover the other by XOR with the fingerprint hash. The relocation loop already assumed that, computing an element's alternate bucket as `i ^ ComputeHashSum32(f)`. But nothing established the pairing, so an element moved during relocation could land in a bucket `Test` never examines.

Upstream Go, for comparison:

```go
i1 = uint(binary.BigEndian.Uint32(hash))
i2 = i1 ^ uint(binary.BigEndian.Uint32(c.computeHash(f)))
```

Measured on a filter filled to 5,000 insertions:

```
without fix:  accepted=4994  falseNegatives=8
with fix:     accepted=4990  falseNegatives=0
```

## The unreachable insert

```csharp
var idx = GetEmptyEntry(b1);
if (idx != -1) { b1[idx] = f; this.count++; return true; }

var b2 = this.Buckets[i2 % this.M];
var ids = GetEmptyEntry(b2);   // assigned...
if (idx != -1)                 // ...but tests idx, always -1 here
```

Reaching that block means `idx == -1`, so the condition could never be true and the write was unreachable. Anything that did not fit in its first bucket went straight to relocation. No compiler warning fires because `ids` is assigned from a method call rather than being a constant.

**Correcting my earlier claim about this one.** In #35 I said it wasted roughly half the filter's capacity. Measured, that is wrong: 4,990 accepted with the fix versus 4,994 without. The cost is wasted relocation work, not lost slots. The false negatives were the real defect; this one is mostly tidiness.

## Why the tests missed both

Every existing Cuckoo test used a filter small enough that relocation never happened — which is exactly the path both defects lived in. All 11 passed throughout.

The new regression test fills a filter past that point and asserts everything the filter accepted is still findable. It fails on the old code with the eight false negatives above.

A second test written alongside it was **dropped**: it passed equally well before and after the fix, so leaving it in would have implied coverage it did not provide.

## Compatibility

Cuckoo element placement changes, so filters persisted by 2.x will not read correctly under 3.0.0. Nothing else is affected — the Bloom-family hash kernel is untouched and remains byte-for-byte compatible with Go BoomFilters, as its hardcoded-digest tests confirm.

## Not addressed

The port still diverges from Go in deriving `i1`: Go reads the digest directly with `BigEndian.Uint32`, while this hashes the digest a second time with a little-endian read. That costs an extra hash per operation and means Cuckoo filters are not interoperable with Go's. It is a separate question — closing it is a compatibility decision, not a bug fix — so it is left alone here.

141 tests pass; build clean under `-warnaserror`.
