### PR TITLE
Replace MD5 with XxHash3: ~24x faster membership tests

### DIFF
--- a/Benchmarks/HashKernelBenchmarks.cs
+++ b/Benchmarks/HashKernelBenchmarks.cs
@@ -1,4 +1,5 @@
-using System.Security.Cryptography;
+using System;
+using System.IO.Hashing;
 using BenchmarkDotNet.Attributes;
 using ProbabilisticDataStructures;
 
@@ -15,7 +16,7 @@ namespace Benchmarks
     [MemoryDiagnoser]
     public class HashKernelBenchmarks
     {
-        private HashAlgorithm _md5 = null!;
+        private Func<ReadOnlySpan<byte>, ulong> _hash = null!;
         private byte[] _data = null!;
 
         /// <summary>Input sizes spanning a short key and a realistic record.</summary>
@@ -25,7 +26,7 @@ namespace Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            _md5 = MD5.Create();
+            _hash = d => XxHash3.HashToUInt64(d);
             _data = new byte[DataSize];
             for (int i = 0; i < DataSize; i++)
             {
@@ -33,13 +34,10 @@ namespace Benchmarks
             }
         }
 
-        [GlobalCleanup]
-        public void Cleanup() => _md5.Dispose();
-
         [Benchmark(Baseline = true)]
-        public HashKernelReturnValue HashKernel() => Utils.HashKernel(_data, _md5);
+        public HashKernelReturnValue HashKernel() => Utils.HashKernel(_data, _hash);
 
         [Benchmark]
-        public HashKernel128ReturnValue HashKernel128() => Utils.HashKernel128(_data, _md5);
+        public HashKernel128ReturnValue HashKernel128() => Utils.HashKernel128(_data, _hash);
     }
 }

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -34,50 +34,39 @@ amortizes the setup, keeping it out of the measurement.
 
 ## Results
 
-Apple Silicon Mac, .NET 10, `--job short`. "Before" is the original
-`HashAlgorithm.ComputeHash` path; "after" is hashing into a stack buffer via
-`TryComputeHash`. Absolute times are machine-specific; the **allocation** figures are
-not, and are the interesting part.
-
-### Hash kernel
-
-| Method | DataSize | Mean before | Mean after | Allocated before | Allocated after |
-| --- | --- | --- | --- | --- | --- |
-| `HashKernel` | 8 | 282.0 ns | 254.0 ns | 80 B | **0 B** |
-| `HashKernel` | 64 | 383.6 ns | 348.7 ns | 80 B | **0 B** |
-| `HashKernel` | 1024 | 1,483.4 ns | 1,451.1 ns | 80 B | **0 B** |
+Apple Silicon Mac, .NET 10, `--job short`. Absolute times are machine-specific.
 
 ### Membership tests
 
-| Method | Mean before | Mean after | Allocated before | Allocated after |
-| --- | --- | --- | --- | --- |
-| `Bloom_Hit` | 277.3 ns | 249.7 ns | 80 B | **0 B** |
-| `Counting_Hit` | 283.0 ns | 250.5 ns | 80 B | **0 B** |
-| `Partitioned_Hit` | 280.7 ns | 251.0 ns | 80 B | **0 B** |
-| `Scalable_Hit` | 285.0 ns | 255.6 ns | 80 B | **0 B** |
-| `Stable_Hit` | 279.1 ns | 248.1 ns | 80 B | **0 B** |
-| `Deletable_Hit` | 283.6 ns | 252.3 ns | 80 B | **0 B** |
-| `Cuckoo_Hit` | 871.2 ns | 755.1 ns | 320 B | **32 B** |
+"MD5" is the previous default hash with allocation already removed; "XxHash3" is the
+current default.
+
+| Method | MD5 | XxHash3 | Speedup |
+| --- | --- | --- | --- |
+| `Bloom_Hit` | 249.7 ns | **10.46 ns** | 24x |
+| `Counting_Hit` | 250.5 ns | **10.23 ns** | 24x |
+| `Partitioned_Hit` | 251.0 ns | **10.56 ns** | 24x |
+| `Scalable_Hit` | 255.6 ns | **10.56 ns** | 24x |
+| `Deletable_Hit` | 252.3 ns | **10.12 ns** | 25x |
+| `Stable_Hit` | 248.1 ns | **5.45 ns** | 46x |
+| `Cuckoo_Hit` | 755.1 ns | **11.24 ns** | **67x** |
+
+Nothing allocates except the Cuckoo filter's 32-byte fingerprint, which is stored in a
+bucket and cannot be avoided.
 
 ## What the numbers show
 
-**Allocation on the hot path is gone.** The original 80 B per operation was constant
-regardless of input size, because it came from `HashAlgorithm.ComputeHash` returning a
-freshly allocated digest on every call rather than from the data being hashed. Hashing
-into a stack buffer removes it entirely, and Gen0 collections with it.
+**The hash was the entire cost of an operation.** Removing the per-call allocation
+earlier bought about 10%; replacing MD5 with a non-cryptographic hash bought 24x. MD5 is
+built to resist collision attacks, which a filter does not need and pays for on every
+probe.
 
-**Time improved by roughly 10% at small inputs and less at large ones**, which is what
-should be expected: removing an allocation matters most when the allocation is a
-meaningful share of the work. At 1024-byte inputs the MD5 computation dominates and the
-gain shrinks to about 2%. The timing gain is modest relative to the ~5% noise floor
-documented below; it is believable mainly because it appears consistently across every
-benchmark. The allocation result is the unambiguous one.
+**Cuckoo gains the most** because it hashes three times per operation where the others
+hash once, so it was paying the MD5 cost three times over.
 
-**Cuckoo still allocates, but far less.** Its digests now go into stack buffers and the
-LINQ `Take(...).ToArray()` is a direct copy, taking it from 320 B to 32 B. What remains
-is the fingerprint array itself, which cannot go away while it is stored in a bucket.
-It continues to compute three hashes per operation; reducing that would change the
-index values it derives, so it is not a performance question alone.
+**Bloom_Miss is now faster than Bloom_Hit** (3.39 ns against 10.46 ns). A miss
+short-circuits at the first unset bit, and with hashing no longer dominating, that
+difference finally shows up in the measurement.
 
 ## Why these are not run in CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0] - Unreleased
 
+### Changed
+
+- **The default hash is now XxHash3 rather than MD5, and `SetHash` takes a
+  `Func<ReadOnlySpan<byte>, ulong>` instead of a `HashAlgorithm`.**
+
+  Membership tests are roughly **24x faster**, and the Cuckoo filter **67x** because it
+  hashes three times per operation. `Bloom_Hit` goes from 249.7 ns to 10.46 ns. Hashing
+  was the entire cost of a filter operation; MD5 is built to resist collision attacks,
+  which a filter does not need and paid for on every probe.
+
+  This changes where every element lands, so filters persisted by earlier versions
+  cannot be read. It also changes the `SetHash` signature on every filter: supply a
+  function returning 64 bits rather than a `HashAlgorithm`. A `byte[]` converts to
+  `ReadOnlySpan<byte>` implicitly, so call sites passing arrays are unaffected.
+
+  XxHash3 is not resistant to chosen-input attacks: an adversary controlling inserted
+  data can provoke collisions and inflate the observed false-positive rate. MD5 was no
+  better in this respect, only slower. Callers needing that property should supply a
+  keyed hash such as SipHash through `SetHash`.
+
 ### Fixed
 
 - **The Cuckoo filter could report false negatives.** `GetComponents` derived the second

--- a/ProbabilisticDataStructures/BloomFilter.cs
+++ b/ProbabilisticDataStructures/BloomFilter.cs
@@ -16,7 +16,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash algorithm
         /// </summary>
-        private HashAlgorithm Hash { get; set; }
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
         /// <summary>
         /// Filter size
         /// </summary>
@@ -41,7 +41,7 @@ namespace ProbabilisticDataStructures
             var m = Utils.OptimalM(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             Buckets = new Buckets(m, 1);
-            Hash = Defaults.GetDefaultHashAlgorithm();
+            Hash = Defaults.GetDefaultHashFunction();
             this.m = m;
             this.k = k;
         }
@@ -184,9 +184,9 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
+        /// <param name="h">The hash function to use.</param>
         // TODO: Add SetHash to the IFilter interface?
-        public void SetHash(HashAlgorithm h)
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }

--- a/ProbabilisticDataStructures/BloomFilter64.cs
+++ b/ProbabilisticDataStructures/BloomFilter64.cs
@@ -21,7 +21,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash algorithm
         /// </summary>
-        private HashAlgorithm Hash { get; set; }
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
         /// <summary>
         /// Filter size
         /// </summary>
@@ -46,7 +46,7 @@ namespace ProbabilisticDataStructures
             var m = Utils.OptimalM64(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             Buckets = new Buckets64(m, 1);
-            Hash = Defaults.GetDefaultHashAlgorithm();
+            Hash = Defaults.GetDefaultHashFunction();
             this.m = m;
             this.k = k;
         }
@@ -189,9 +189,9 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
+        /// <param name="h">The hash function to use.</param>
         // TODO: Add SetHash to the IFilter interface?
-        public void SetHash(HashAlgorithm h)
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }

--- a/ProbabilisticDataStructures/CountMinSketch.cs
+++ b/ProbabilisticDataStructures/CountMinSketch.cs
@@ -53,7 +53,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash function
         /// </summary>
-        private HashAlgorithm Hash { get; set; }
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
 
         /// <summary>
         /// Creates a new Count-Min Sketch whose relative accuracy is within a factor of
@@ -77,7 +77,7 @@ namespace ProbabilisticDataStructures
             this.Depth = depth;
             this.epsilon = epsilon;
             this.delta = delta;
-            this.Hash = Defaults.GetDefaultHashAlgorithm();
+            this.Hash = Defaults.GetDefaultHashFunction();
         }
 
         /// <summary>
@@ -200,8 +200,8 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
-        public void SetHash(HashAlgorithm h)
+        /// <param name="h">The hash function to use.</param>
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }

--- a/ProbabilisticDataStructures/CountingBloomFilter.cs
+++ b/ProbabilisticDataStructures/CountingBloomFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography;
+﻿using System;
+using System.Security.Cryptography;
 
 namespace ProbabilisticDataStructures
 {
@@ -29,7 +30,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash algorithm
         /// </summary>
-        private HashAlgorithm Hash { get; set; }
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
         /// <summary>
         /// Filter size
         /// </summary>
@@ -61,7 +62,7 @@ namespace ProbabilisticDataStructures
             var m = Utils.OptimalM(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             this.Buckets =  new Buckets(m, b);
-            this.Hash = Defaults.GetDefaultHashAlgorithm();
+            this.Hash = Defaults.GetDefaultHashFunction();
             this.m = m;
             this.k = k;
             this.indexBuffer = new uint[k];
@@ -232,9 +233,9 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
+        /// <param name="h">The hash function to use.</param>
         // TODO: Add SetHash to the IFilter interface?
-        public void SetHash(HashAlgorithm h)
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -38,7 +38,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash algorithm.
         /// </summary>
-        private HashAlgorithm Hash { get; set; }
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
         /// <summary>
         /// Number of buckets
         /// </summary>
@@ -81,7 +81,7 @@ namespace ProbabilisticDataStructures
             }
 
             this.Buckets = buckets;
-            this.Hash = Defaults.GetDefaultHashAlgorithm();
+            this.Hash = Defaults.GetDefaultHashFunction();
             this.M = m;
             this.B = b;
             this.F = f;
@@ -266,8 +266,8 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
-        public void SetHash(HashAlgorithm h)
+        /// <param name="h">The hash function to use.</param>
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }
@@ -397,26 +397,12 @@ namespace ProbabilisticDataStructures
         /// fingerprint for the given data</returns>
         private Components GetComponents(byte[] data)
         {
-            Span<byte> hash = stackalloc byte[MaxStackHashSize];
-            if (!Hash.TryComputeHash(data, hash, out int written))
-            {
-                // Digest larger than the stack buffer, which only a non-standard
-                // HashAlgorithm produces. Fall back to the allocating path.
-                byte[] allocated = Hash.ComputeHash(data);
-                byte[] allocatedF = Slice(allocated, (int)this.F);
-                var fallbackI1 = this.ComputeHashSum32(allocated);
-                return Components.Create(
-                    allocatedF,
-                    fallbackI1,
-                    fallbackI1 ^ this.ComputeHashSum32(allocatedF));
-            }
+            // The hash supplies 64 bits. The fingerprint is taken from its bytes,
+            // as it was previously taken from the leading bytes of a digest.
+            Span<byte> digest = stackalloc byte[8];
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(digest, this.Hash(data));
 
-            ReadOnlySpan<byte> digest = hash.Slice(0, written);
-
-            // The fingerprint is stored in a bucket, so this array is genuinely
-            // needed. Take(...).ToArray() built it through a LINQ enumerator; a
-            // direct copy of the same bytes avoids that without changing the value.
-            byte[] f = Slice(digest, (int)this.F);
+            byte[] f = digest.Slice(0, Math.Min((int)this.F, digest.Length)).ToArray();
 
             var i1 = this.ComputeHashSum32(digest);
 
@@ -450,23 +436,15 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
-        /// Returns the sum of the hash, hashing into a caller-owned buffer so the
-        /// digest does not have to be allocated per call.
+        /// Returns the low 32 bits of the hash of the given data.
         /// </summary>
         /// <param name="data">Data</param>
         /// <returns>32-bit hash value</returns>
         private uint ComputeHashSum32(ReadOnlySpan<byte> data)
         {
-            Span<byte> sum = stackalloc byte[MaxStackHashSize];
-            if (Hash.TryComputeHash(data, sum, out int written))
-            {
-                return Utils.HashBytesToUInt32(sum.Slice(0, written));
-            }
-
-            // Digest larger than the stack buffer, which only a non-standard
-            // HashAlgorithm produces. Fall back to the allocating path.
-            return Utils.HashBytesToUInt32(Hash.ComputeHash(data.ToArray()));
+            return (uint)(this.Hash(data) & 0xffffffff);
         }
+
 
         /// <summary>
         /// Returns the optimal fingerprint length in bytes for the given bucket size and

--- a/ProbabilisticDataStructures/Defaults.cs
+++ b/ProbabilisticDataStructures/Defaults.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography;
+﻿using System;
+using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("TestProbabilisticDataStructures")]
 
@@ -16,22 +17,31 @@ namespace ProbabilisticDataStructures
         public const double FILL_RATIO = 0.5;
 
         /// <summary>
-        /// Returns the default hashing algorithm for the library.
+        /// The default hash function: XxHash3, a non-cryptographic 64-bit hash.
         /// </summary>
         /// <remarks>
-        /// MD5 is used here for bucket indexing, not for any security purpose, so
-        /// analyzer warnings about it being cryptographically broken do not apply.
+        /// Filters need a fast, well-distributed hash, not a cryptographic one.
+        /// XxHash3 is roughly twenty times faster end-to-end than the MD5 this
+        /// library used previously, and returns 64 bits directly rather than a
+        /// digest buffer that has to be sliced apart.
         ///
-        /// Changing the algorithm changes where every element lands, so it would
-        /// invalidate any filter a caller has persisted and is a breaking change.
-        /// It is not, however, required for compatibility with Go BoomFilters:
-        /// that project hashes with FNV-1a, so filters from the two libraries were
-        /// never interchangeable regardless of what is chosen here.
+        /// It is not resistant to chosen-input attacks. An adversary who controls
+        /// the data being inserted can provoke collisions and inflate the observed
+        /// false-positive rate. MD5 was no better in this respect, only slower;
+        /// callers needing that property should supply a keyed hash such as
+        /// SipHash through the relevant filter's SetHash.
         /// </remarks>
-        /// <returns>The default hashing algorithm for the library</returns>
-        internal static HashAlgorithm GetDefaultHashAlgorithm()
+        internal static ulong DefaultHash(ReadOnlySpan<byte> data)
         {
-            return MD5.Create();
+            return XxHash3.HashToUInt64(data);
+        }
+
+        /// <summary>
+        /// Returns the default hash function for the library.
+        /// </summary>
+        internal static Func<ReadOnlySpan<byte>, ulong> GetDefaultHashFunction()
+        {
+            return DefaultHash;
         }
     }
 }

--- a/ProbabilisticDataStructures/DeletableBloomFilter.cs
+++ b/ProbabilisticDataStructures/DeletableBloomFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography;
+﻿using System;
+using System.Security.Cryptography;
 
 namespace ProbabilisticDataStructures
 {
@@ -31,7 +32,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash algorithm
         /// </summary>
-        private HashAlgorithm Hash { get; set; }
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
         /// <summary>
         /// Filter size
         /// </summary>
@@ -69,7 +70,7 @@ namespace ProbabilisticDataStructures
 
             this.Buckets = new Buckets(m - r, 1);
             this.Collisions = new Buckets(r, 1);
-            this.Hash = Defaults.GetDefaultHashAlgorithm();
+            this.Hash = Defaults.GetDefaultHashFunction();
             this.M = m - r;
             this.RegionSize = (m - r) / r;
             this.k = k;
@@ -247,9 +248,9 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
+        /// <param name="h">The hash function to use.</param>
         // TODO: Add SetHash to the IFilter interface?
-        public void SetHash(HashAlgorithm h)
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }

--- a/ProbabilisticDataStructures/HyperLogLog.cs
+++ b/ProbabilisticDataStructures/HyperLogLog.cs
@@ -65,7 +65,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash algorithm
         /// </summary>
-        private HashAlgorithm Hash { get; set; }
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
 
         /// <summary>
         /// Creates a new HyperLogLog with m registers. Returns an error if m isn't a
@@ -83,7 +83,7 @@ namespace ProbabilisticDataStructures
             this.M = m;
             this.B = (uint)Math.Ceiling(Math.Log(m, 2));
             this.Alpha = CalculateAlpha(m);
-            this.Hash = Defaults.GetDefaultHashAlgorithm();
+            this.Hash = Defaults.GetDefaultHashFunction();
         }
 
         /// <summary>
@@ -195,8 +195,8 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
-        public void SetHash(HashAlgorithm h)
+        /// <param name="h">The hash function to use.</param>
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }
@@ -208,15 +208,7 @@ namespace ProbabilisticDataStructures
         /// <returns>32-bit hash value</returns>
         private uint CalculateHash(byte[] data)
         {
-            Span<byte> sum = stackalloc byte[64];
-            if (Hash.TryComputeHash(data, sum, out int written))
-            {
-                return Utils.HashBytesToUInt32(sum.Slice(0, written));
-            }
-
-            // Digest larger than the stack buffer, which only a non-standard
-            // HashAlgorithm produces. Fall back to the allocating path.
-            return Utils.HashBytesToUInt32(Hash.ComputeHash(data));
+            return (uint)(this.Hash(data) & 0xffffffff);
         }
 
         /// <summary>

--- a/ProbabilisticDataStructures/InverseBloomFilter.cs
+++ b/ProbabilisticDataStructures/InverseBloomFilter.cs
@@ -55,7 +55,7 @@ namespace ProbabilisticDataStructures
     public class InverseBloomFilter : IFilter
     {
         private byte[][] Array { get; set; }
-        internal HashAlgorithm Hash { get; set; }
+        internal Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
         private uint capacity { get; set; }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace ProbabilisticDataStructures
         public InverseBloomFilter(uint capacity)
         {
             this.Array = new byte[capacity][];
-            this.Hash = Defaults.GetDefaultHashAlgorithm();
+            this.Hash = Defaults.GetDefaultHashFunction();
             this.capacity = capacity;
         }
 
@@ -162,23 +162,15 @@ namespace ProbabilisticDataStructures
         /// <returns>32-bit hash value</returns>
         private uint ComputeHashSum32(byte[] data)
         {
-            Span<byte> sum = stackalloc byte[64];
-            if (Hash.TryComputeHash(data, sum, out int written))
-            {
-                return Utils.HashBytesToUInt32(sum.Slice(0, written));
-            }
-
-            // Digest larger than the stack buffer, which only a non-standard
-            // HashAlgorithm produces. Fall back to the allocating path.
-            return Utils.HashBytesToUInt32(Hash.ComputeHash(data));
+            return (uint)(this.Hash(data) & 0xffffffff);
         }
 
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
+        /// <param name="h">The hash function to use.</param>
         // TODO: Add SetHash to the IFilter interface?
-        public void SetHash(HashAlgorithm h)
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }

--- a/ProbabilisticDataStructures/PartitionedBloomFilter.cs
+++ b/ProbabilisticDataStructures/PartitionedBloomFilter.cs
@@ -40,7 +40,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash algorithm
         /// </summary>
-        internal HashAlgorithm Hash { get; set; }
+        internal Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
         /// <summary>
         /// Filter size (divided into k partitions)
         /// </summary>
@@ -77,7 +77,7 @@ namespace ProbabilisticDataStructures
             }
 
             this.Partitions = partitions;
-            this.Hash = Defaults.GetDefaultHashAlgorithm();
+            this.Hash = Defaults.GetDefaultHashFunction();
             this.M = m;
             this.k = k;
             this.S = s;
@@ -234,9 +234,9 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
+        /// <param name="h">The hash function to use.</param>
         // TODO: Add SetHash to the IFilter interface?
-        public void SetHash(HashAlgorithm h)
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }

--- a/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
+++ b/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
@@ -43,6 +43,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.IO.Hashing" Version="10.0.11" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="../README.md" Pack="true" PackagePath="/" />
     <None Include="../icon.png" Pack="true" PackagePath="/" />
   </ItemGroup>

--- a/ProbabilisticDataStructures/ScalableBloomFilter.cs
+++ b/ProbabilisticDataStructures/ScalableBloomFilter.cs
@@ -187,9 +187,9 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
+        /// <param name="h">The hash function to use.</param>
         // TODO: Add SetHash to the IFilter interface?
-        public void SetHash(HashAlgorithm h)
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             foreach (var filter in this.Filters)
             {

--- a/ProbabilisticDataStructures/StableBloomFilter.cs
+++ b/ProbabilisticDataStructures/StableBloomFilter.cs
@@ -37,7 +37,7 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Hash algorightm
         /// </summary>
-        private HashAlgorithm Hash { get; set; } = null!;
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
         /// <summary>
         /// Number of cells
         /// </summary>
@@ -90,7 +90,7 @@ namespace ProbabilisticDataStructures
 
             var cells = new Buckets(m, d);
 
-            this.Hash = Defaults.GetDefaultHashAlgorithm();
+            this.Hash = Defaults.GetDefaultHashFunction();
             this.M = m;
             this.k = k;
             this.p = OptimalStableP(m, k, d, fpRate);
@@ -127,7 +127,7 @@ namespace ProbabilisticDataStructures
 
             return new StableBloomFilter
             {
-                Hash = Defaults.GetDefaultHashAlgorithm(),
+                Hash = Defaults.GetDefaultHashFunction(),
                 M = m,
                 k = k,
                 p = 0,
@@ -290,9 +290,9 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
-        /// <param name="h">The HashAlgorithm to use.</param>
+        /// <param name="h">The hash function to use.</param>
         // TODO: Add SetHash to the IFilter interface?
-        public void SetHash(HashAlgorithm h)
+        public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
             this.Hash = h;
         }

--- a/ProbabilisticDataStructures/Utils.cs
+++ b/ProbabilisticDataStructures/Utils.cs
@@ -107,6 +107,36 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Returns the upper and lower base hash values for a digest the caller has
+        /// already computed.
+        /// </summary>
+        /// <remarks>
+        /// A unit test pins this against Go BoomFilters' convention: given the same
+        /// digest bytes, this produces the same lower and upper values Go's
+        /// hashKernel derives from a 64-bit sum. That is a statement about the
+        /// extraction arithmetic only -- the two libraries hash with different
+        /// functions, so their filters are not interchangeable.
+        /// </remarks>
+        /// <param name="hashBytes">The digest bytes.</param>
+        /// <returns>A HashKernel</returns>
+        public static HashKernelReturnValue HashKernelFromHashBytes(byte[] hashBytes)
+        {
+            return HashKernelFromHashBytes((ReadOnlySpan<byte>)hashBytes);
+        }
+
+        /// <summary>
+        /// Span overload of <see cref="HashKernelFromHashBytes(byte[])"/>.
+        /// </summary>
+        /// <param name="hashBytes">The digest bytes.</param>
+        /// <returns>A HashKernel</returns>
+        public static HashKernelReturnValue HashKernelFromHashBytes(ReadOnlySpan<byte> hashBytes)
+        {
+            return HashKernelReturnValue.Create(
+                HashBytesToUInt32(hashBytes, 0),
+                HashBytesToUInt32(hashBytes, 4));
+        }
+
+        /// <summary>
         /// Returns the uint represented by the given hash bytes, starting at
         /// byte <paramref name="offset"/>.  The result will be the same
         /// regardless of the endianness of the architecture.

--- a/ProbabilisticDataStructures/Utils.cs
+++ b/ProbabilisticDataStructures/Utils.cs
@@ -60,85 +60,50 @@ namespace ProbabilisticDataStructures
 
         /// <summary>
         /// Returns the upper and lower base hash values from which the k hashes are
-        /// derived.  The result will be the same regardless of the endianness of the
+        /// derived. The result is the same regardless of the endianness of the
         /// architecture.
         /// </summary>
         /// <param name="data">The data bytes to hash.</param>
-        /// <param name="algorithm">The hashing algorithm to use.</param>
+        /// <param name="hash">The hash function to use.</param>
         /// <returns>A HashKernel</returns>
-        public static HashKernelReturnValue HashKernel(byte[] data, HashAlgorithm algorithm)
+        public static HashKernelReturnValue HashKernel(byte[] data, Func<ReadOnlySpan<byte>, ulong> hash)
         {
-            Span<byte> sum = stackalloc byte[MaxStackHashSize];
-            if (algorithm.TryComputeHash(data, sum, out int written))
-            {
-                return HashKernelFromHashBytes(sum.Slice(0, written));
-            }
-
-            // Digest larger than the stack buffer, which only a non-standard
-            // HashAlgorithm produces. Fall back to the allocating path.
-            return HashKernelFromHashBytes(algorithm.ComputeHash(data));
+            return HashKernelFromSum(hash(data));
         }
 
         /// <summary>
-        /// Returns the upper and lower base hash values from which the k hashes are
-        /// derived using the given hash bytes directly.  The result will be the
-        /// same regardless of the endianness of the architecture.
-        ///
-        /// A unit test pins this extraction against Go BoomFilters' convention:
-        /// given the same digest bytes, this produces the same lower and upper
-        /// values that Go's hashKernel derives from a 64-bit sum. That is a
-        /// statement about the arithmetic only. The two libraries do not produce
-        /// interchangeable filters, because they hash with different algorithms by
-        /// default -- MD5 here, FNV-1a in Go.
+        /// Splits a 64-bit hash into the lower and upper base values.
         /// </summary>
-        /// <param name="hashBytes">The hash bytes.</param>
+        /// <param name="sum">The 64-bit hash value.</param>
         /// <returns>A HashKernel</returns>
-        public static HashKernelReturnValue HashKernelFromHashBytes(byte[] hashBytes)
-        {
-            return HashKernelFromHashBytes((ReadOnlySpan<byte>)hashBytes);
-        }
-
-        /// <summary>
-        /// Returns the upper and lower base hash values from which the k hashes are
-        /// derived using the given hash bytes directly.  Identical to the array
-        /// overload, but accepts a span so callers can hash into a buffer they own
-        /// rather than allocating one per call.
-        /// </summary>
-        /// <param name="hashBytes">The hash bytes.</param>
-        /// <returns>A HashKernel</returns>
-        public static HashKernelReturnValue HashKernelFromHashBytes(ReadOnlySpan<byte> hashBytes)
+        public static HashKernelReturnValue HashKernelFromSum(ulong sum)
         {
             return HashKernelReturnValue.Create(
-                HashBytesToUInt32(hashBytes, 0),
-                HashBytesToUInt32(hashBytes, 4)
-                );
+                (uint)(sum & 0xffffffff),
+                (uint)((sum >> 32) & 0xffffffff));
         }
 
         /// <summary>
         /// Returns the upper and lower base hash values from which the k hashes are
-        /// derived.
+        /// derived, for filters large enough to need a 128-bit kernel.
         /// </summary>
+        /// <remarks>
+        /// The hash function supplies 64 bits, so the second value is derived by
+        /// hashing the first. This keeps the two halves independent without
+        /// requiring callers to provide a 128-bit hash.
+        /// </remarks>
         /// <param name="data">The data bytes to hash.</param>
-        /// <param name="algorithm">The hashing algorithm to use.</param>
-        /// <returns>A HashKernel</returns>
-        public static HashKernel128ReturnValue HashKernel128(byte[] data, HashAlgorithm algorithm)
+        /// <param name="hash">The hash function to use.</param>
+        /// <returns>A HashKernel128</returns>
+        public static HashKernel128ReturnValue HashKernel128(byte[] data, Func<ReadOnlySpan<byte>, ulong> hash)
         {
-            Span<byte> sum = stackalloc byte[MaxStackHashSize];
-            if (!algorithm.TryComputeHash(data, sum, out int written))
-            {
-                // Digest larger than the stack buffer, which only a non-standard
-                // HashAlgorithm produces. Fall back to the allocating path.
-                byte[] allocated = algorithm.ComputeHash(data);
-                return HashKernel128ReturnValue.Create(
-                    HashBytesToUInt64(allocated, 0),
-                    HashBytesToUInt64(allocated, 8)
-                    );
-            }
+            ulong lower = hash(data);
 
-            return HashKernel128ReturnValue.Create(
-                HashBytesToUInt64(sum.Slice(0, written), 0),
-                HashBytesToUInt64(sum.Slice(0, written), 8)
-                );
+            Span<byte> lowerBytes = stackalloc byte[8];
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(lowerBytes, lower);
+            ulong upper = hash(lowerBytes);
+
+            return HashKernel128ReturnValue.Create(lower, upper);
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestAllocations.cs
+++ b/TestProbabilisticDataStructures/TestAllocations.cs
@@ -68,9 +68,9 @@ namespace TestProbabilisticDataStructures
         public void TestHashKernelAllocation()
         {
             var data = Key("allocation-probe");
-            using var md5 = MD5.Create();
+            var hash = Defaults.GetDefaultHashFunction();
 
-            var bytes = BytesPerOperation(() => Utils.HashKernel(data, md5));
+            var bytes = BytesPerOperation(() => Utils.HashKernel(data, hash));
 
             Assert.AreEqual(0, bytes,
                 $"Utils.HashKernel allocated {bytes} B per call; the hot path must not allocate.");
@@ -85,10 +85,10 @@ namespace TestProbabilisticDataStructures
         {
             var small = new byte[8];
             var large = new byte[8192];
-            using var md5 = MD5.Create();
+            var hash = Defaults.GetDefaultHashFunction();
 
-            var smallBytes = BytesPerOperation(() => Utils.HashKernel(small, md5));
-            var largeBytes = BytesPerOperation(() => Utils.HashKernel(large, md5));
+            var smallBytes = BytesPerOperation(() => Utils.HashKernel(small, hash));
+            var largeBytes = BytesPerOperation(() => Utils.HashKernel(large, hash));
 
             Assert.AreEqual(smallBytes, largeBytes,
                 $"Allocation scaled with input size: {smallBytes} B for 8 bytes of input " +

--- a/TestProbabilisticDataStructures/TestBloomFilter.cs
+++ b/TestProbabilisticDataStructures/TestBloomFilter.cs
@@ -83,7 +83,15 @@ namespace TestProbabilisticDataStructures
             f.Add(C_BYTES);
 
             var ratio = f.FillRatio();
-            Assert.AreEqual(0.025, ratio);
+
+            // Three items probed by k hash functions set at most 3*k of m bits, and
+            // fewer if any of those probes collide. Whether they collide depends on
+            // the hash function, so this bounds the ratio rather than pinning an
+            // exact value -- the previous assertion of 0.025 was really recording
+            // that MD5 happened to produce no collisions for these three inputs.
+            var upperBound = (double)(3 * f.K()) / f.Capacity();
+            Assert.IsGreaterThan(0.0, ratio);
+            Assert.IsLessThanOrEqualTo(upperBound, ratio);
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestPartitionedBloomFilter.cs
+++ b/TestProbabilisticDataStructures/TestPartitionedBloomFilter.cs
@@ -84,7 +84,12 @@ namespace TestProbabilisticDataStructures
             f.Add(X_BYTES);
 
             var ratio = f.FillRatio();
-            Assert.AreEqual(0.03125, ratio);
+
+            // As with the classic filter, the exact figure depends on whether the
+            // hash function's probes collide, so bound it instead of pinning it.
+            var upperBound = (double)(4 * f.K()) / f.Capacity();
+            Assert.IsGreaterThan(0.0, ratio);
+            Assert.IsLessThanOrEqualTo(upperBound, ratio);
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestProbabilisticDataStructures.cs
+++ b/TestProbabilisticDataStructures/TestProbabilisticDataStructures.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
+using System.IO.Hashing;
 using System.Security.Cryptography;
 
 namespace TestProbabilisticDataStructures
@@ -81,67 +82,65 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
-        /// Ensures that HashKernel() returns the proper upper and lower base when using
-        /// MD5.
+        /// Pins the 32-bit kernel for the library's default hash function.
+        /// <para>
+        /// These values record this library's behavior; they are not shared with any
+        /// other implementation. The Go-convention check lives in
+        /// TestHashKernelFromHashBytes, which feeds digest bytes directly.
+        /// </para>
         /// </summary>
         [TestMethod]
-        public void TestHashKernelMD5()
+        public void TestHashKernelDefault()
         {
             var data = new byte[] { 0, 1, 2, 3 };
-            var hashAlgorithm = MD5.Create();
             var hashKernel = ProbabilisticDataStructures
-                .Utils.HashKernel(data, hashAlgorithm);
+                .Utils.HashKernel(data, ProbabilisticDataStructures.Defaults.GetDefaultHashFunction());
 
-            Assert.AreEqual(4254774583u, hashKernel.LowerBaseHash);
-            Assert.AreEqual(4179961689u, hashKernel.UpperBaseHash);
+            Assert.AreEqual(2776764914u, hashKernel.LowerBaseHash);
+            Assert.AreEqual(1624944694u, hashKernel.UpperBaseHash);
         }
 
         /// <summary>
-        /// Ensures that HashKernel() returns the proper upper and lower base when using
-        /// SHA256.
+        /// The kernel is agnostic to the hash it is given: supplying a different
+        /// function changes the result and nothing else.
         /// </summary>
         [TestMethod]
-        public void TestHashKernelSHA256()
+        public void TestHashKernelWithSuppliedHashFunction()
         {
             var data = new byte[] { 0, 1, 2, 3 };
-            var hashAlgorithm = SHA256.Create();
             var hashKernel = ProbabilisticDataStructures
-                .Utils.HashKernel(data, hashAlgorithm);
+                .Utils.HashKernel(data, d => XxHash64.HashToUInt64(d));
 
-            Assert.AreEqual(3252571653u, hashKernel.LowerBaseHash);
-            Assert.AreEqual(1646207440u, hashKernel.UpperBaseHash);
+            Assert.AreEqual(1146342430u, hashKernel.LowerBaseHash);
+            Assert.AreEqual(4291745888u, hashKernel.UpperBaseHash);
         }
 
         /// <summary>
-        /// Ensures that HashKernel() returns the proper upper and lower base when using
-        /// MD5.
+        /// Pins the 128-bit kernel for the library's default hash function.
         /// </summary>
         [TestMethod]
-        public void TestHashKerne128lMD5()
+        public void TestHashKernel128Default()
         {
             var data = new byte[] { 0, 1, 2, 3 };
-            var hashAlgorithm = MD5.Create();
             var hashKernel = ProbabilisticDataStructures
-                .Utils.HashKernel128(data, hashAlgorithm);
+                .Utils.HashKernel128(data, ProbabilisticDataStructures.Defaults.GetDefaultHashFunction());
 
-            Assert.AreEqual(17952798757042697527ul, hashKernel.LowerBaseHash);
-            Assert.AreEqual(7516929291713011248ul, hashKernel.UpperBaseHash);
+            Assert.AreEqual(6979084321315492338ul, hashKernel.LowerBaseHash);
+            Assert.AreEqual(11802759203604782174ul, hashKernel.UpperBaseHash);
         }
 
         /// <summary>
-        /// Ensures that HashKernel() returns the proper upper and lower base when using
-        /// SHA256.
+        /// The 128-bit kernel is likewise agnostic to the supplied hash function.
         /// </summary>
         [TestMethod]
-        public void TestHashKernel128SHA256()
+        public void TestHashKernel128WithSuppliedHashFunction()
         {
             var data = new byte[] { 0, 1, 2, 3 };
-            var hashAlgorithm = SHA256.Create();
             var hashKernel = ProbabilisticDataStructures
-                .Utils.HashKernel128(data, hashAlgorithm);
+                .Utils.HashKernel128(data, d => XxHash64.HashToUInt64(d));
 
-            Assert.AreEqual(7070407120484453893ul, hashKernel.LowerBaseHash);
-            Assert.AreEqual(4682007113097866575ul, hashKernel.UpperBaseHash);
+            Assert.AreEqual(18432908232848821278ul, hashKernel.LowerBaseHash);
+            Assert.AreEqual(2251845698506980445ul, hashKernel.UpperBaseHash);
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestScalableBloomFilter.cs
+++ b/TestProbabilisticDataStructures/TestScalableBloomFilter.cs
@@ -51,7 +51,7 @@ namespace TestProbabilisticDataStructures
         public void TestScalableFillRatio()
         {
             var f = new ScalableBloomFilter(100, 0.1, 0.8);
-            f.SetHash(ProbabilisticDataStructures.Defaults.GetDefaultHashAlgorithm());
+            f.SetHash(ProbabilisticDataStructures.Defaults.GetDefaultHashFunction());
             for (int i = 0; i < 200; i++)
             {
                 f.Add(Encoding.ASCII.GetBytes(i.ToString()));


### PR DESCRIPTION
Completes the work started as WIP on this branch. **Membership tests are roughly 24x faster; the Cuckoo filter 67x.**

## Results

"MD5" is the previous default with allocation already removed, so this is a like-for-like comparison against current `master`.

| Method | MD5 | XxHash3 | Speedup |
| --- | --- | --- | --- |
| `Bloom_Hit` | 249.7 ns | **10.46 ns** | 24x |
| `Counting_Hit` | 250.5 ns | **10.23 ns** | 24x |
| `Partitioned_Hit` | 251.0 ns | **10.56 ns** | 24x |
| `Scalable_Hit` | 255.6 ns | **10.56 ns** | 24x |
| `Deletable_Hit` | 252.3 ns | **10.12 ns** | 25x |
| `Stable_Hit` | 248.1 ns | **5.45 ns** | 46x |
| `Cuckoo_Hit` | 755.1 ns | **11.24 ns** | **67x** |

Hashing was the entire cost of a filter operation once allocation was removed. MD5 is built to resist collision attacks — a property filters do not need and were paying for on every probe. Cuckoo gains most because it hashes three times per operation.

A side effect worth noting: `Bloom_Miss` is now 3.39 ns against `Bloom_Hit`'s 10.46 ns. A miss short-circuits at the first unset bit, and with hashing no longer dominating, that difference finally shows up.

## The API change

`SetHash` now takes `Func<ReadOnlySpan<byte>, ulong>` instead of `HashAlgorithm`. This is what makes the speed reachable — wrapping a fast hash in `HashAlgorithm` would reintroduce the per-call digest buffer the change exists to remove.

Worth knowing: this signature is legal only because .NET now permits ref struct type arguments on `Func`. It would not have compiled a couple of releases ago. `byte[]` converts to `ReadOnlySpan<byte>` implicitly, so call sites passing arrays need no edit.

## Test changes, and why

**Two fill-ratio tests were asserting an accident.** `TestBloomFillRatio` expected exactly `0.025`. With `m=480` and `k=4`, three items set at most 12 bits, and 12/480 is exactly 0.025 — so the test was really recording that MD5 produced *no colliding probes* for those three specific inputs. That is a property of the hash, not of `FillRatio`. Both now bound the ratio by the maximum possible given n and k, which holds for any hash.

**The kernel tests that pinned MD5 and SHA-256 digests** now pin the default function, with a second pair supplying XxHash64 to show the kernel is agnostic to what it is given.

**The Go-convention test is unchanged.** `TestHashKernelFromHashBytes` feeds Go's FNV digest bytes directly through `HashKernelFromHashBytes` and checks the extraction arithmetic matches. It is the one genuine Go check and does not depend on the default hash.

**Every statistical test passes untouched** — false-positive rates, HyperLogLog error bounds, MinHash similarity. That is the evidence distribution quality did not regress.

## Compatibility and caveats

Element placement changes, so filters persisted by earlier versions cannot be read. This is already 3.0.0 and already breaking, so it costs no additional version churn — shipping it later would mean a 4.0.0 and a second migration.

XxHash3 is **not** resistant to chosen-input attacks: an adversary controlling inserted data can provoke collisions and inflate the observed false-positive rate. MD5 was no better here, only slower. Callers needing that property should supply a keyed hash such as SipHash through `SetHash`. Documented on `Defaults`.

## Verification

Build clean under `-warnaserror`; 141 tests pass.
