### PR TITLE
Cover error paths, counter saturation, and the remaining public API

### DIFF
--- a/TestProbabilisticDataStructures/TestErrorPaths.cs
+++ b/TestProbabilisticDataStructures/TestErrorPaths.cs
@@ -1,0 +1,112 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Covers the library's failure modes.
+    /// <para>
+    /// Every throw site in the library was previously unexercised -- the suite
+    /// contained no exception assertions at all -- so nothing stopped an argument
+    /// check from being weakened or removed unnoticed.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class TestErrorPaths
+    {
+        /// <summary>
+        /// HyperLogLog indexes registers by masking, so a register count that is not
+        /// a power of two would silently produce a skewed distribution rather than
+        /// an obvious failure. The constructor rejects it instead.
+        /// </summary>
+        [TestMethod]
+        public void TestHyperLogLogRejectsNonPowerOfTwoRegisterCount()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => new HyperLogLog(3));
+            StringAssert.Contains(ex.Message, "power of two");
+        }
+
+        [TestMethod]
+        public void TestHyperLogLogAcceptsPowerOfTwoRegisterCount()
+        {
+            // The boundary either side of the rejected case above.
+            _ = new HyperLogLog(2);
+            _ = new HyperLogLog(4);
+            _ = new HyperLogLog(1024);
+        }
+
+        /// <summary>
+        /// Merging estimators with different register counts cannot produce a
+        /// meaningful union, so it is refused rather than approximated.
+        /// </summary>
+        [TestMethod]
+        public void TestHyperLogLogMergeRejectsMismatchedRegisterCounts()
+        {
+            var a = new HyperLogLog(16);
+            var b = new HyperLogLog(32);
+
+            var ex = Assert.Throws<ArgumentException>(() => a.Merge(b));
+            StringAssert.Contains(ex.Message, "registers must match");
+        }
+
+        [TestMethod]
+        public void TestHyperLogLogMergeAcceptsMatchingRegisterCounts()
+        {
+            var a = new HyperLogLog(16);
+            var b = new HyperLogLog(16);
+
+            Assert.IsTrue(a.Merge(b));
+        }
+
+        /// <summary>
+        /// Count-Min Sketch matrices only combine cell-for-cell, so a depth
+        /// mismatch is refused.
+        /// </summary>
+        [TestMethod]
+        public void TestCountMinSketchMergeRejectsMismatchedDepth()
+        {
+            // depth is ceil(ln(1/delta)), so the deltas must differ enough to cross
+            // an integer boundary -- 0.99 and 0.999 both yield depth 1, which is why
+            // the guard below asserts on depth rather than on delta.
+            var a = new CountMinSketch(0.001, 0.99);
+            var b = new CountMinSketch(0.001, 0.01);
+            Assert.AreNotEqual(a.Depth, b.Depth, "test needs sketches of differing depth");
+
+            var ex = Assert.Throws<Exception>(() => a.Merge(b));
+            StringAssert.Contains(ex.Message, "depth must match");
+        }
+
+        /// <summary>
+        /// As above, for a width mismatch.
+        /// </summary>
+        [TestMethod]
+        public void TestCountMinSketchMergeRejectsMismatchedWidth()
+        {
+            // Same delta so depth matches and the width check is what fires.
+            var a = new CountMinSketch(0.001, 0.99);
+            var b = new CountMinSketch(0.01, 0.99);
+            Assert.AreEqual(a.Depth, b.Depth, "test needs matching depth so width is checked");
+            Assert.AreNotEqual(a.Width, b.Width, "test needs sketches of differing width");
+
+            var ex = Assert.Throws<Exception>(() => a.Merge(b));
+            StringAssert.Contains(ex.Message, "width must match");
+        }
+
+        /// <summary>
+        /// Records that a zero false-positive rate is rejected, and how.
+        /// <para>
+        /// OptimalM divides by the log of the rate, which overflows when converting
+        /// the resulting infinity to a uint. OverflowException is not a good way to
+        /// report an invalid argument -- ArgumentOutOfRangeException would say what
+        /// the caller did wrong -- but it is the current behavior, and pinning it
+        /// means a future change to argument validation is a deliberate one.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestBloomFilterRejectsZeroFalsePositiveRate()
+        {
+            Assert.Throws<OverflowException>(() => new BloomFilter(100, 0.0));
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestSaturationAndBounds.cs
+++ b/TestProbabilisticDataStructures/TestSaturationAndBounds.cs
@@ -1,0 +1,85 @@
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Pins behavior at the edges of a counter's range, which no test previously
+    /// reached.
+    /// </summary>
+    [TestClass]
+    public class TestSaturationAndBounds
+    {
+        private static byte[] Key(string s) => Encoding.ASCII.GetBytes(s);
+
+        /// <summary>
+        /// A counting filter's counters saturate, and once they do the filter can no
+        /// longer tell how many times an element was added. Removals then clear it
+        /// after at most max steps rather than after as many steps as there were
+        /// adds.
+        /// <para>
+        /// This is inherent to counting Bloom filters rather than a defect, but it is
+        /// a sharp edge: Count() keeps rising while the counters stop, so the two
+        /// disagree. Callers who delete must not assume adds and removes balance.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestCountingFilterCountersSaturate()
+        {
+            const byte bitsPerCounter = 4;
+            const int max = (1 << bitsPerCounter) - 1;   // 15
+            const int adds = 40;
+
+            var f = new CountingBloomFilter(100, bitsPerCounter, 0.01);
+            var a = Key("a");
+            for (int i = 0; i < adds; i++)
+            {
+                f.Add(a);
+            }
+
+            // Count tracks insertions, not counter state, so it keeps climbing.
+            Assert.AreEqual((uint)adds, f.Count());
+            Assert.IsTrue(f.Test(a));
+
+            var removals = 0;
+            while (f.Test(a) && removals <= adds)
+            {
+                f.TestAndRemove(a);
+                removals++;
+            }
+
+            Assert.IsFalse(f.Test(a), "element should be removable");
+            Assert.IsLessThanOrEqualTo(max, removals,
+                $"counters cap at {max}, so clearing the element should take at most that " +
+                $"many removals, not the {adds} additions performed.");
+        }
+
+        /// <summary>
+        /// Buckets store their maximum in a byte, so a bucket size wider than eight
+        /// bits allocates the extra space but cannot use the extra range: the
+        /// maximum clamps to 255.
+        /// <para>
+        /// This pins current behavior rather than endorsing it. Buckets.cs carries a
+        /// TODO questioning whether the clamp is correct; whichever way that is
+        /// resolved, it should be a deliberate change with this test updated, not a
+        /// silent one.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestBucketSizeWiderThanAByteClampsToByteMax()
+        {
+            var narrow = new Buckets(10, 8);
+            Assert.AreEqual((byte)255, narrow.MaxBucketValue());
+
+            var wide = new Buckets(10, 16);
+            Assert.AreEqual((byte)255, wide.MaxBucketValue(),
+                "a 16-bit bucket allocates 16 bits but its maximum still clamps to 255.");
+
+            // The clamp is a cap, not a failure: the bucket still round-trips values
+            // inside the reachable range.
+            wide.Set(0, 200);
+            Assert.AreEqual(200u, wide.Get(0));
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestUncoveredApi.cs
+++ b/TestProbabilisticDataStructures/TestUncoveredApi.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Public members that no test referenced, plus the Top-K behavior that only
+    /// appears once more distinct elements arrive than the structure retains.
+    /// </summary>
+    [TestClass]
+    public class TestUncoveredApi
+    {
+        private static byte[] Key(string s) => Encoding.ASCII.GetBytes(s);
+
+        /// <summary>
+        /// Epsilon and Delta report the accuracy parameters the sketch was built
+        /// with, including across a Reset.
+        /// </summary>
+        [TestMethod]
+        public void TestCountMinSketchReportsItsAccuracyParameters()
+        {
+            var cms = new CountMinSketch(0.001, 0.99);
+
+            Assert.AreEqual(0.001, cms.Epsilon());
+            Assert.AreEqual(0.99, cms.Delta());
+
+            cms.Add(Key("a"));
+            cms.Reset();
+
+            Assert.AreEqual(0.001, cms.Epsilon(), "Reset clears counts, not configuration");
+            Assert.AreEqual(0.99, cms.Delta(), "Reset clears counts, not configuration");
+        }
+
+        /// <summary>
+        /// HashKernelFromSum splits a 64-bit hash into the lower and upper halves the
+        /// filters derive their k probes from. It is the seam every filter's hashing
+        /// runs through, so its bit layout is pinned explicitly.
+        /// </summary>
+        [TestMethod]
+        public void TestHashKernelFromSumSplitsTheValue()
+        {
+            var kernel = Utils.HashKernelFromSum(0xAABBCCDD_11223344UL);
+
+            Assert.AreEqual(0x11223344u, kernel.LowerBaseHash, "lower half is the low 32 bits");
+            Assert.AreEqual(0xAABBCCDDu, kernel.UpperBaseHash, "upper half is the high 32 bits");
+        }
+
+        [TestMethod]
+        public void TestHashKernelFromSumHandlesBoundaryValues()
+        {
+            var zero = Utils.HashKernelFromSum(0UL);
+            Assert.AreEqual(0u, zero.LowerBaseHash);
+            Assert.AreEqual(0u, zero.UpperBaseHash);
+
+            var max = Utils.HashKernelFromSum(ulong.MaxValue);
+            Assert.AreEqual(uint.MaxValue, max.LowerBaseHash);
+            Assert.AreEqual(uint.MaxValue, max.UpperBaseHash);
+        }
+
+        /// <summary>
+        /// Top-K retains only the k most frequent elements. This adds more distinct
+        /// elements than k so that the heap has to evict, which the existing Top-K
+        /// test never forced.
+        /// </summary>
+        [TestMethod]
+        public void TestTopKEvictsLeastFrequentBeyondK()
+        {
+            var topK = new TopK(0.001, 0.99, 3);
+
+            // Frequencies chosen so the expected survivors are unambiguous.
+            foreach (var (word, times) in new[]
+            {
+                ("alpha", 10), ("bravo", 8), ("charlie", 6), ("delta", 4), ("echo", 2),
+            })
+            {
+                for (int i = 0; i < times; i++)
+                {
+                    topK.Add(Key(word));
+                }
+            }
+
+            var elements = topK.Elements();
+            Assert.HasCount(3, elements);
+
+            var words = elements.Select(e => Encoding.ASCII.GetString(e.Data)).ToArray();
+            CollectionAssert.AreEquivalent(
+                new[] { "charlie", "bravo", "alpha" }, words,
+                "the three most frequent elements should survive and the rest be evicted");
+
+            // Elements come back in ascending frequency order.
+            var freqs = elements.Select(e => e.Freq).ToArray();
+            CollectionAssert.AreEqual(freqs.OrderBy(f => f).ToArray(), freqs,
+                "Elements() should return ascending frequency order");
+        }
+
+        /// <summary>
+        /// Reset returns Top-K to its initial state, including releasing the elements
+        /// the heap was holding.
+        /// </summary>
+        [TestMethod]
+        public void TestTopKResetClearsRetainedElements()
+        {
+            var topK = new TopK(0.001, 0.99, 3);
+            foreach (var word in new[] { "alpha", "bravo", "charlie", "delta" })
+            {
+                topK.Add(Key(word));
+            }
+
+            Assert.IsGreaterThan(0, topK.Elements().Length);
+
+            var returned = topK.Reset();
+
+            Assert.AreSame(topK, returned, "Reset returns the same instance for chaining");
+            Assert.IsEmpty(topK.Elements());
+            Assert.AreEqual(0u, topK.N);
+        }
+    }
+}


### PR DESCRIPTION
Fills the mechanical gaps from the coverage audit. **155 tests, up from 141**, and no untested public members remain.

The audit's main finding was that the gaps were not untested *methods* — only 3 of roughly 100 public members went unreferenced — but untested **conditions**. That is the same shape as the Cuckoo false-negative fixed in #36: the lines executed under test, and only the filter state needed to expose the defect never occurred.

## Error paths — previously 0% covered

The suite contained **no exception assertion anywhere**, so every argument check in the library could have been weakened or deleted unnoticed. Now covered:

- `HyperLogLog` rejecting a register count that is not a power of two
- `HyperLogLog.Merge` rejecting mismatched register counts
- `CountMinSketch.Merge` rejecting mismatched depth, and mismatched width
- A zero false-positive rate

That last test pins an `OverflowException`, which is a poor way to report an invalid argument — `ArgumentOutOfRangeException` would tell the caller what they did wrong. The test says so explicitly, so improving it later is a deliberate change rather than an accidental one.

**A trap worth recording:** depth is `ceil(ln(1/delta))`, so `0.99` and `0.999` both give depth 1. My first version of the depth-mismatch test used those values, guarded the setup by asserting the *deltas* differed, and passed while exercising nothing at all. The guards now assert on the derived `Depth` and `Width` rather than on the inputs.

## Counter saturation

Adding an element 40 times into 4-bit counters leaves `Count()` reporting 40 while the counters stop at 15 — so the element clears after at most 15 removals, not 40. That is inherent to counting Bloom filters rather than a defect, but **adds and removes not balancing** is a sharp edge that nothing recorded.

## Buckets wider than a byte

A 16-bit bucket allocates 16 bits but clamps its maximum to 255, so half the allocated range is unreachable. `Buckets.cs` carries a `// TODO: Figure out this truncation thing` questioning whether that clamp is right.

This does not resolve it — that is a behavior decision — but it pins the current answer so whichever way it goes is deliberate.

## Remaining API and Top-K

`CountMinSketch.Epsilon`/`Delta`, `Utils.HashKernelFromSum` including boundary values, and Top-K eviction. The existing Top-K test never added more distinct elements than the structure retains, so the heap never had to evict.

## Still open, needing your decision

Two items from the audit are behavior questions rather than test-writing, so they are **not** in this PR:

1. **`Add(null)` silently succeeds in 3.0.0** and is indistinguishable from empty input. It threw `ArgumentNullException` in 2.x. This is a live, shipped, undocumented change.
2. **The `Buckets` >8-bit TODO** above.

Build clean under `-warnaserror`; 155 tests pass.
