### PR TITLE
Reject null data and over-wide bucket sizes (3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - Unreleased
+
+### Fixed
+
+- **Passing `null` as data now throws `ArgumentNullException` again.** In 3.0.0 it
+  silently succeeded and was indistinguishable from an empty array, because a null
+  array converts to an empty span and hashes to the same value.
+
+  This was a regression. Version 2.x threw, because hashing went through
+  `HashAlgorithm.ComputeHash`, which rejects null. Moving to span-based hashing
+  removed the check without anyone noticing, and nothing in the test suite passed
+  null to anything.
+
+  It matters more than a missing argument check usually would: without it, a caller's
+  null bug does not surface at the call site. It quietly inserts a phantom element
+  that collides with empty input and produces a wrong answer later, elsewhere.
+
+  Empty input remains valid and distinct from null.
+
+### Changed
+
+- **`Buckets` and `Buckets64` now reject a bucket size wider than 8 bits** with
+  `ArgumentOutOfRangeException`, rather than accepting it and capping the value at 255.
+
+  A bucket's maximum is stored in a byte, so a wider bucket allocated the extra space
+  without being able to hold a larger value -- a 16-bit bucket cost twice the memory
+  for no additional range. The bit packing itself handles wider buckets correctly; only
+  the maximum could not.
+
+  This resolves a long-standing `TODO` questioning whether the cap was intended. It is:
+  upstream Go BoomFilters stores its maximum in a `uint8` too, where the same
+  expression wraps to 255 rather than clamping. Both implementations have always
+  capped at 255, so this rejects a request neither could honor.
+
+  These are internal types. Reaching the limit requires passing a bucket size above 8
+  to `CountingBloomFilter` or `StableBloomFilter`, which would previously have wasted
+  memory silently.
+
 ## [3.0.0] - 2026-08-13
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          lived nowhere in the repo: AppVeyor patched AssemblyInfo.cs at build time from
          its own build counter, which is how the published package version (1.0.1) and
          the GitHub release tags (v1.0.9) drifted apart. -->
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/ProbabilisticDataStructures/BloomFilter.cs
+++ b/ProbabilisticDataStructures/BloomFilter.cs
@@ -105,6 +105,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data is maybe contained in the filter.</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -128,6 +130,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The filter.</returns>
         public IFilter Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -150,6 +154,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was probably contained in the filter.</returns>
         public bool TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;

--- a/ProbabilisticDataStructures/BloomFilter64.cs
+++ b/ProbabilisticDataStructures/BloomFilter64.cs
@@ -110,6 +110,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data is maybe contained in the filter.</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel128(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -133,6 +135,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The filter.</returns>
         public IFilter Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel128(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -155,6 +159,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was probably contained in the filter.</returns>
         public bool TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel128(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;

--- a/ProbabilisticDataStructures/Buckets.cs
+++ b/ProbabilisticDataStructures/Buckets.cs
@@ -1,4 +1,6 @@
-﻿namespace ProbabilisticDataStructures
+﻿using System;
+
+namespace ProbabilisticDataStructures
 {
     /// <summary>
     /// Buckets is a fast, space-efficient array of buckets where each bucket can store
@@ -6,6 +8,23 @@
     /// </summary>
     public class Buckets
     {
+        /// <summary>
+        /// The widest bucket supported, in bits.
+        /// </summary>
+        /// <remarks>
+        /// A bucket's maximum value is held in a byte, so eight bits is the widest
+        /// that can be fully used. The bit-packing itself would handle more --
+        /// GetBits and SetBits span byte boundaries correctly -- but a wider bucket
+        /// would allocate the extra space and still cap its value at 255, so the
+        /// memory would be paid for and unusable.
+        ///
+        /// Upstream Go BoomFilters has the same cap, reached differently: its max
+        /// field is a uint8, so (1 &lt;&lt; bucketSize) - 1 wraps to 255 for any size of
+        /// eight or more rather than being clamped. Rejecting the argument is
+        /// preferred here over silently accepting a request that cannot be honored.
+        /// </remarks>
+        private const byte MaxBucketSizeBits = 8;
+
         private byte[] Data { get; set; }
         private byte bucketSize { get; set; }
         private byte _max;
@@ -17,9 +36,10 @@
             }
             set
             {
-                // TODO: Figure out this truncation thing.
-                // I'm not sure if MaxValue is always supposed to be capped at 255 via
-                // a byte conversion or not...
+                // Capping at 255 is correct and matches upstream: Go's Buckets
+                // stores max in a uint8, so the same expression wraps to 255 there.
+                // The constructor now rejects bucket sizes that would reach this
+                // branch, so it remains only as a guard.
                 if (value > byte.MaxValue)
                     _max = byte.MaxValue;
                 else
@@ -36,6 +56,14 @@
         /// <param name="bucketSize">Number of bits per bucket.</param>
         internal Buckets(uint count, byte bucketSize)
         {
+            if (bucketSize > MaxBucketSizeBits)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bucketSize), bucketSize,
+                    $"Bucket size must be at most {MaxBucketSizeBits} bits. A bucket's " +
+                    "maximum value is stored in a byte, so wider buckets would allocate " +
+                    "the extra space without being able to hold a larger value.");
+            }
+
             this.count = count;
             this.Data = new byte[(count * bucketSize + 7) / 8];
             this.bucketSize = bucketSize;

--- a/ProbabilisticDataStructures/Buckets64.cs
+++ b/ProbabilisticDataStructures/Buckets64.cs
@@ -13,6 +13,23 @@ namespace ProbabilisticDataStructures
     /// </summary>
     public class Buckets64
     {
+        /// <summary>
+        /// The widest bucket supported, in bits.
+        /// </summary>
+        /// <remarks>
+        /// A bucket's maximum value is held in a byte, so eight bits is the widest
+        /// that can be fully used. The bit-packing itself would handle more --
+        /// GetBits and SetBits span byte boundaries correctly -- but a wider bucket
+        /// would allocate the extra space and still cap its value at 255, so the
+        /// memory would be paid for and unusable.
+        ///
+        /// Upstream Go BoomFilters has the same cap, reached differently: its max
+        /// field is a uint8, so (1 &lt;&lt; bucketSize) - 1 wraps to 255 for any size of
+        /// eight or more rather than being clamped. Rejecting the argument is
+        /// preferred here over silently accepting a request that cannot be honored.
+        /// </remarks>
+        private const byte MaxBucketSizeBits = 8;
+
         // The largest C# array to create; the largest power of 2 that C# can support.
         private const uint maxArraySize = 1U << 30;
         private byte[][] Data { get; set; }
@@ -27,9 +44,10 @@ namespace ProbabilisticDataStructures
             }
             set
             {
-                // TODO: Figure out this truncation thing.
-                // I'm not sure if MaxValue is always supposed to be capped at 255 via
-                // a byte conversion or not...
+                // Capping at 255 is correct and matches upstream: Go's Buckets
+                // stores max in a uint8, so the same expression wraps to 255 there.
+                // The constructor now rejects bucket sizes that would reach this
+                // branch, so it remains only as a guard.
                 if (value > byte.MaxValue)
                     _max = byte.MaxValue;
                 else
@@ -46,6 +64,14 @@ namespace ProbabilisticDataStructures
         /// <param name="bucketSize">Number of bits per bucket.</param>
         internal Buckets64(ulong count, byte bucketSize)
         {
+            if (bucketSize > MaxBucketSizeBits)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bucketSize), bucketSize,
+                    $"Bucket size must be at most {MaxBucketSizeBits} bits. A bucket's " +
+                    "maximum value is stored in a byte, so wider buckets would allocate " +
+                    "the extra space without being able to hold a larger value.");
+            }
+
             this.count = count;
             this.bucketSize = bucketSize;
             AllocateArray(count, bucketSize);

--- a/ProbabilisticDataStructures/CountMinSketch.cs
+++ b/ProbabilisticDataStructures/CountMinSketch.cs
@@ -114,6 +114,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The CountMinSketch</returns>
         public CountMinSketch Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;

--- a/ProbabilisticDataStructures/CountingBloomFilter.cs
+++ b/ProbabilisticDataStructures/CountingBloomFilter.cs
@@ -118,6 +118,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data is maybe contained in the filter.</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -141,6 +143,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The filter.</returns>
         public IFilter Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -163,6 +167,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was probably contained in the filter.</returns>
         public bool TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -191,6 +197,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was in the filter before removal.</returns>
         public bool TestAndRemove(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -124,6 +124,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data is a member</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var components = this.GetComponents(data);
             var i1 = components.Hash1;
             var i2 = components.Hash2;
@@ -159,6 +161,8 @@ namespace ProbabilisticDataStructures
         /// </returns>
         public bool Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var components = this.GetComponents(data);
             var i1 = components.Hash1;
             var i2 = components.Hash2;
@@ -178,6 +182,8 @@ namespace ProbabilisticDataStructures
         /// </returns>
         public TestAndAddReturnValue TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var components = this.GetComponents(data);
             var i1 = components.Hash1;
             var i2 = components.Hash2;
@@ -218,6 +224,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether the data was a member or not</returns>
         public bool TestAndRemove(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var components = this.GetComponents(data);
             var i1 = components.Hash1;
             var i2 = components.Hash2;

--- a/ProbabilisticDataStructures/DeletableBloomFilter.cs
+++ b/ProbabilisticDataStructures/DeletableBloomFilter.cs
@@ -113,6 +113,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data is maybe contained in the filter.</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -136,6 +138,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The filter.</returns>
         public IFilter Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -167,6 +171,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was probably contained in the filter.</returns>
         public bool TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -200,6 +206,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was a member before this call</returns>
         public bool TestAndRemove(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;

--- a/ProbabilisticDataStructures/HyperLogLog.cs
+++ b/ProbabilisticDataStructures/HyperLogLog.cs
@@ -106,6 +106,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The HyperLogLog</returns>
         public HyperLogLog Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hash = CalculateHash(data);
             var k = 32 - this.B;
             var r = CalculateRho(hash << (int)this.B, k);

--- a/ProbabilisticDataStructures/InverseBloomFilter.cs
+++ b/ProbabilisticDataStructures/InverseBloomFilter.cs
@@ -81,6 +81,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data is present</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var index = this.Index(data);
             var val = this.Array[index];
             if (val == null)
@@ -97,6 +99,8 @@ namespace ProbabilisticDataStructures
         /// <returns></returns>
         public IFilter Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var index = this.Index(data);
             this.GetAndSet(index, data);
             return this;
@@ -110,6 +114,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether the data was already a member</returns>
         public bool TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var index = this.Index(data);
             var oldId = this.GetAndSet(index, data);
             if (oldId == null)

--- a/ProbabilisticDataStructures/PartitionedBloomFilter.cs
+++ b/ProbabilisticDataStructures/PartitionedBloomFilter.cs
@@ -149,6 +149,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was found</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -173,6 +175,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The PartitionedBloomFilter</returns>
         public IFilter Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -197,6 +201,8 @@ namespace ProbabilisticDataStructures
         /// </returns>
         public bool TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;

--- a/ProbabilisticDataStructures/ScalableBloomFilter.cs
+++ b/ProbabilisticDataStructures/ScalableBloomFilter.cs
@@ -138,6 +138,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data is maybe contained in the filter.</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             // Querying is made by testing for the presence in each filter.
             foreach (var filter in this.Filters)
             {
@@ -158,6 +160,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The ScalableBloomFilter</returns>
         public IFilter Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var idx = this.Filters.Count() - 1;
 
             // If the last filter has reached its fill ratio, add a new one.
@@ -179,6 +183,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was present before adding it</returns>
         public bool TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var member = this.Test(data);
             this.Add(data);
             return member;

--- a/ProbabilisticDataStructures/StableBloomFilter.cs
+++ b/ProbabilisticDataStructures/StableBloomFilter.cs
@@ -202,6 +202,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data is maybe contained in the filter</returns>
         public bool Test(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -225,6 +227,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The filter.</returns>
         public IFilter Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             // Randomly decrement p cells to make room for new elements.
             this.Decrement();
 
@@ -249,6 +253,8 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the data was present before adding.</returns>
         public bool TestAndAdd(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;

--- a/ProbabilisticDataStructures/TopK.cs
+++ b/ProbabilisticDataStructures/TopK.cs
@@ -1,4 +1,5 @@
-﻿namespace ProbabilisticDataStructures
+﻿using System;
+namespace ProbabilisticDataStructures
 {
     /// <summary>
     /// TopK uses a Count-Min Sketch to calculate the top-K frequent elements in a
@@ -35,6 +36,8 @@
         /// <returns>The TopK</returns>
         public TopK Add(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             this.Cms.Add(data);
             this.N++;
 

--- a/TestProbabilisticDataStructures/TestBuckets.cs
+++ b/TestProbabilisticDataStructures/TestBuckets.cs
@@ -90,7 +90,7 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void BenchmarkBucketsIncrement()
         {
-            var buckets = new Buckets(10000, 10);
+            var buckets = new Buckets(10000, 8);
             for (uint i = 0; i < buckets.count; i++)
             {
                 buckets.Increment(i % 10000, 1);
@@ -100,7 +100,7 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void BenchmarkBucketsSet()
         {
-            var buckets = new Buckets(10000, 10);
+            var buckets = new Buckets(10000, 8);
             for (uint i = 0; i < buckets.count; i++)
             {
                 buckets.Set(i % 10000, 1);
@@ -110,7 +110,7 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void BenchmarkBucketsGet()
         {
-            var buckets = new Buckets(10000, 10);
+            var buckets = new Buckets(10000, 8);
             for (uint i = 0; i < buckets.count; i++)
             {
                 buckets.Get(i % 10000);

--- a/TestProbabilisticDataStructures/TestBuckets64.cs
+++ b/TestProbabilisticDataStructures/TestBuckets64.cs
@@ -90,7 +90,7 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void BenchmarkBuckets64Increment()
         {
-            var buckets = new Buckets64(10000, 10);
+            var buckets = new Buckets64(10000, 8);
             for (uint i = 0; i < buckets.count; i++)
             {
                 buckets.Increment(i % 10000, 1);
@@ -100,7 +100,7 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void BenchmarkBuckets64Set()
         {
-            var buckets = new Buckets64(10000, 10);
+            var buckets = new Buckets64(10000, 8);
             for (uint i = 0; i < buckets.count; i++)
             {
                 buckets.Set(i % 10000, 1);
@@ -110,7 +110,7 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void BenchmarkBuckets64Get()
         {
-            var buckets = new Buckets64(10000, 10);
+            var buckets = new Buckets64(10000, 8);
             for (uint i = 0; i < buckets.count; i++)
             {
                 buckets.Get(i % 10000);

--- a/TestProbabilisticDataStructures/TestNullArguments.cs
+++ b/TestProbabilisticDataStructures/TestNullArguments.cs
@@ -1,0 +1,83 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Every public entry point that takes data rejects null.
+    /// <para>
+    /// This is the .NET convention, and it matters more than usual here. Without the
+    /// check, a null array converts to an empty span and hashes to the same value as
+    /// <see cref="Array.Empty{T}"/>, so a caller's null bug would not surface at the
+    /// call site -- it would quietly insert a phantom element and produce a wrong
+    /// answer later, somewhere else.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class TestNullArguments
+    {
+        [TestMethod]
+        public void TestFiltersRejectNullData()
+        {
+            var bloom = new BloomFilter(100, 0.01);
+            Assert.Throws<ArgumentNullException>(() => bloom.Add(null!));
+            Assert.Throws<ArgumentNullException>(() => bloom.Test(null!));
+            Assert.Throws<ArgumentNullException>(() => bloom.TestAndAdd(null!));
+
+            var bloom64 = new BloomFilter64(100, 0.01);
+            Assert.Throws<ArgumentNullException>(() => bloom64.Add(null!));
+
+            var counting = CountingBloomFilter.NewDefaultCountingBloomFilter(100, 0.01);
+            Assert.Throws<ArgumentNullException>(() => counting.Add(null!));
+            Assert.Throws<ArgumentNullException>(() => counting.TestAndRemove(null!));
+
+            var partitioned = new PartitionedBloomFilter(100, 0.01);
+            Assert.Throws<ArgumentNullException>(() => partitioned.Add(null!));
+
+            var scalable = ScalableBloomFilter.NewDefaultScalableBloomFilter(0.01);
+            Assert.Throws<ArgumentNullException>(() => scalable.Add(null!));
+
+            var stable = StableBloomFilter.NewDefaultStableBloomFilter(100, 0.01);
+            Assert.Throws<ArgumentNullException>(() => stable.Add(null!));
+
+            var deletable = new DeletableBloomFilter(100, 10, 0.01);
+            Assert.Throws<ArgumentNullException>(() => deletable.Add(null!));
+            Assert.Throws<ArgumentNullException>(() => deletable.TestAndRemove(null!));
+
+            var inverse = new InverseBloomFilter(100);
+            Assert.Throws<ArgumentNullException>(() => inverse.Add(null!));
+
+            var cuckoo = new CuckooBloomFilter(100, 0.01);
+            Assert.Throws<ArgumentNullException>(() => cuckoo.Add(null!));
+            Assert.Throws<ArgumentNullException>(() => cuckoo.TestAndRemove(null!));
+
+            var cms = new CountMinSketch(0.001, 0.99);
+            Assert.Throws<ArgumentNullException>(() => cms.Add(null!));
+
+            var hll = HyperLogLog.NewDefaultHyperLogLog(0.01);
+            Assert.Throws<ArgumentNullException>(() => hll.Add(null!));
+
+            var topK = new TopK(0.001, 0.99, 3);
+            Assert.Throws<ArgumentNullException>(() => topK.Add(null!));
+        }
+
+        /// <summary>
+        /// Empty input is legitimate and distinct from null: an empty array is a
+        /// value the caller meant to store, and it round-trips.
+        /// </summary>
+        [TestMethod]
+        public void TestEmptyDataIsAcceptedAndDistinctFromNull()
+        {
+            var f = new BloomFilter(100, 0.01);
+            var empty = Array.Empty<byte>();
+
+            Assert.IsFalse(f.Test(empty));
+            f.Add(empty);
+            Assert.IsTrue(f.Test(empty), "an empty array is a storable value");
+
+            Assert.Throws<ArgumentNullException>(() => f.Test(null!),
+                "null is rejected even though empty input is accepted");
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestSaturationAndBounds.cs
+++ b/TestProbabilisticDataStructures/TestSaturationAndBounds.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
@@ -56,30 +57,48 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
-        /// Buckets store their maximum in a byte, so a bucket size wider than eight
-        /// bits allocates the extra space but cannot use the extra range: the
-        /// maximum clamps to 255.
+        /// A bucket's maximum value is held in a byte, so eight bits is the widest
+        /// bucket that can be fully used. Wider ones are rejected rather than
+        /// accepted and silently capped: the bit packing would allocate the extra
+        /// space, but the value could still never exceed 255, so the memory would be
+        /// paid for and unreachable.
         /// <para>
-        /// This pins current behavior rather than endorsing it. Buckets.cs carries a
-        /// TODO questioning whether the clamp is correct; whichever way that is
-        /// resolved, it should be a deliberate change with this test updated, not a
-        /// silent one.
+        /// Upstream Go reaches the same 255 ceiling by different means -- its max
+        /// field is a uint8, so the expression wraps rather than clamping -- so this
+        /// rejects a request that has never been honorable in either implementation.
         /// </para>
         /// </summary>
         [TestMethod]
-        public void TestBucketSizeWiderThanAByteClampsToByteMax()
+        public void TestBucketSizeWiderThanAByteIsRejected()
         {
-            var narrow = new Buckets(10, 8);
-            Assert.AreEqual((byte)255, narrow.MaxBucketValue());
+            var widest = new Buckets(10, 8);
+            Assert.AreEqual((byte)255, widest.MaxBucketValue());
 
-            var wide = new Buckets(10, 16);
-            Assert.AreEqual((byte)255, wide.MaxBucketValue(),
-                "a 16-bit bucket allocates 16 bits but its maximum still clamps to 255.");
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new Buckets(10, 9));
+            StringAssert.Contains(ex.Message, "at most 8 bits");
 
-            // The clamp is a cap, not a failure: the bucket still round-trips values
-            // inside the reachable range.
-            wide.Set(0, 200);
-            Assert.AreEqual(200u, wide.Get(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buckets64(10, 16));
+        }
+
+        /// <summary>
+        /// Every bucket width up to the limit round-trips values across its full
+        /// range, including the boundary where a bucket spans two bytes.
+        /// </summary>
+        [TestMethod]
+        public void TestSupportedBucketWidthsRoundTrip()
+        {
+            for (byte bits = 1; bits <= 8; bits++)
+            {
+                var b = new Buckets(16, bits);
+                var max = b.MaxBucketValue();
+
+                b.Set(0, max);
+                b.Set(3, max);
+
+                Assert.AreEqual((uint)max, b.Get(0), $"bucketSize {bits} lost its value");
+                Assert.AreEqual((uint)max, b.Get(3), $"bucketSize {bits} lost a spanning value");
+                Assert.AreEqual(0u, b.Get(1), $"bucketSize {bits} bled into a neighbour");
+            }
         }
     }
 }


### PR DESCRIPTION
The two behavior decisions left open by the coverage audit in #39. Releases as **3.0.1**.

## Null is rejected again

`Add(null)` silently succeeded in 3.0.0, indistinguishable from an empty array — a null array converts to an empty span and hashes to the same value.

**This was a regression I introduced.** 2.x threw `ArgumentNullException` because hashing went through `HashAlgorithm.ComputeHash`, which rejects null. Moving to span-based hashing dropped the check, and nothing in the suite passed null to anything.

Throwing is the .NET convention: the BCL rejects null reference arguments rather than coercing them, and null and empty are distinct throughout the framework — `string.IsNullOrEmpty` exists precisely because callers must *opt in* to treating them the same.

It matters more than a missing argument check usually would. Without it, a caller's null bug doesn't surface at the call site — it inserts a phantom element that collides with empty input and produces a wrong answer later, somewhere else.

Restoring it is a **fix, not a break**: it returns behavior to what 2.x had and convention expects.

**The guard is free.** `Bloom_Hit` measures 10.30 ns against 10.46 ns before — inside noise.

Empty input remains valid and distinct from null, with a test asserting both.

## Bucket sizes wider than a byte are rejected

`Buckets` and `Buckets64` now throw `ArgumentOutOfRangeException` above 8 bits instead of accepting the request and capping the value at 255. A 16-bit bucket cost twice the memory for no additional range. The bit packing handles wider buckets correctly — `GetBits`/`SetBits` span byte boundaries fine — only the maximum, stored in a `byte`, could not.

**This resolves the `// TODO: Figure out this truncation thing` in `Buckets.cs`.** The answer is that capping at 255 is correct and intentional: upstream Go stores its max in a `uint8`, where `(1 << bucketSize) - 1` *wraps* to 255 rather than clamping. Both implementations have always capped there, so this rejects a request neither could ever honor.

Worth noting: **the suite's own benchmark loops constructed 10-bit buckets** — exactly the silent waste being removed. They now use 8. That's a decent sign the wide-bucket path was never used deliberately.

The test from #39 that pinned the clamp is replaced by one asserting the rejection, plus a new test that every supported width (1–8) round-trips its full range, including where a bucket spans two bytes.

## Verification

Build clean under `-warnaserror`; **158 tests** pass. Benchmarks re-run to confirm no regression.
