### PR TITLE
Correctness audit: 14 defects across 9 structures (3.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is inherent -- a filter cannot tell such a removal from a real one -- and is now
   documented rather than fixed.
 
+
 - **`Reset()` clears the item count** on `BloomFilter`, `BloomFilter64` and
   `PartitionedBloomFilter`. All three emptied their buckets and left the count where it
   was, so a filter that was empty by every other measure still reported the items it
@@ -155,6 +156,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A bucket width of zero is rejected** with `ArgumentOutOfRangeException` rather than
   throwing `IndexOutOfRangeException` on first use. `new CountingBloomFilter(n, 0, r)`
   allocated no storage and then read from it.
+
+### Changed
+
+- **`MinHash.Similarity` returns the resemblance it documents.** Broder's resemblance is
+  the Jaccard index -- distinct words in both bags over distinct words in either. This
+  returned the Sørensen–Dice coefficient, `2|A∩B| / (|A|+|B|)`, which is related as
+  `D = 2J / (1 + J)` and so is consistently higher: **bags of one third resemblance were
+  reported at one half**.
+
+  None of the MinHash machinery contributed to that result. It generated `k` hash
+  permutations and never used them, because the loop over them ignored its own index,
+  and returned agreement over element positions instead. The same input gave the same
+  answer on every run despite the random hashes, which is the tell.
+
+  The result is now computed exactly rather than estimated. Broder's estimator earns its
+  error when a set is too large to hold or a signature can be reused across many
+  comparisons, and neither applies to a call handed both bags in full; estimating would
+  cost accuracy and time and buy nothing. A signature-based API, which is where the
+  estimator does pay, is being considered alongside serialization.
+
+  Removing the unused permutations also removed their cost: comparing two 400-word bags
+  took 163 ms and now takes about 15 µs.
+
+  Two empty bags now return 1 rather than `NaN`, and a null bag throws
+  `ArgumentNullException` rather than `NullReferenceException`.
 
 ## [3.0.1] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is inherent -- a filter cannot tell such a removal from a real one -- and is now
   documented rather than fixed.
 
+- **`ScalableBloomFilter` validates its tightening ratio.** The ratio scales each new
+  filter's false positive rate down from the last, and the structure's guarantee -- a
+  compound rate bounded by `P0 / (1 - r)` -- is a geometric series that only converges
+  below 1. A ratio of exactly 1 was accepted and tightened nothing: asking for 1% and
+  adding 20,000 items measured **83%**. The filter kept working and quietly stopped
+  honoring the rate requested of it. Ratios at or below 0 and above 1 did throw, but
+  from inside `Add`, naming `fpRate` -- a parameter the caller had passed correctly.
+
+- **`ScalableBloomFilter.Reset()` keeps a hash function set with `SetHash`.** It
+  rebuilds its list of filters from scratch and did not carry the hash across, silently
+  restoring the default. Every other filter's `Reset` preserves it.
+
 - **A bucket width of zero is rejected** with `ArgumentOutOfRangeException` rather than
   throwing `IndexOutOfRangeException` on first use. `new CountingBloomFilter(n, 0, r)`
   allocated no storage and then read from it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is inherent -- a filter cannot tell such a removal from a real one -- and is now
   documented rather than fixed.
 
+- **`CountMinSketch` validates `epsilon` and `delta`.** `delta` is the probability that
+  an estimate exceeds the error `epsilon` allows, and the matrix depth `ln(1 / delta)`
+  is only positive below one. At one and above the matrix had **no rows**, and a sketch
+  with no rows did not fail: `Count` minimises over an empty set of rows and returns its
+  initial value, so **every element was reported as having been seen 18446744073709551615
+  times**. Values at or below zero, and `NaN`, surfaced as `OverflowException` or
+  `DivideByZeroException` from the sizing arithmetic. An `epsilon` small enough to need
+  a matrix wider than `uint.MaxValue` is now rejected rather than wrapping.
+
+- **`CountMinSketch.Count(null)` and `Merge(null)` throw `ArgumentNullException`.**
+  `Count` hashed the empty span and returned a number; `Merge` threw
+  `NullReferenceException`.
+
+- **`CountMinSketch.Merge` throws `ArgumentException` rather than the bare `Exception`**
+  on a width or depth mismatch, which could not be caught without catching every
+  unrelated failure alongside it. The message now names both dimensions and the
+  parameter each follows from.
+
 - **`TopK` returns the top k.** Its min-heap was not one. `Pop` removed the root with
   `List.Remove`, which slides every later element down a position instead of restoring
   the ordering, and an element already in the heap had its frequency raised in place

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Valid arguments are unaffected. `HyperLogLog` and `TopK` already validated theirs;
   this brings the rest of the library in line.
 
+- **`HyperLogLog` threw `IndexOutOfRangeException` at 2^29 registers.** `b` splits the
+  hash into a register index and the bits `rho` scans, so it has to be exactly
+  `log2(m)`. Deriving it as `Ceiling(Log(m, 2))` is not exact: at `m = 2^29` the
+  floating-point logarithm lands just above 29 and the ceiling returns 30, leaving the
+  register index able to exceed the array. It is now derived with `BitOperations.Log2`.
+  Separately, a register count of zero passed the power-of-two check, because `0 - 1`
+  underflows to all ones; it is now rejected. The estimator itself is unchanged.
+
+- **`DeletableBloomFilter` threw `IndexOutOfRangeException` for any collision region
+  count that is a multiple of eight**, including `8`, `16`, `32` and `64`. The region
+  size was rounded down, so the trailing bits of the data region mapped to region index
+  `r` -- one past the last collision bucket. Whether that was fatal depended on
+  something unrelated: the collision bitmap allocates whole bytes, and for most values
+  of `r` the stray index landed in the leftover padding bits and went unnoticed, but a
+  multiple of eight leaves no padding and the write ran off the array. Passing an `r`
+  larger than the `m - r` data bits rounded the region size down to zero and threw
+  `DivideByZeroException` on the first `Add`. The region size is now rounded up, which
+  keeps every index inside the array and non-zero. Stored filter contents are
+  unaffected; only which region a bit is attributed to changes.
+
 ## [3.0.1] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keeps every index inside the array and non-zero. Stored filter contents are
   unaffected; only which region a bit is attributed to changes.
 
+- **`CountingBloomFilter` removals no longer hide elements that are still present.**
+  A counter that reaches its maximum has stopped tracking how many elements it stands
+  for, but removals decremented it anyway, resuming the count from the ceiling. Enough
+  of those drove it to zero while elements needing it were still in the filter --
+  precisely the false negative that a counting filter exists to avoid. Saturated
+  counters are now left alone, which costs space rather than correctness: the elements
+  covering them become permanently unremovable.
+
+  The effect scaled with how quickly counters saturate. Removing half of 2000 elements
+  left **745 of the 1000 survivors unfindable at 1 bit per counter** and 42 at 2 bits.
+  The default 4-bit counters showed none at that load, which is why this went unseen.
+
+  Removing an element that was never added still introduces false negatives. That one
+  is inherent -- a filter cannot tell such a removal from a real one -- and is now
+  documented rather than fixed.
+
+- **A bucket width of zero is rejected** with `ArgumentOutOfRangeException` rather than
+  throwing `IndexOutOfRangeException` on first use. `new CountingBloomFilter(n, 0, r)`
+  allocated no storage and then read from it.
+
 ## [3.0.1] - 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is inherent -- a filter cannot tell such a removal from a real one -- and is now
   documented rather than fixed.
 
+- **`Reset()` clears the item count** on `BloomFilter`, `BloomFilter64` and
+  `PartitionedBloomFilter`. All three emptied their buckets and left the count where it
+  was, so a filter that was empty by every other measure still reported the items it
+  used to hold. `CountingBloomFilter` and `DeletableBloomFilter` already cleared theirs.
+
+  The count is not only reported: `EstimatedFillRatio()` is derived from it, and a
+  partitioned filter's is what a scalable filter consults to decide when to grow. A
+  filter emptied after 800 additions reported an estimated fill ratio of **44%**.
+
 - **`CountMinSketch` validates `epsilon` and `delta`.** `delta` is the probability that
   an estimate exceeds the error `epsilon` allows, and the matrix depth `ln(1 / delta)`
   is only positive below one. At one and above the matrix had **no rows**, and a sketch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - Unreleased
+
+### Fixed
+
+- **Filter constructors now validate their arguments and throw
+  `ArgumentOutOfRangeException`** instead of failing later, or not at all.
+
+  Three problems, all of which reported something true about the internals and
+  nothing about the mistake:
+
+  - A false positive rate of 0, 1, a negative, a value above 1, or `NaN` surfaced as
+    an `OverflowException` from a numeric conversion inside the sizing math. A rate of
+    exactly 1 was worse: it constructed successfully and produced a filter with zero
+    bits and zero hash functions, which silently reported every element as present.
+
+  - Sizing a filter for zero items constructed successfully and then threw
+    `DivideByZeroException` on first use, far from the cause. This affected
+    `BloomFilter`, `BloomFilter64`, `CountingBloomFilter`, `PartitionedBloomFilter`
+    and `CuckooBloomFilter`.
+
+  - `DeletableBloomFilter` splits its bits between a data region and a collision
+    region. Passing a collision count at or above the filter's size underflowed the
+    `uint` subtraction `m - r`, so `new DeletableBloomFilter(0, 10, 0.01)` silently
+    allocated roughly **512 MB** and reported a capacity above four billion.
+
+  Valid arguments are unaffected. `HyperLogLog` and `TopK` already validated theirs;
+  this brings the rest of the library in line.
+
 ## [3.0.1] - 2026-08-13
 
 ### Fixed
@@ -251,6 +279,7 @@ This release modernizes the entire build. The library had not been touched since
 - Initial release: a C# port of [Tyler Treat's](https://github.com/tylertreat)
   [BoomFilters](https://github.com/tylertreat/BoomFilters) Go project.
 
+[3.1.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v3.0.1...HEAD
 [3.0.1]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v2.0.1...v3.0.0
 [2.0.1]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v2.0.0...v2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0] - Unreleased
+## [3.1.0] - 2026-08-14
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is inherent -- a filter cannot tell such a removal from a real one -- and is now
   documented rather than fixed.
 
+- **`InverseBloomFilter` no longer reports data it never saw.** This is the only filter
+  here that stores the data rather than only hashing it, and `Test` answers by comparing
+  the stored bytes against the query. It kept the caller's array instead of copying,
+  so the caller's next write into that buffer changed what the filter held.
+
+  Reusing a single buffer per record -- ordinary, and the reason callers work in bytes
+  at all -- left every written slot pointing at the same array, so a value never added
+  could be read straight back out of a slot it was never put in. **38.8% of never-added
+  values were reported present**, against a structure whose defining property is that it
+  never reports a false positive at all. `Add` and `TestAndAdd` now copy. `Test` is
+  unchanged and still does not allocate.
+
+- **`new InverseBloomFilter(0)`** throws `ArgumentOutOfRangeException` rather than
+  `DivideByZeroException` on first use.
+
+- **Corrected the claim that the inverse filter is thread-safe.** The README said it
+  "uses a CAS-style approach, which makes it thread-safe" while its own thread-safety
+  section said no filter in the library is. The second is right: Jeff Hodges' original
+  swaps the stored value atomically, and this reads and writes the slot in two steps.
+  The README also credited the implementation with FNV-1 hashing, which it has never
+  used, and explained the absence of thread safety by a `HashAlgorithm` instance the
+  filters stopped holding in 3.0.0. Concurrent `Test` calls are in fact safe against
+  each other under the default hashing, which is now what the README says.
+
 - **`ScalableBloomFilter` validates its tightening ratio.** The ratio scales each new
   filter's false positive rate down from the last, and the structure's guarantee -- a
   compound rate bounded by `P0 / (1 - r)` -- is a geometric series that only converges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is inherent -- a filter cannot tell such a removal from a real one -- and is now
   documented rather than fixed.
 
+- **`TopK` returns the top k.** Its min-heap was not one. `Pop` removed the root with
+  `List.Remove`, which slides every later element down a position instead of restoring
+  the ordering, and an element already in the heap had its frequency raised in place
+  with no re-ordering at all. The root therefore stopped being the minimum -- and the
+  root is both what an arriving element is compared against and what gets evicted, so
+  the structure discarded frequent elements and kept rare ones. `Down`, the sift that
+  both paths needed, was present and never called.
+
+  Given a stream with distinct frequencies and a sketch wide enough to count it
+  exactly, so that the right answer is unambiguous, **89 of 150 configurations returned
+  the wrong set**. All 150 are now correct. Reported frequencies were also stale, since
+  an element's count was only refreshed on the path the broken ordering skipped.
+
+- **`TopK` copies the data it stores.** It handed the caller's arrays back through
+  `Elements()` without copying, so a caller reusing one buffer to add from found every
+  entry holding their last write.
+
+- **`new TopK(epsilon, delta, 0)`** throws `ArgumentOutOfRangeException` rather than
+  indexing its empty heap on the first `Add`.
+
 - **`InverseBloomFilter` no longer reports data it never saw.** This is the only filter
   here that stores the data rather than only hashing it, and `Test` answers by comparing
   the stored bytes against the query. It kept the caller's array instead of copying,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          lived nowhere in the repo: AppVeyor patched AssemblyInfo.cs at build time from
          its own build counter, which is how the published package version (1.0.1) and
          the GitHub release tags (v1.0.9) drifted apart. -->
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/ProbabilisticDataStructures/BloomFilter.cs
+++ b/ProbabilisticDataStructures/BloomFilter.cs
@@ -187,6 +187,7 @@ namespace ProbabilisticDataStructures
         public BloomFilter Reset()
         {
             this.Buckets.Reset();
+            this.count = 0;
             return this;
         }
 

--- a/ProbabilisticDataStructures/BloomFilter.cs
+++ b/ProbabilisticDataStructures/BloomFilter.cs
@@ -38,6 +38,9 @@ namespace ProbabilisticDataStructures
         /// <param name="fpRate">Desired false positive rate.</param>
         public BloomFilter(uint n, double fpRate)
         {
+            Guard.ValidItemCount(n, nameof(n));
+            Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+
             var m = Utils.OptimalM(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             Buckets = new Buckets(m, 1);

--- a/ProbabilisticDataStructures/BloomFilter64.cs
+++ b/ProbabilisticDataStructures/BloomFilter64.cs
@@ -192,6 +192,7 @@ namespace ProbabilisticDataStructures
         public BloomFilter64 Reset()
         {
             this.Buckets.Reset();
+            this.count = 0;
             return this;
         }
 

--- a/ProbabilisticDataStructures/BloomFilter64.cs
+++ b/ProbabilisticDataStructures/BloomFilter64.cs
@@ -43,6 +43,9 @@ namespace ProbabilisticDataStructures
         /// <param name="fpRate">Desired false positive rate.</param>
         public BloomFilter64(ulong n, double fpRate)
         {
+            Guard.ValidItemCount(n, nameof(n));
+            Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+
             var m = Utils.OptimalM64(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             Buckets = new Buckets64(m, 1);

--- a/ProbabilisticDataStructures/Buckets.cs
+++ b/ProbabilisticDataStructures/Buckets.cs
@@ -56,6 +56,14 @@ namespace ProbabilisticDataStructures
         /// <param name="bucketSize">Number of bits per bucket.</param>
         internal Buckets(uint count, byte bucketSize)
         {
+            if (bucketSize == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bucketSize), bucketSize,
+                    "Bucket size must be at least 1 bit. A zero-bit bucket holds no " +
+                    "value and allocates no storage, so reading one indexes an empty " +
+                    "array.");
+            }
+
             if (bucketSize > MaxBucketSizeBits)
             {
                 throw new ArgumentOutOfRangeException(nameof(bucketSize), bucketSize,

--- a/ProbabilisticDataStructures/Buckets64.cs
+++ b/ProbabilisticDataStructures/Buckets64.cs
@@ -64,6 +64,14 @@ namespace ProbabilisticDataStructures
         /// <param name="bucketSize">Number of bits per bucket.</param>
         internal Buckets64(ulong count, byte bucketSize)
         {
+            if (bucketSize == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bucketSize), bucketSize,
+                    "Bucket size must be at least 1 bit. A zero-bit bucket holds no " +
+                    "value and allocates no storage, so reading one indexes an empty " +
+                    "array.");
+            }
+
             if (bucketSize > MaxBucketSizeBits)
             {
                 throw new ArgumentOutOfRangeException(nameof(bucketSize), bucketSize,

--- a/ProbabilisticDataStructures/CountMinSketch.cs
+++ b/ProbabilisticDataStructures/CountMinSketch.cs
@@ -64,6 +64,9 @@ namespace ProbabilisticDataStructures
         /// <param name="delta">Relative-accuracy probability</param>
         public CountMinSketch(double epsilon, double delta)
         {
+            Guard.ValidSketchEpsilon(epsilon, nameof(epsilon));
+            Guard.ValidSketchDelta(delta, nameof(delta));
+
             var width = (uint)(Math.Ceiling(Math.E / epsilon));
             var depth = (uint)(Math.Ceiling(Math.Log(1 / delta)));
             this.Matrix = new UInt64[depth][];
@@ -138,6 +141,8 @@ namespace ProbabilisticDataStructures
         /// <returns>The data to count.</returns>
         public UInt64 Count(byte[] data)
         {
+            ArgumentNullException.ThrowIfNull(data);
+
             var hashKernel = Utils.HashKernel(data, this.Hash);
             var lower = hashKernel.LowerBaseHash;
             var upper = hashKernel.UpperBaseHash;
@@ -160,14 +165,25 @@ namespace ProbabilisticDataStructures
         /// <returns>True if successful.</returns>
         public bool Merge(CountMinSketch other)
         {
+            ArgumentNullException.ThrowIfNull(other);
+
+            // ArgumentException rather than Exception: a caller who wants to fall back
+            // to merging some other way cannot catch the bare one without catching
+            // every unrelated failure alongside it.
             if (this.Depth != other.Depth)
             {
-                throw new Exception("Matrix depth must match.");
+                throw new ArgumentException(
+                    $"Matrix depth must match. This sketch is {this.Depth} rows deep " +
+                    $"and the other is {other.Depth}; depth follows from delta, so the " +
+                    "two sketches were built with different ones.", nameof(other));
             }
 
             if (this.Width != other.Width)
             {
-                throw new Exception("Matrix width must match.");
+                throw new ArgumentException(
+                    $"Matrix width must match. This sketch is {this.Width} columns wide " +
+                    $"and the other is {other.Width}; width follows from epsilon, so the " +
+                    "two sketches were built with different ones.", nameof(other));
             }
 
             for (uint i = 0; i < this.Depth; i++)

--- a/ProbabilisticDataStructures/CountingBloomFilter.cs
+++ b/ProbabilisticDataStructures/CountingBloomFilter.cs
@@ -17,6 +17,17 @@ namespace ProbabilisticDataStructures
     /// allow elements to be removed, they introduce a non-zero probability of false
     /// negatives in addition to the possibility of false positives.
     ///
+    /// That probability has one source, and it is unavoidable: removing an element
+    /// that was never added. A filter cannot tell such a removal from a real one, so
+    /// it decrements counters that other elements still depend on. Only remove what
+    /// was added.
+    ///
+    /// Counters that reach their maximum are a separate matter. Such a counter has
+    /// stopped tracking how many elements it stands for, so it is never decremented
+    /// again and the elements covering it become permanently unremovable. This costs
+    /// space rather than correctness, and is the reason removals and additions do not
+    /// balance. Wider buckets saturate later.
+    ///
     /// Counting Bloom Filters are useful for cases where elements are both added
     /// and removed from the data set. Since they use n-bit buckets, CBFs use
     /// roughly n-times more memory than traditional Bloom filters.
@@ -219,9 +230,22 @@ namespace ProbabilisticDataStructures
 
             if (member)
             {
+                // A counter that reached its maximum stopped counting, so it no longer
+                // knows how many elements it stands for. Decrementing it would assume
+                // it does, and the count it resumes from is too low by however many
+                // increments were dropped -- enough of those and the counter reaches
+                // zero while elements that need it are still present. Deleting without
+                // introducing false negatives is the whole of what a counting filter
+                // adds to a plain one, so a saturated counter is left alone instead.
+                // The cost is that its space is never reclaimed, which is the lesser
+                // of the two: the filter stays correct and merely gets fuller.
+                var max = this.Buckets.MaxBucketValue();
                 foreach (var idx in this.indexBuffer)
                 {
-                    this.Buckets.Increment(idx, -1);
+                    if (this.Buckets.Get(idx) < max)
+                    {
+                        this.Buckets.Increment(idx, -1);
+                    }
                 }
                 this.count--;
             }

--- a/ProbabilisticDataStructures/CountingBloomFilter.cs
+++ b/ProbabilisticDataStructures/CountingBloomFilter.cs
@@ -59,6 +59,9 @@ namespace ProbabilisticDataStructures
         /// <param name="fpRate">Desired false positive rate.</param>
         public CountingBloomFilter(uint n, byte b, double fpRate)
         {
+            Guard.ValidItemCount(n, nameof(n));
+            Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+
             var m = Utils.OptimalM(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             this.Buckets =  new Buckets(m, b);

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -70,6 +70,9 @@ namespace ProbabilisticDataStructures
         /// <param name="fpRate">Target false-positive rate</param>
         public CuckooBloomFilter(uint n, double fpRate)
         {
+            Guard.ValidItemCount(n, nameof(n));
+            Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+
             var b = (uint)4;
             var f = CalculateF(b, fpRate);
             var m = Power2(n / f * 8);

--- a/ProbabilisticDataStructures/DeletableBloomFilter.cs
+++ b/ProbabilisticDataStructures/DeletableBloomFilter.cs
@@ -65,8 +65,16 @@ namespace ProbabilisticDataStructures
         /// <param name="fpRate">Desired false positive rate</param>
         public DeletableBloomFilter(uint n, uint r, double fpRate)
         {
+            Guard.ValidItemCount(n, nameof(n));
+            Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+
             var m = Utils.OptimalM(n, fpRate);
             var k = Utils.OptimalK(fpRate);
+
+            // r shares the filter's bits with the data region, so it has to leave
+            // room; a larger value underflows m - r and allocates enormously.
+            Guard.ValidCollisionRegionCount(r, m, nameof(r));
+
 
             this.Buckets = new Buckets(m - r, 1);
             this.Collisions = new Buckets(r, 1);

--- a/ProbabilisticDataStructures/DeletableBloomFilter.cs
+++ b/ProbabilisticDataStructures/DeletableBloomFilter.cs
@@ -80,7 +80,18 @@ namespace ProbabilisticDataStructures
             this.Collisions = new Buckets(r, 1);
             this.Hash = Defaults.GetDefaultHashFunction();
             this.M = m - r;
-            this.RegionSize = (m - r) / r;
+            // Rounded up, not down. The data region rarely divides evenly into r
+            // regions, and rounding down leaves a remainder that maps to region
+            // index r -- one past the last collision bucket. Rounding up keeps
+            // every index inside the array: for RegionSize >= M/r, the largest
+            // index (M - 1) / RegionSize is at most r(M - 1)/M, which is below r.
+            // The final region is correspondingly shorter, which is the intent:
+            // regions partition the data bits, so the last one holds what is left.
+            //
+            // Rounding up also keeps RegionSize non-zero. r is only required to be
+            // smaller than m, so it may exceed the data region m - r, and dividing
+            // down would then floor to zero and fault on the first Add.
+            this.RegionSize = (this.M + r - 1) / r;
             this.k = k;
             this.IndexBuffer = new uint[k];
         }

--- a/ProbabilisticDataStructures/ElementHeap.cs
+++ b/ProbabilisticDataStructures/ElementHeap.cs
@@ -69,9 +69,23 @@ namespace ProbabilisticDataStructures
         /// <returns>The Element that was removed</returns>
         internal Element Pop()
         {
-            var elementToRemove = this.Heap[0];
-            this.Heap.Remove(elementToRemove);
-            return elementToRemove;
+            // Removing the root by List.Remove shifts every later element down one
+            // position, which is not a heap operation: the array that comes back is
+            // the old one slid left, and its parent/child relationships are whatever
+            // that shift happened to produce. The heap has no minimum at the root
+            // afterwards, so the next Pop evicts an arbitrary element.
+            //
+            // Extraction is instead the standard three steps -- take the root, move
+            // the last element into its place, and sift that element down until the
+            // ordering holds again. Down existed for this and was never called.
+            var min = this.Heap[0];
+            var last = this.Len() - 1;
+
+            this.Swap(0, last);
+            this.Heap.RemoveAt(last);
+            this.Down(0, this.Len());
+
+            return min;
         }
 
         internal void Up(int j)
@@ -144,8 +158,15 @@ namespace ProbabilisticDataStructures
                 var element = this.Heap[i];
                 if (Enumerable.SequenceEqual(data, element.Data))
                 {
-                    // Element already in top-k.
+                    // Element already in top-k. Raising its frequency in place leaves
+                    // it possibly greater than a child's, so the ordering has to be
+                    // restored or the root stops being the minimum -- and the root is
+                    // what isTop compares against and what Pop evicts.
+                    //
+                    // Sifting down is enough: a frequency read from the sketch only
+                    // ever grows, so an updated element can only sink.
                     element.Freq = freq;
+                    this.Down(i, this.Len());
                     return;
                 }
             }
@@ -156,10 +177,12 @@ namespace ProbabilisticDataStructures
                 this.Pop();
             }
 
-            // Add element to top-k.
+            // Add element to top-k. The data is copied rather than retained: it is
+            // handed back to callers through Elements(), and a caller reusing the
+            // buffer they added from would otherwise rewrite every entry in the heap.
             this.Push(new Element
             {
-                Data = data,
+                Data = (byte[])data.Clone(),
                 Freq = freq,
             });
         }

--- a/ProbabilisticDataStructures/Guard.cs
+++ b/ProbabilisticDataStructures/Guard.cs
@@ -52,6 +52,29 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// A scalable filter tightens each new filter's false positive rate by this
+        /// ratio, so it has to be a proper fraction.
+        /// </summary>
+        /// <remarks>
+        /// The structure's guarantee is a compound false positive rate bounded by
+        /// P0 / (1 - r), which is the sum of a geometric series and only converges for
+        /// a ratio below one. At exactly one the rate never tightens and the compound
+        /// rate grows without bound with every filter added; above one each filter is
+        /// looser than the last. Either way the filter still works and simply stops
+        /// honoring the rate that was asked for, which is worse than refusing.
+        /// </remarks>
+        internal static void ValidTighteningRatio(double r, string paramName)
+        {
+            if (double.IsNaN(r) || r <= 0.0 || r >= 1.0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, r,
+                    "The tightening ratio must be greater than 0 and less than 1. Each " +
+                    "new filter's false positive rate is the previous one's scaled by " +
+                    "this ratio, and the compound rate is only bounded when it shrinks.");
+            }
+        }
+
+        /// <summary>
         /// The deletable filter partitions its bits into data and collision regions,
         /// so the collision count has to leave room for the data.
         /// </summary>

--- a/ProbabilisticDataStructures/Guard.cs
+++ b/ProbabilisticDataStructures/Guard.cs
@@ -52,6 +52,52 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// A count-min sketch's epsilon fixes the width of its matrix, as e / epsilon,
+        /// so it has to be positive and not so small that the width is unbuildable.
+        /// </summary>
+        internal static void ValidSketchEpsilon(double epsilon, string paramName)
+        {
+            if (double.IsNaN(epsilon) || epsilon <= 0.0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, epsilon,
+                    "Epsilon must be greater than 0. It bounds the sketch's " +
+                    "overestimate as a fraction of the total count, and a bound of " +
+                    "zero or less asks for a matrix of infinite width.");
+            }
+
+            var width = Math.Ceiling(Math.E / epsilon);
+            if (width > uint.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(paramName, epsilon,
+                    $"Epsilon of {epsilon} needs a matrix {width} columns wide, which " +
+                    $"exceeds the {uint.MaxValue} addressable. Use a larger epsilon.");
+            }
+        }
+
+        /// <summary>
+        /// A count-min sketch's delta is the probability that its estimate exceeds the
+        /// error epsilon allows, so it is a probability of failure and not of success.
+        /// </summary>
+        /// <remarks>
+        /// The matrix depth is ln(1 / delta), which is only positive below one. At one
+        /// and above it is zero or negative and the matrix has no rows at all, and a
+        /// sketch with no rows does not fail loudly: Count takes a minimum over an
+        /// empty set of rows and returns the initial value, so every element is
+        /// reported as having been seen ulong.MaxValue times.
+        /// </remarks>
+        internal static void ValidSketchDelta(double delta, string paramName)
+        {
+            if (double.IsNaN(delta) || delta <= 0.0 || delta >= 1.0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, delta,
+                    "Delta must be greater than 0 and less than 1. It is the " +
+                    "probability that an estimate exceeds the error epsilon allows, " +
+                    "so it is a probability of failure: a smaller delta is a deeper, " +
+                    "more reliable sketch.");
+            }
+        }
+
+        /// <summary>
         /// A scalable filter tightens each new filter's false positive rate by this
         /// ratio, so it has to be a proper fraction.
         /// </summary>

--- a/ProbabilisticDataStructures/Guard.cs
+++ b/ProbabilisticDataStructures/Guard.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace ProbabilisticDataStructures
+{
+    /// <summary>
+    /// Argument checks shared by the filter constructors.
+    /// <para>
+    /// Without these, invalid arguments did not fail where they were passed. A false
+    /// positive rate of zero surfaced as an OverflowException from a numeric
+    /// conversion deep in the sizing math; a capacity of zero produced a filter that
+    /// constructed successfully and then threw DivideByZeroException on first use;
+    /// and a collision-bit count larger than the filter underflowed a uint, quietly
+    /// allocating hundreds of megabytes. Each of those reported something true about
+    /// the machinery and nothing about the mistake.
+    /// </para>
+    /// </summary>
+    internal static class Guard
+    {
+        /// <summary>
+        /// A false positive rate has to sit strictly between zero and one.
+        /// </summary>
+        /// <remarks>
+        /// Zero is unachievable and makes the optimal size infinite. One asks for a
+        /// filter with no discriminating power: the sizing math yields zero bits and
+        /// zero hash functions, so the filter stores nothing and reports every
+        /// element as present. Both ends are rejected rather than accepted and left
+        /// to behave strangely later.
+        /// </remarks>
+        internal static void ValidFalsePositiveRate(double fpRate, string paramName)
+        {
+            if (double.IsNaN(fpRate) || fpRate <= 0.0 || fpRate >= 1.0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, fpRate,
+                    "False positive rate must be greater than 0 and less than 1. " +
+                    "A rate of 0 cannot be achieved, and a rate of 1 describes a filter " +
+                    "that reports every element as present.");
+            }
+        }
+
+        /// <summary>
+        /// A filter has to be sized for at least one item; sizing for none yields a
+        /// filter of zero bits, which divides by zero the first time it is used.
+        /// </summary>
+        internal static void ValidItemCount(ulong n, string paramName)
+        {
+            if (n == 0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, n,
+                    "A filter must be sized for at least one item. Sizing for zero " +
+                    "produces a filter with no buckets, which fails on first use.");
+            }
+        }
+
+        /// <summary>
+        /// The deletable filter partitions its bits into data and collision regions,
+        /// so the collision count has to leave room for the data.
+        /// </summary>
+        internal static void ValidCollisionRegionCount(uint r, uint m, string paramName)
+        {
+            if (r == 0 || r >= m)
+            {
+                throw new ArgumentOutOfRangeException(paramName, r,
+                    $"The number of collision-information bits must be greater than 0 and " +
+                    $"less than the filter's {m} bits, since the two share the same space. " +
+                    "A larger value underflows the data region.");
+            }
+        }
+    }
+}

--- a/ProbabilisticDataStructures/HyperLogLog.cs
+++ b/ProbabilisticDataStructures/HyperLogLog.cs
@@ -16,6 +16,7 @@ included in all copies or substantial portions of the Software.
 */
 
 using System;
+using System.Numerics;
 using System.Linq;
 using System.Security.Cryptography;
 
@@ -74,6 +75,11 @@ namespace ProbabilisticDataStructures
         /// <param name="m">Number of registers (must be a power of two)</param>
         public HyperLogLog(uint m)
         {
+            // Zero passes the power-of-two test below, because 0 - 1 underflows to
+            // all ones and 0 & anything is 0. It would build an estimator with no
+            // registers, which then indexes an empty array.
+            Guard.ValidItemCount(m, nameof(m));
+
             if ((m & (m - 1)) != 0)
             {
                 throw new ArgumentException(String.Format("{0} is not a power of two", m));
@@ -81,7 +87,12 @@ namespace ProbabilisticDataStructures
 
             this.Registers = new byte[m];
             this.M = m;
-            this.B = (uint)Math.Ceiling(Math.Log(m, 2));
+
+            // Exact by construction. Computing this as Ceiling(Log(m, 2)) is not:
+            // for m = 2^29 the floating-point logarithm lands just above 29, so the
+            // ceiling returns 30. That leaves k = 32 - b too small, and the register
+            // index derived from it can exceed the register array.
+            this.B = (uint)BitOperations.Log2(m);
             this.Alpha = CalculateAlpha(m);
             this.Hash = Defaults.GetDefaultHashFunction();
         }

--- a/ProbabilisticDataStructures/InverseBloomFilter.cs
+++ b/ProbabilisticDataStructures/InverseBloomFilter.cs
@@ -37,9 +37,9 @@ using System.Security.Cryptography;
 namespace ProbabilisticDataStructures
 {
     /// <summary>
-    /// InverseBloomFilter is a concurrent "inverse" Bloom filter, which is
-    /// effectively the opposite of a classic Bloom filter. This was originally
-    /// described and written by Jeff Hodges:
+    /// InverseBloomFilter is an "inverse" Bloom filter, which is effectively the
+    /// opposite of a classic Bloom filter. This was originally described and
+    /// written by Jeff Hodges:
     ///
     /// http://www.somethingsimilar.com/2012/05/21/the-opposite-of-a-bloom-filter/
     ///
@@ -51,6 +51,11 @@ namespace ProbabilisticDataStructures
     ///
     /// An example use case is deduplicating events while processing a stream of
     /// data. Ideally, duplicate events are relatively close together.
+    ///
+    /// This filter stores the data itself rather than only its hash, and takes its
+    /// own copy on <see cref="Add"/> so that a caller reusing their buffer cannot
+    /// change what it holds. It is not thread-safe: the original swaps the stored
+    /// value atomically, and this reads and writes the slot in two steps.
     /// </summary>
     public class InverseBloomFilter : IFilter
     {
@@ -64,6 +69,8 @@ namespace ProbabilisticDataStructures
         /// <param name="capacity">The capacity of the filter</param>
         public InverseBloomFilter(uint capacity)
         {
+            Guard.ValidItemCount(capacity, nameof(capacity));
+
             this.Array = new byte[capacity][];
             this.Hash = Defaults.GetDefaultHashFunction();
             this.capacity = capacity;
@@ -146,7 +153,22 @@ namespace ProbabilisticDataStructures
         private byte[] GetAndSet(uint index, byte[] data)
         {
             var oldData = this.Array[index];
-            this.Array[index] = data;
+
+            // Copied, not retained. This filter is the only one here that keeps the
+            // data rather than just hashing it, and Test answers by comparing the
+            // stored bytes against the query. Holding the caller's array would let
+            // their next write into it change what this filter believes it holds --
+            // and callers do reuse buffers, which is the whole reason they are fast.
+            //
+            // That is not a small error. A caller filling one buffer per record leaves
+            // every written slot pointing at the same array, so the filter answers
+            // every one of them with whatever that buffer holds now. Querying a value
+            // never added then reads it straight back out of a slot it was never put
+            // in, and the filter reports it present: measured at 38.8% against a
+            // structure whose defining property is that it never reports a false
+            // positive at all.
+            this.Array[index] = (byte[])data.Clone();
+
             return oldData;
         }
 

--- a/ProbabilisticDataStructures/MinHash.cs
+++ b/ProbabilisticDataStructures/MinHash.cs
@@ -1,138 +1,76 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ProbabilisticDataStructures
 {
     /// <summary>
-    /// MinHash is a variation of the technique for estimating similarity between
-    /// two sets as presented by Broder in On the resemblance and containment of
-    /// documents:
+    /// MinHash computes the similarity between two bags of words, as the resemblance
+    /// defined by Broder in On the resemblance and containment of documents:
     ///
     /// http://gatekeeper.dec.com/ftp/pub/dec/SRC/publications/broder/positano-final-wpnums.pdf
     ///
-    /// This can be used to cluster or compare documents by splitting the corpus
-    /// into a bag of words. MinHash returns the approximated similarity ratio of
-    /// the two bags. The similarity is less accurate for very small bags of words.
+    /// The resemblance of two sets is their Jaccard index: the size of their
+    /// intersection over the size of their union. This can be used to cluster or
+    /// compare documents by splitting the corpus into a bag of words.
     /// </summary>
+    /// <remarks>
+    /// The result is exact, not estimated. Broder's estimator is worth its error when
+    /// a set is too large to hold or a signature has to be computed once and reused
+    /// across many comparisons; neither applies to an API that is handed both bags in
+    /// full and compares them once. Estimating here would cost accuracy and time and
+    /// buy nothing.
+    /// <para>
+    /// Prior versions did neither. They generated hash permutations and never used
+    /// them -- the loop over them ignored its own index -- and returned agreement over
+    /// element positions, which for bags without repeats is the Sorensen-Dice
+    /// coefficient rather than the resemblance. The two are related as D = 2J / (1 + J),
+    /// so results were consistently too high: sets of one third resemblance were
+    /// reported at one half.
+    /// </para>
+    /// </remarks>
     public static class MinHash
     {
-        private static Random random = new Random();
-
         /// <summary>
-        /// Returns the similarity between two bags.
+        /// Returns the resemblance of two bags: the number of distinct words in both,
+        /// over the number of distinct words in either. Repeated words count once.
         /// </summary>
-        /// <param name="bag1">The first bag</param>
-        /// <param name="bag2">The second bag</param>
-        /// <returns>The similarity between the bags</returns>
+        /// <param name="bag1">The first bag.</param>
+        /// <param name="bag2">The second bag.</param>
+        /// <returns>
+        /// The resemblance, from 0 for bags sharing no word to 1 for bags with the
+        /// same distinct words. Two empty bags resemble each other exactly and give 1.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Either bag, or any word in either bag, is null.
+        /// </exception>
         public static float Similarity(string[] bag1, string[] bag2)
         {
-            var k = bag1.Length + bag2.Length;
-            var hashes = new int[k];
-            for (int i = 0; i < k; i++)
+            ArgumentNullException.ThrowIfNull(bag1);
+            ArgumentNullException.ThrowIfNull(bag2);
+
+            var first = new HashSet<string>(bag1, StringComparer.Ordinal);
+            var second = new HashSet<string>(bag2, StringComparer.Ordinal);
+
+            // Both empty is 0 / 0. Defined as 1 rather than left as NaN, which is what
+            // it used to produce: two bags with the same distinct words -- none --
+            // resemble each other exactly, and every other equal pair returns 1.
+            if (first.Count == 0 && second.Count == 0)
             {
-                var a = random.Next();
-                var b = random.Next();
-                var c = random.Next();
-                var x = computeHash((uint)(a * b * c), (uint)a, (uint)b, c);
-                hashes[i] = (int)x;
+                return 1f;
             }
 
-            var bMap = bitMap(bag1, bag2);
-            var minHashValues = hashBuckets(2, k);
-            minHash(bag1, 0, minHashValues, bMap, k, hashes);
-            minHash(bag2, 1, minHashValues, bMap, k, hashes);
-            return similarity(minHashValues, k);
-        }
-
-        private static void minHash(
-            string[] bag,
-            int bagIndex,
-            int[][] minHashValues,
-            Dictionary<string, bool[]> bitArray,
-            int k,
-            int[] hashes)
-        {
-            var options = new ParallelOptions();
-            options.MaxDegreeOfParallelism = 4;
-            var index = 0;
-
-            foreach (var element in bitArray)
+            var intersection = 0;
+            foreach (var word in first)
             {
-                Parallel.For(0, k, options, (i, loopState) =>
+                if (second.Contains(word))
                 {
-                    if (bag.Contains(element.Key))
-                    {
-                        var hindex = hashes[index];
-                        if (hindex < minHashValues[bagIndex][index])
-                        {
-                            minHashValues[bagIndex][index] = hindex;
-                        }
-                    }
-                });
-                index++;
-            }
-        }
-
-        private static Dictionary<string, bool[]> bitMap(string[] bag1, string[] bag2)
-        {
-            var bitArray = new Dictionary<string, bool[]>();
-            foreach (var element in bag1)
-            {
-                bitArray[element] = new bool[] { true, false };
-            }
-
-            foreach (var element in bag2)
-            {
-                if (bitArray.ContainsKey(element))
-                {
-                    bitArray[element] = new bool[] { true, true };
-                }
-                else
-                {
-                    bitArray[element] = new bool[] { false, true };
+                    intersection++;
                 }
             }
 
-            return bitArray;
-        }
-
-        private static int[][] hashBuckets(int numSets, int k)
-        {
-            var minHashValues = new int[numSets][];
-            for (int i = 0; i < numSets; i++)
-            {
-                minHashValues[i] = new int[k];
-            }
-
-            for (int i = 0; i < numSets; i++)
-            {
-                for (int j = 0; j < k; j++)
-                {
-                    minHashValues[i][j] = int.MaxValue;
-                }
-            }
-            return minHashValues;
-        }
-
-        private static uint computeHash(uint x, uint a, uint b, int u)
-        {
-            return (a * x + b) >> (32 - u);
-        }
-
-        private static float similarity(int[][] minHashValues, int k)
-        {
-            var identicalMinHashes = 0;
-            for (int i = 0; i < k; i++)
-            {
-                if (minHashValues[0][i] == minHashValues[1][i])
-                {
-                    identicalMinHashes++;
-                }
-            }
-
-            return (float)(1.0 * (float)identicalMinHashes) / (float)k;
+            // Inclusion-exclusion, so the union is never materialized.
+            var union = first.Count + second.Count - intersection;
+            return (float)intersection / union;
         }
     }
 }

--- a/ProbabilisticDataStructures/PartitionedBloomFilter.cs
+++ b/ProbabilisticDataStructures/PartitionedBloomFilter.cs
@@ -237,6 +237,8 @@ namespace ProbabilisticDataStructures
             {
                 partition.Reset();
             }
+
+            this.count = 0;
             return this;
         }
 

--- a/ProbabilisticDataStructures/PartitionedBloomFilter.cs
+++ b/ProbabilisticDataStructures/PartitionedBloomFilter.cs
@@ -66,6 +66,9 @@ namespace ProbabilisticDataStructures
         /// <param name="fpRate">Desired false-positive rate</param>
         public PartitionedBloomFilter(uint n, double fpRate)
         {
+            Guard.ValidItemCount(n, nameof(n));
+            Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+
             var m = Utils.OptimalM(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             var partitions = new Buckets[k];

--- a/ProbabilisticDataStructures/ScalableBloomFilter.cs
+++ b/ProbabilisticDataStructures/ScalableBloomFilter.cs
@@ -72,6 +72,9 @@ namespace ProbabilisticDataStructures
         /// <param name="r"></param>
         public ScalableBloomFilter(uint hint, double fpRate, double r)
         {
+            Guard.ValidItemCount(hint, nameof(hint));
+            Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+
             this.Filters = new List<PartitionedBloomFilter>();
             this.R = r;
             this.FP = fpRate;

--- a/ProbabilisticDataStructures/ScalableBloomFilter.cs
+++ b/ProbabilisticDataStructures/ScalableBloomFilter.cs
@@ -74,6 +74,7 @@ namespace ProbabilisticDataStructures
         {
             Guard.ValidItemCount(hint, nameof(hint));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+            Guard.ValidTighteningRatio(r, nameof(r));
 
             this.Filters = new List<PartitionedBloomFilter>();
             this.R = r;
@@ -213,8 +214,15 @@ namespace ProbabilisticDataStructures
         /// <returns>The reset bloom filter.</returns>
         public ScalableBloomFilter Reset()
         {
+            // Reset empties the filter; it does not reconfigure it. Every filter added
+            // after the first takes its hash from Filters[0], so dropping the list
+            // without carrying the hash across would quietly restore the default and
+            // leave a caller who set their own hashing elsewhere than they left it.
+            var hash = this.Filters[0].Hash;
+
             this.Filters = new List<PartitionedBloomFilter>();
             this.AddFilter();
+            this.Filters[0].SetHash(hash);
             return this;
         }
 

--- a/ProbabilisticDataStructures/StableBloomFilter.cs
+++ b/ProbabilisticDataStructures/StableBloomFilter.cs
@@ -78,6 +78,9 @@ namespace ProbabilisticDataStructures
         /// <param name="fpRate">Desired false-positive rate</param>
         public StableBloomFilter(uint m, byte d, double fpRate)
         {
+            Guard.ValidItemCount(m, nameof(m));
+            Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
+
             var k = Utils.OptimalK(fpRate) / 2;
             if (k > m)
             {

--- a/ProbabilisticDataStructures/TopK.cs
+++ b/ProbabilisticDataStructures/TopK.cs
@@ -23,6 +23,8 @@ namespace ProbabilisticDataStructures
         /// <returns></returns>
         public TopK(double epsilon, double delta, uint k)
         {
+            Guard.ValidItemCount(k, nameof(k));
+
             this.Cms = new CountMinSketch(epsilon, delta);
             this.K = k;
             this.elements = new ElementHeap((int)k);

--- a/README.md
+++ b/README.md
@@ -63,9 +63,8 @@ This is deliberate and matches the Go implementation this library is a port of. 
 locks would impose a cost on the single-threaded case, which is the common one, and the
 right granularity depends on the caller's access pattern rather than the filter's.
 
-`Test` is not safe to call concurrently with `Add` or `TestAndAdd`, and it is not safe
-to call `Test` concurrently with itself either: the filters hold a `HashAlgorithm`
-instance and reuse it across calls, and `HashAlgorithm` is itself not thread-safe.
+`Test` is not safe to call concurrently with `Add` or `TestAndAdd`: the filters mutate
+their bucket arrays in place, without synchronization.
 
 If you need concurrent access, synchronize externally:
 
@@ -82,9 +81,10 @@ public bool Contains(byte[] data)
 }
 ```
 
-A reader-writer lock will not help without further care, because concurrent `Test` calls
-still share the same `HashAlgorithm`. Give each thread its own filter, or hold an
-exclusive lock for every operation.
+Concurrent `Test` calls are safe against each other under the default hashing, which is
+a pure function over the input, so a reader-writer lock is enough if you supply no hash
+of your own. A hash function passed to `SetHash` is shared by every call, so one holding
+mutable state -- a reused `HashAlgorithm` instance, for example -- takes that away.
 
 ## Contributions
 Pull-requests are welcome, but submitting an issue is probably the best place to start if you have complex critiques or suggestions.
@@ -184,11 +184,13 @@ namespace FilterExample
 
 ## Inverse Bloom Filter
 
-An Inverse Bloom Filter, or "the opposite of a Bloom filter", is a concurrent, probabilistic data structure used to test whether an item has been observed or not. This implementation, [originally described and written by Jeff Hodges](http://www.somethingsimilar.com/2012/05/21/the-opposite-of-a-bloom-filter/), replaces the use of MD5 hashing with a non-cryptographic FNV-1 function.
+An Inverse Bloom Filter, or "the opposite of a Bloom filter", is a probabilistic data structure used to test whether an item has been observed or not. It was [originally described and written by Jeff Hodges](http://www.somethingsimilar.com/2012/05/21/the-opposite-of-a-bloom-filter/).
 
 The Inverse Bloom Filter may report a false negative but can never report a false positive. That is, it may report that an item has not been seen when it actually has, but it will never report an item as seen which it hasn't come across. This behaves in a similar manner to a fixed-size hashmap which does not handle conflicts.
 
-This structure is particularly well-suited to streams in which duplicates are relatively close together. It uses a CAS-style approach, which makes it thread-safe.
+This structure is particularly well-suited to streams in which duplicates are relatively close together.
+
+It is not thread-safe. Jeff Hodges' original swaps the stored value atomically; this implementation reads and writes the slot in two steps, so concurrent use can lose an entry or tear one. See [Thread safety](#thread-safety).
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -587,7 +587,19 @@ namespace FilterExample
 
 This is a variation of the technique for estimating similarity between two sets as presented by Broder in [On the resemblance and containment of documents](http://gatekeeper.dec.com/ftp/pub/dec/SRC/publications/broder/positano-final-wpnums.pdf).
 
-MinHash is a probabilistic algorithm which can be used to cluster or compare documents by splitting the corpus into a bag of words. MinHash returns the approximated similarity ratio of the two bags. The similarity is less accurate for very small bags of words.
+`Similarity` can be used to cluster or compare documents by splitting the corpus into a
+bag of words. It returns the resemblance of the two bags -- the number of distinct words
+in both over the number of distinct words in either, which is their Jaccard index.
+Repeated words count once, and two empty bags resemble each other exactly.
+
+The result is exact, not estimated. Broder's estimator earns its error when a set is too
+large to hold, or when a signature can be computed once and reused across many
+comparisons; neither applies to a call that is handed both bags in full and compares
+them once, where estimating would cost accuracy and time and buy nothing.
+
+Before 3.1.0 this returned the Sørensen–Dice coefficient instead, which is related as
+`D = 2J / (1 + J)` and so is consistently higher: bags of one third resemblance were
+reported at one half. See the [changelog](CHANGELOG.md) if you depended on those values.
 
 ### Usage
 
@@ -621,6 +633,7 @@ namespace FilterExample
                 "sara"
             };
 
+            // 5 words in both, 7 distinct across the two: 5 / 7 = 0.714...
             Console.WriteLine(string.Format("similarity: {0}", MinHash.Similarity(bag1.ToArray(), bag2.ToArray())));
         }
     }

--- a/TestProbabilisticDataStructures/TestErrorPaths.cs
+++ b/TestProbabilisticDataStructures/TestErrorPaths.cs
@@ -94,19 +94,68 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
-        /// Records that a zero false-positive rate is rejected, and how.
+        /// A false positive rate must sit strictly between zero and one. Previously
+        /// these surfaced as an OverflowException from a numeric conversion deep in
+        /// the sizing math, which reported something true about the machinery and
+        /// nothing about the mistake.
+        /// </summary>
+        [TestMethod]
+        public void TestFilterRejectsFalsePositiveRateOutsideZeroToOne()
+        {
+            foreach (var bad in new[] { 0.0, 1.0, -0.5, 2.0, double.NaN })
+            {
+                var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                    () => new BloomFilter(100, bad),
+                    $"a false positive rate of {bad} should be rejected");
+                Assert.AreEqual("fpRate", ex.ParamName);
+            }
+
+            // A rate inside the range is accepted.
+            _ = new BloomFilter(100, 0.5);
+        }
+
+        /// <summary>
+        /// Sizing a filter for zero items produced one with no buckets, which
+        /// constructed successfully and then threw DivideByZeroException on first
+        /// use -- a failure reported far from its cause.
+        /// </summary>
+        [TestMethod]
+        public void TestFilterRejectsZeroItemCount()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter(0, 0.01));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter64(0, 0.01));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PartitionedBloomFilter(0, 0.01));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CuckooBloomFilter(0, 0.01));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CountingBloomFilter(0, 4, 0.01));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new DeletableBloomFilter(0, 10, 0.01));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new StableBloomFilter(0, 1, 0.01));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ScalableBloomFilter(0, 0.01, 0.8));
+        }
+
+        /// <summary>
+        /// The deletable filter splits its bits between data and collision
+        /// information, so the collision count has to leave room for the data.
         /// <para>
-        /// OptimalM divides by the log of the rate, which overflows when converting
-        /// the resulting infinity to a uint. OverflowException is not a good way to
-        /// report an invalid argument -- ArgumentOutOfRangeException would say what
-        /// the caller did wrong -- but it is the current behavior, and pinning it
-        /// means a future change to argument validation is a deliberate one.
+        /// Without this check the subtraction m - r underflowed a uint: constructing
+        /// with more collision bits than the filter has silently allocated about
+        /// 512 MB and reported a capacity of over four billion.
         /// </para>
         /// </summary>
         [TestMethod]
-        public void TestBloomFilterRejectsZeroFalsePositiveRate()
+        public void TestDeletableFilterRejectsCollisionRegionLargerThanFilter()
         {
-            Assert.Throws<OverflowException>(() => new BloomFilter(100, 0.0));
+            var m = Utils.OptimalM(100, 0.01);
+
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => new DeletableBloomFilter(100, m + 1, 0.01));
+            Assert.AreEqual("r", ex.ParamName);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => new DeletableBloomFilter(100, m, 0.01));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new DeletableBloomFilter(100, 0, 0.01));
+
+            // A value leaving room for the data region is accepted.
+            var f = new DeletableBloomFilter(100, 10, 0.01);
+            Assert.IsLessThanOrEqualTo(m, f.Capacity());
         }
     }
 }

--- a/TestProbabilisticDataStructures/TestErrorPaths.cs
+++ b/TestProbabilisticDataStructures/TestErrorPaths.cs
@@ -130,6 +130,8 @@ namespace TestProbabilisticDataStructures
             Assert.Throws<ArgumentOutOfRangeException>(() => new DeletableBloomFilter(0, 10, 0.01));
             Assert.Throws<ArgumentOutOfRangeException>(() => new StableBloomFilter(0, 1, 0.01));
             Assert.Throws<ArgumentOutOfRangeException>(() => new ScalableBloomFilter(0, 0.01, 0.8));
+            // A capacity of zero left nowhere to put anything and divided by it.
+            Assert.Throws<ArgumentOutOfRangeException>(() => new InverseBloomFilter(0));
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestErrorPaths.cs
+++ b/TestProbabilisticDataStructures/TestErrorPaths.cs
@@ -132,6 +132,8 @@ namespace TestProbabilisticDataStructures
             Assert.Throws<ArgumentOutOfRangeException>(() => new ScalableBloomFilter(0, 0.01, 0.8));
             // A capacity of zero left nowhere to put anything and divided by it.
             Assert.Throws<ArgumentOutOfRangeException>(() => new InverseBloomFilter(0));
+            // A top-0 has no room for anything and indexed its empty heap.
+            Assert.Throws<ArgumentOutOfRangeException>(() => new TopK(0.001, 0.01, 0));
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestErrorPaths.cs
+++ b/TestProbabilisticDataStructures/TestErrorPaths.cs
@@ -73,7 +73,10 @@ namespace TestProbabilisticDataStructures
             var b = new CountMinSketch(0.001, 0.01);
             Assert.AreNotEqual(a.Depth, b.Depth, "test needs sketches of differing depth");
 
-            var ex = Assert.Throws<Exception>(() => a.Merge(b));
+            // ArgumentException, not the bare Exception this used to throw: a caller
+            // wanting to fall back to some other merge could not catch that one
+            // without catching every unrelated failure alongside it.
+            var ex = Assert.Throws<ArgumentException>(() => a.Merge(b));
             StringAssert.Contains(ex.Message, "depth must match");
         }
 
@@ -89,7 +92,7 @@ namespace TestProbabilisticDataStructures
             Assert.AreEqual(a.Depth, b.Depth, "test needs matching depth so width is checked");
             Assert.AreNotEqual(a.Width, b.Width, "test needs sketches of differing width");
 
-            var ex = Assert.Throws<Exception>(() => a.Merge(b));
+            var ex = Assert.Throws<ArgumentException>(() => a.Merge(b));
             StringAssert.Contains(ex.Message, "width must match");
         }
 
@@ -134,6 +137,25 @@ namespace TestProbabilisticDataStructures
             Assert.Throws<ArgumentOutOfRangeException>(() => new InverseBloomFilter(0));
             // A top-0 has no room for anything and indexed its empty heap.
             Assert.Throws<ArgumentOutOfRangeException>(() => new TopK(0.001, 0.01, 0));
+
+            // Epsilon fixes the sketch's width as e / epsilon. Zero and below asked
+            // for infinite width and surfaced as OverflowException or
+            // DivideByZeroException from the conversion.
+            foreach (var epsilon in new[] { 0.0, -0.1, double.NaN })
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => new CountMinSketch(epsilon, 0.01));
+            }
+
+            // Delta is a probability of failure, and the depth ln(1 / delta) is only
+            // positive below one. At one and above the matrix had no rows, which did
+            // not fail: Count minimises over no rows and returns its initial value, so
+            // every element was reported as seen ulong.MaxValue times.
+            foreach (var delta in new[] { 0.0, 1.0, 2.0, -0.5, double.NaN })
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => new CountMinSketch(0.001, delta));
+            }
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestFilterSemantics.cs
+++ b/TestProbabilisticDataStructures/TestFilterSemantics.cs
@@ -238,6 +238,101 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// A top-k structure has one job. Given a stream whose frequencies are all
+        /// distinct, and a sketch wide enough to count it without error, the answer is
+        /// not approximate and there is nothing to be lenient about.
+        /// <para>
+        /// It got this wrong across most configurations, because its min-heap was not
+        /// one. Pop removed the root with List.Remove, which slides every later element
+        /// down a position rather than restoring the ordering, and an element already
+        /// in the heap had its frequency raised in place with no re-ordering at all.
+        /// The root therefore stopped being the minimum, and the root is both what new
+        /// elements are compared against and what gets evicted. 89 of these 150
+        /// configurations returned the wrong set.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestTopKReturnsTheExactTopKWhenCountsAreExact()
+        {
+            const int distinct = 200;
+
+            foreach (uint k in new uint[] { 1, 2, 5, 10, 25, 50 })
+            {
+                for (int seed = 0; seed < 5; seed++)
+                {
+                    // Item i occurs (distinct - i + 5) times, so every frequency
+                    // differs and the correct answer is exactly items 0..k-1.
+                    var stream = new List<int>();
+                    for (int i = 0; i < distinct; i++)
+                    {
+                        for (int j = 0; j < distinct - i + 5; j++)
+                        {
+                            stream.Add(i);
+                        }
+                    }
+
+                    var rand = new Random(seed);
+                    for (int i = stream.Count - 1; i > 0; i--)
+                    {
+                        int j = rand.Next(i + 1);
+                        (stream[i], stream[j]) = (stream[j], stream[i]);
+                    }
+
+                    // Wide and deep enough that the sketch counts this stream exactly.
+                    var topK = new TopK(0.0001, 0.001, k);
+                    foreach (var x in stream)
+                    {
+                        topK.Add(Key($"i{x:D4}"));
+                    }
+
+                    var got = topK.Elements()
+                        .Select(e => Encoding.ASCII.GetString(e.Data))
+                        .ToHashSet();
+                    var want = Enumerable.Range(0, (int)k)
+                        .Select(i => $"i{i:D4}")
+                        .ToHashSet();
+
+                    Assert.IsTrue(got.SetEquals(want),
+                        $"k={k} seed={seed}: missing {string.Join(", ", want.Except(got))}, " +
+                        $"unexpected {string.Join(", ", got.Except(want))}");
+
+                    // And ordered from lowest to highest frequency, as documented.
+                    var freqs = topK.Elements().Select(e => e.Freq).ToArray();
+                    CollectionAssert.AreEqual(freqs.OrderBy(x => x).ToArray(), freqs,
+                        $"k={k} seed={seed}: Elements() must be ascending by frequency");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Elements() hands the stored arrays back to the caller, and the heap kept the
+        /// arrays it was given rather than copying them, so a caller reusing one buffer
+        /// to add from would find every entry holding their last write.
+        /// </summary>
+        [TestMethod]
+        public void TestTopKIsUnaffectedByMutatingAddedData()
+        {
+            var topK = new TopK(0.001, 0.01, 3);
+            var buffer = new byte[4];
+
+            foreach (var name in new[] { "aaaa", "bbbb", "cccc" })
+            {
+                Encoding.ASCII.GetBytes(name).CopyTo(buffer, 0);
+                topK.Add(buffer);
+            }
+
+            Encoding.ASCII.GetBytes("zzzz").CopyTo(buffer, 0);
+
+            var names = topK.Elements()
+                .Select(e => Encoding.ASCII.GetString(e.Data))
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToArray();
+
+            CollectionAssert.AreEqual(new[] { "aaaa", "bbbb", "cccc" }, names,
+                "the heap held the caller's buffer rather than a copy of it");
+        }
+
+        /// <summary>
         /// The inverse filter is a bounded "recently seen" cache rather than a growing
         /// set: an element whose slot is claimed by a later one is forgotten. False
         /// negatives are therefore expected here, which is the opposite of every other

--- a/TestProbabilisticDataStructures/TestFilterSemantics.cs
+++ b/TestProbabilisticDataStructures/TestFilterSemantics.cs
@@ -177,6 +177,67 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// The inverse filter's one hard guarantee is that it never reports an item it
+        /// has not seen. It is the only filter here that stores the data rather than
+        /// only hashing it, and it kept the caller's array instead of copying, so the
+        /// caller's next write into that buffer changed what the filter held.
+        /// <para>
+        /// Reusing one buffer per record is ordinary and is the reason callers work in
+        /// bytes at all. It left every written slot pointing at the same array, so a
+        /// value never added could be read straight back out of a slot it was never
+        /// put in: 38.8% of never-added values were reported present.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestInverseFilterNeverReportsUnseenData()
+        {
+            const uint capacity = 1000;
+            var f = new InverseBloomFilter(capacity);
+            var buffer = new byte[8];
+
+            for (int i = 0; i < 500; i++)
+            {
+                Encoding.ASCII.GetBytes($"rec-{i:D3}").CopyTo(buffer, 0);
+                f.Add(buffer);
+            }
+
+            var falsePositives = 0;
+            for (int i = 0; i < 10000; i++)
+            {
+                var unseen = Encoding.ASCII.GetBytes($"nev-{i:D4}");
+                // As a caller would on their next read, before querying.
+                unseen.CopyTo(buffer, 0);
+                if (f.Test(unseen))
+                {
+                    falsePositives++;
+                }
+            }
+
+            Assert.AreEqual(0, falsePositives,
+                $"{falsePositives} values that were never added were reported present; " +
+                "this filter must never report a false positive.");
+        }
+
+        /// <summary>
+        /// The same guarantee stated at its smallest: one element, mutated in place
+        /// after being added.
+        /// </summary>
+        [TestMethod]
+        public void TestInverseFilterIsUnaffectedByMutatingAddedData()
+        {
+            var f = new InverseBloomFilter(1000);
+            var data = new byte[] { 1, 2, 3 };
+
+            f.Add(data);
+            data[0] = 9;
+
+            Assert.IsTrue(f.Test(new byte[] { 1, 2, 3 }),
+                "what was added should still be found after the caller reuses its array");
+            Assert.IsFalse(f.Test(new byte[] { 9, 2, 3 }),
+                "what was never added should not be found");
+        }
+
+        /// <summary>
         /// The inverse filter is a bounded "recently seen" cache rather than a growing
         /// set: an element whose slot is claimed by a later one is forgotten. False
         /// negatives are therefore expected here, which is the opposite of every other

--- a/TestProbabilisticDataStructures/TestFilterSemantics.cs
+++ b/TestProbabilisticDataStructures/TestFilterSemantics.cs
@@ -333,6 +333,50 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Reset restores a filter to its original state, and a filter in its original
+        /// state holds nothing. Three of them emptied their buckets and left the item
+        /// count where it was, so a filter reporting itself empty by every other
+        /// measure still claimed the items it used to hold.
+        /// <para>
+        /// The count is not only reported. EstimatedFillRatio is derived from it, and
+        /// a partitioned filter's is what a scalable filter consults to decide when to
+        /// grow, so a stale count made a freshly emptied filter look 44% full.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestResetEmptiesTheItemCount()
+        {
+            const int added = 800;
+
+            var bloom = new BloomFilter(1000, 0.01);
+            var bloom64 = new BloomFilter64(1000, 0.01);
+            var partitioned = new PartitionedBloomFilter(1000, 0.01);
+            var counting = new CountingBloomFilter(1000, 4, 0.01);
+            var deletable = new DeletableBloomFilter(1000, 10, 0.01);
+
+            for (int i = 0; i < added; i++)
+            {
+                var key = Key($"item-{i}");
+                bloom.Add(key);
+                bloom64.Add(key);
+                partitioned.Add(key);
+                counting.Add(key);
+                deletable.Add(key);
+            }
+
+            Assert.AreEqual(0u, bloom.Reset().Count());
+            Assert.AreEqual(0ul, bloom64.Reset().Count());
+            Assert.AreEqual(0u, partitioned.Reset().Count());
+            Assert.AreEqual(0u, counting.Reset().Count());
+            Assert.AreEqual(0u, deletable.Reset().Count());
+
+            // The count feeds the fill estimate, which is what actually acts on it.
+            Assert.AreEqual(0.0, bloom.EstimatedFillRatio());
+            Assert.AreEqual(0.0, bloom64.EstimatedFillRatio());
+            Assert.AreEqual(0.0, partitioned.EstimatedFillRatio());
+        }
+
+        /// <summary>
         /// The inverse filter is a bounded "recently seen" cache rather than a growing
         /// set: an element whose slot is claimed by a later one is forgotten. False
         /// negatives are therefore expected here, which is the opposite of every other

--- a/TestProbabilisticDataStructures/TestFilterSemantics.cs
+++ b/TestProbabilisticDataStructures/TestFilterSemantics.cs
@@ -123,6 +123,60 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// A scalable filter's guarantee is a compound false positive rate bounded by
+        /// P0 / (1 - r). That is the sum of a geometric series, so it only converges
+        /// for a ratio strictly between zero and one.
+        /// <para>
+        /// A ratio of exactly 1 was accepted and never tightened anything: asking for
+        /// 1% and adding 20,000 items to a filter hinted at 100 measured **83%**. The
+        /// filter kept working and simply stopped honoring the rate requested of it,
+        /// which is worse than refusing the argument. Ratios outside the range in the
+        /// other direction did throw, but from inside Add and blaming fpRate -- a
+        /// parameter the caller had passed correctly.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestScalableFilterRejectsRatiosThatDoNotTighten()
+        {
+            foreach (var r in new[] { -0.5, 0.0, 1.0, 1.5, 2.0, double.NaN })
+            {
+                Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                    () => new ScalableBloomFilter(100, 0.01, r),
+                    $"a tightening ratio of {r} does not bound the compound rate");
+            }
+
+            // The open interval between them is what the structure is defined on.
+            foreach (var r in new[] { 0.001, 0.5, 0.8, 0.999 })
+            {
+                _ = new ScalableBloomFilter(100, 0.01, r);
+            }
+        }
+
+        /// <summary>
+        /// Reset empties a filter; it does not reconfigure it. The scalable filter
+        /// rebuilds its list from scratch, and did so without carrying the hash across,
+        /// so a caller who had set their own was quietly returned to the default.
+        /// </summary>
+        [TestMethod]
+        public void TestScalableFilterResetKeepsTheHashFunction()
+        {
+            var f = new ScalableBloomFilter(100, 0.01, 0.8);
+
+            // Degenerate on purpose: a constant hash puts every key in the same place,
+            // so any key reads as present. Nothing else produces that.
+            f.SetHash(_ => 12345UL);
+            f.Add(Key("a"));
+            Assert.IsTrue(f.Test(Key("unrelated")),
+                "sanity: with a constant hash every key collides");
+
+            f.Reset();
+            f.Add(Key("a"));
+
+            Assert.IsTrue(f.Test(Key("unrelated")),
+                "Reset restored the default hash and discarded the one that was set");
+        }
+
+        /// <summary>
         /// The inverse filter is a bounded "recently seen" cache rather than a growing
         /// set: an element whose slot is claimed by a later one is forgotten. False
         /// negatives are therefore expected here, which is the opposite of every other

--- a/TestProbabilisticDataStructures/TestFilterSemantics.cs
+++ b/TestProbabilisticDataStructures/TestFilterSemantics.cs
@@ -66,6 +66,63 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// The number of collision regions is a free parameter, so every value has to
+        /// work. It did not: the region size was rounded down, which sent the trailing
+        /// bits of the data region to region index r -- one past the last collision
+        /// bucket. Buckets does not bounds-check, so what happened next depended on
+        /// whether the bitmap had padding to absorb the write. A multiple of eight has
+        /// none, and Add threw; other values landed in padding and worked by accident.
+        /// </summary>
+        [TestMethod]
+        public void TestDeletableFilterAcceptsAnyRegionCount()
+        {
+            // Powers of two are the values a caller reaches for first, and are exactly
+            // the ones that used to throw.
+            uint[] regionCounts = { 1, 2, 3, 7, 8, 10, 16, 32, 64, 100, 128, 1000 };
+
+            foreach (var r in regionCounts)
+            {
+                const int count = 500;
+                var f = new DeletableBloomFilter(count, r, 0.01);
+
+                for (int i = 0; i < count; i++)
+                {
+                    f.Add(Key($"r{r}-item-{i}"));
+                }
+
+                for (int i = 0; i < count / 2; i++)
+                {
+                    f.TestAndRemove(Key($"r{r}-item-{i}"));
+                }
+
+                var missing = Enumerable.Range(count / 2, count / 2)
+                    .Count(i => !f.Test(Key($"r{r}-item-{i}")));
+
+                Assert.AreEqual(0, missing,
+                    $"r={r}: {missing} elements disappeared after removing unrelated ones.");
+            }
+        }
+
+        /// <summary>
+        /// r is only required to be smaller than the filter's m bits, so it is allowed
+        /// to exceed the m - r bits left for data. Rounding the region size down gave
+        /// zero in that case and the first Add divided by it.
+        /// </summary>
+        [TestMethod]
+        public void TestDeletableFilterHandlesMoreRegionsThanDataBits()
+        {
+            // 1000 items at a 1% rate sizes m at 9586 bits, so this leaves 11 for data
+            // and asks for more regions than there are bits to put in them.
+            var f = new DeletableBloomFilter(1000, 9575, 0.01);
+            Assert.IsGreaterThan(0u, f.Capacity(), "the data region should not be empty");
+
+            var a = Key("present");
+            f.Add(a);
+            Assert.IsTrue(f.Test(a), "an added element must be found");
+            Assert.IsTrue(f.TestAndRemove(a), "removing a present element reports present");
+        }
+
+        /// <summary>
         /// The inverse filter is a bounded "recently seen" cache rather than a growing
         /// set: an element whose slot is claimed by a later one is forgotten. False
         /// negatives are therefore expected here, which is the opposite of every other

--- a/TestProbabilisticDataStructures/TestHyperLogLogInternals.cs
+++ b/TestProbabilisticDataStructures/TestHyperLogLogInternals.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// The derivations HyperLogLog depends on, rather than its estimate.
+    /// </summary>
+    [TestClass]
+    public class TestHyperLogLogInternals
+    {
+        /// <summary>
+        /// b splits a 32-bit hash into a register index and the bits rho scans, so it
+        /// has to be exactly log2(m). Deriving it as Ceiling(Log(m, 2)) is not exact:
+        /// at m = 2^29 the floating-point logarithm lands just above 29 and the
+        /// ceiling returns 30, leaving k = 32 - b too small and letting the register
+        /// index run past the end of the register array.
+        /// <para>
+        /// Every power of two a caller can pass is checked, since the failure affects
+        /// exactly one of them and would be invisible in a spot check.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestRegisterIndexAlwaysFitsTheRegisterArray()
+        {
+            // 2^30 registers is already a gigabyte, so the loop verifies the
+            // arithmetic rather than allocating each size.
+            for (int exponent = 1; exponent <= 30; exponent++)
+            {
+                var m = (uint)Math.Pow(2, exponent);
+                var b = (uint)System.Numerics.BitOperations.Log2(m);
+
+                Assert.AreEqual((uint)exponent, b,
+                    $"b for m = 2^{exponent} must be exactly {exponent}");
+
+                // The index is the top b bits of a 32-bit hash, so its largest value
+                // must still be inside the register array.
+                var k = 32 - b;
+                var largestIndex = (ulong)uint.MaxValue >> (int)k;
+                Assert.IsLessThanOrEqualTo((ulong)m - 1, largestIndex,
+                    $"a register index derived with b = {b} would run past {m} registers");
+            }
+        }
+
+        /// <summary>
+        /// Zero registers passes a naive power-of-two test, because 0 - 1 underflows
+        /// to all ones. It is rejected before that check can admit it.
+        /// </summary>
+        [TestMethod]
+        public void TestZeroRegisterCountIsRejected()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new HyperLogLog(0));
+
+            // Still rejected for the original reason when it is not a power of two.
+            Assert.Throws<ArgumentException>(() => new HyperLogLog(3));
+
+            // And a valid size still constructs.
+            _ = new HyperLogLog(16);
+        }
+
+        /// <summary>
+        /// The estimator counts distinct elements, so repeating one must not move the
+        /// estimate.
+        /// </summary>
+        [TestMethod]
+        public void TestRepeatedElementsDoNotInflateTheEstimate()
+        {
+            var hll = HyperLogLog.NewDefaultHyperLogLog(0.01);
+            const int distinct = 1000;
+
+            for (int i = 0; i < distinct; i++)
+            {
+                for (int repeat = 0; repeat < 50; repeat++)
+                {
+                    hll.Add(Encoding.ASCII.GetBytes($"dup-{i}"));
+                }
+            }
+
+            var estimate = (double)hll.Count();
+            var error = Math.Abs(estimate - distinct) / distinct;
+
+            Assert.IsLessThanOrEqualTo(0.10, error,
+                $"estimate {estimate} for {distinct} distinct elements added 50 times each; " +
+                "repeats must not be counted.");
+        }
+
+        /// <summary>
+        /// The estimate should track the true cardinality within the error the chosen
+        /// accuracy implies. The bound is the standard error, not a hard ceiling, so
+        /// this allows generous headroom and exists to catch a broken estimator rather
+        /// than to police the constant.
+        /// </summary>
+        [TestMethod]
+        public void TestEstimateStaysWithinItsErrorBound()
+        {
+            const int distinct = 100000;
+
+            foreach (var target in new[] { 0.05, 0.01 })
+            {
+                var hll = HyperLogLog.NewDefaultHyperLogLog(target);
+                for (int i = 0; i < distinct; i++)
+                {
+                    hll.Add(Encoding.ASCII.GetBytes($"item-{i}"));
+                }
+
+                var estimate = (double)hll.Count();
+                var error = Math.Abs(estimate - distinct) / distinct;
+
+                Assert.IsLessThanOrEqualTo(target * 3, error,
+                    $"target {target:P0}: estimated {estimate:N0} against {distinct:N0}, " +
+                    $"error {error:P2}");
+            }
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestMinHash.cs
+++ b/TestProbabilisticDataStructures/TestMinHash.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
 
@@ -9,7 +11,15 @@ namespace TestProbabilisticDataStructures
     public class TestMinHash
     {
         /// <summary>
-        /// Ensures that MinHash returns the correct similarity ratio.
+        /// Resemblance is the Jaccard index: distinct words in both bags over distinct
+        /// words in either. These are exact values, not a range, because the result is
+        /// computed rather than estimated.
+        /// <para>
+        /// The last assertion used to allow anything from 0.5 to 0.7, which is wide
+        /// enough to admit the Sorensen-Dice coefficient the implementation actually
+        /// returned. 500 of the same 1000 words resemble them at exactly 0.5; Dice puts
+        /// the same pair at 0.667, and the range accepted both.
+        /// </para>
         /// </summary>
         [TestMethod]
         public void TestMinHashSimilarity()
@@ -22,8 +32,8 @@ namespace TestProbabilisticDataStructures
                 "sara"
             };
 
-            var simRatio = MinHash.Similarity(bag.ToArray(), bag.ToArray());
-            Assert.AreEqual(1.0, simRatio);
+            // A bag resembles itself exactly.
+            Assert.AreEqual(1.0f, MinHash.Similarity(bag.ToArray(), bag.ToArray()));
 
             var dict = Words.Dictionary(1000);
             var bag2 = new List<string>();
@@ -32,15 +42,90 @@ namespace TestProbabilisticDataStructures
                 bag2.Add(i.ToString());
             }
 
-            simRatio = MinHash.Similarity(dict, bag2.ToArray());
-            Assert.AreEqual(0.0, simRatio);
+            // Nothing in common.
+            Assert.AreEqual(0.0f, MinHash.Similarity(dict, bag2.ToArray()));
 
+            // 500 words drawn from the same 1000: the intersection is 500 and the
+            // union is 1000, so the resemblance is exactly one half.
             var bag3 = Words.Dictionary(500);
-            simRatio = MinHash.Similarity(dict, bag3);
-            if (simRatio > 0.7 || simRatio < 0.5)
+            Assert.AreEqual(0.5f, MinHash.Similarity(dict, bag3));
+        }
+
+        /// <summary>
+        /// The definition, stated on small bags where the answer can be read off.
+        /// Prior versions returned the Sorensen-Dice coefficient, which is related as
+        /// D = 2J / (1 + J) and so is consistently higher: the first case below was
+        /// reported as 0.5.
+        /// </summary>
+        [TestMethod]
+        public void TestMinHashSimilarityIsTheJaccardIndex()
+        {
+            // {a,b} and {b,c} share one word out of three distinct.
+            Assert.AreEqual(1f / 3f, MinHash.Similarity(
+                new[] { "a", "b" }, new[] { "b", "c" }), 1e-6);
+
+            // Three shared, five distinct.
+            Assert.AreEqual(0.6f, MinHash.Similarity(
+                new[] { "a", "b", "c", "d" }, new[] { "a", "b", "c", "e" }), 1e-6);
+
+            // A subset: three shared, six distinct.
+            Assert.AreEqual(0.5f, MinHash.Similarity(
+                new[] { "a", "b", "c" }, new[] { "a", "b", "c", "d", "e", "f" }), 1e-6);
+
+            // Repeats are not words in their own right; both bags hold {a, b}.
+            Assert.AreEqual(1.0f, MinHash.Similarity(
+                new[] { "a", "a", "a", "b" }, new[] { "a", "b" }));
+        }
+
+        /// <summary>
+        /// Agreement with the definition computed directly, over random bags, so that
+        /// the assertions above are not the only shapes covered.
+        /// </summary>
+        [TestMethod]
+        public void TestMinHashAgreesWithJaccardComputedDirectly()
+        {
+            var rand = new Random(1);
+
+            for (int trial = 0; trial < 2000; trial++)
             {
-                Assert.Fail(string.Format("Expected between 0.5 and 0.7, got {0}", simRatio));
+                var bag1 = Enumerable.Range(0, rand.Next(1, 40))
+                    .Select(_ => $"w{rand.Next(50)}").ToArray();
+                var bag2 = Enumerable.Range(0, rand.Next(1, 40))
+                    .Select(_ => $"w{rand.Next(50)}").ToArray();
+
+                var set1 = bag1.ToHashSet();
+                var set2 = bag2.ToHashSet();
+                var expected = (float)set1.Intersect(set2).Count() / set1.Union(set2).Count();
+
+                Assert.AreEqual(expected, MinHash.Similarity(bag1, bag2), 1e-6,
+                    $"trial {trial}: {{{string.Join(",", bag1)}}} vs {{{string.Join(",", bag2)}}}");
             }
         }
+
+        /// <summary>
+        /// Two empty bags hold the same distinct words -- none -- so they resemble each
+        /// other exactly. The division is 0 / 0 and used to return NaN.
+        /// </summary>
+        [TestMethod]
+        public void TestMinHashHandlesEmptyBags()
+        {
+            Assert.AreEqual(1.0f, MinHash.Similarity(new string[0], new string[0]));
+            Assert.AreEqual(0.0f, MinHash.Similarity(new[] { "a" }, new string[0]));
+            Assert.AreEqual(0.0f, MinHash.Similarity(new string[0], new[] { "a" }));
+        }
+
+        /// <summary>
+        /// Null bags threw NullReferenceException, which every other entry point in
+        /// the library stopped doing in 3.0.1.
+        /// </summary>
+        [TestMethod]
+        public void TestMinHashRejectsNull()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => MinHash.Similarity(null!, new[] { "a" }));
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => MinHash.Similarity(new[] { "a" }, null!));
+        }
+
     }
 }

--- a/TestProbabilisticDataStructures/TestNullArguments.cs
+++ b/TestProbabilisticDataStructures/TestNullArguments.cs
@@ -79,5 +79,19 @@ namespace TestProbabilisticDataStructures
             Assert.Throws<ArgumentNullException>(() => f.Test(null!),
                 "null is rejected even though empty input is accepted");
         }
+        /// <summary>
+        /// Add rejected null and Count did not, so a null query hashed the empty span
+        /// and returned a number.
+        /// </summary>
+        [TestMethod]
+        public void TestCountMinSketchRejectsNull()
+        {
+            var sketch = new CountMinSketch(0.001, 0.01);
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => sketch.Add(null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => sketch.Count(null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => sketch.Merge(null!));
+        }
+
     }
 }

--- a/TestProbabilisticDataStructures/TestSaturationAndBounds.cs
+++ b/TestProbabilisticDataStructures/TestSaturationAndBounds.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
@@ -16,17 +17,18 @@ namespace TestProbabilisticDataStructures
 
         /// <summary>
         /// A counting filter's counters saturate, and once they do the filter can no
-        /// longer tell how many times an element was added. Removals then clear it
-        /// after at most max steps rather than after as many steps as there were
-        /// adds.
+        /// longer tell how many elements they stand for. A saturated counter is
+        /// therefore never decremented: the element becomes permanently unremovable
+        /// and its space is never reclaimed.
         /// <para>
-        /// This is inherent to counting Bloom filters rather than a defect, but it is
-        /// a sharp edge: Count() keeps rising while the counters stop, so the two
-        /// disagree. Callers who delete must not assume adds and removes balance.
+        /// The alternative -- resuming the count from the ceiling -- reaches zero
+        /// while elements that need the counter are still present, which is a false
+        /// negative. Deleting without introducing those is the whole of what a
+        /// counting filter adds to a plain one, so leaking space is the lesser cost.
         /// </para>
         /// </summary>
         [TestMethod]
-        public void TestCountingFilterCountersSaturate()
+        public void TestCountingFilterSaturatedCountersAreNotDecremented()
         {
             const byte bitsPerCounter = 4;
             const int max = (1 << bitsPerCounter) - 1;   // 15
@@ -39,21 +41,69 @@ namespace TestProbabilisticDataStructures
                 f.Add(a);
             }
 
-            // Count tracks insertions, not counter state, so it keeps climbing.
+            // Count tracks insertions, not counter state, so it keeps climbing past
+            // the ceiling the counters stopped at.
             Assert.AreEqual((uint)adds, f.Count());
             Assert.IsTrue(f.Test(a));
 
-            var removals = 0;
-            while (f.Test(a) && removals <= adds)
+            // Every counter is saturated, so no number of removals clears it.
+            for (int i = 0; i < adds + max; i++)
             {
                 f.TestAndRemove(a);
-                removals++;
             }
 
-            Assert.IsFalse(f.Test(a), "element should be removable");
-            Assert.IsLessThanOrEqualTo(max, removals,
-                $"counters cap at {max}, so clearing the element should take at most that " +
-                $"many removals, not the {adds} additions performed.");
+            Assert.IsTrue(f.Test(a),
+                $"counters saturated at {max} after {adds} additions, so they can no " +
+                "longer be safely decremented and the element stays present.");
+        }
+
+        /// <summary>
+        /// The property that distinguishes a counting filter from a plain one:
+        /// removing elements must not make the remaining ones disappear. Narrow
+        /// counters make this sharp, because they saturate at ordinary loads -- with
+        /// one bit per counter every shared bucket saturates immediately.
+        /// <para>
+        /// Decrementing saturated counters broke this badly. At one bit per counter
+        /// 745 of 1000 surviving elements became unfindable, and at two bits, 42.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestCountingFilterRemovalNeverHidesRemainingElements()
+        {
+            foreach (byte bitsPerCounter in new byte[] { 1, 2, 4, 8 })
+            {
+                const int count = 2000;
+                var f = new CountingBloomFilter(count, bitsPerCounter, 0.01);
+
+                for (int i = 0; i < count; i++)
+                {
+                    f.Add(Key($"b{bitsPerCounter}-item-{i}"));
+                }
+
+                for (int i = 0; i < count / 2; i++)
+                {
+                    f.TestAndRemove(Key($"b{bitsPerCounter}-item-{i}"));
+                }
+
+                var missing = Enumerable.Range(count / 2, count / 2)
+                    .Count(i => !f.Test(Key($"b{bitsPerCounter}-item-{i}")));
+
+                Assert.AreEqual(0, missing,
+                    $"{bitsPerCounter}-bit counters: {missing} elements disappeared " +
+                    "after removing unrelated ones.");
+            }
+        }
+
+        /// <summary>
+        /// A zero-bit bucket holds no value and allocates no storage, so the first
+        /// read indexed an empty array and threw IndexOutOfRangeException. It is
+        /// rejected where it is passed instead.
+        /// </summary>
+        [TestMethod]
+        public void TestZeroWidthBucketIsRejected()
+        {
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new CountingBloomFilter(100, 0, 0.01));
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestScalableBloomFilter.cs
+++ b/TestProbabilisticDataStructures/TestScalableBloomFilter.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
+using System.Linq;
 using System.Text;
 
 namespace TestProbabilisticDataStructures
@@ -22,15 +23,25 @@ namespace TestProbabilisticDataStructures
             Assert.AreEqual(0.8, f.R);
         }
 
+        /// <summary>
+        /// Capacity is the sum over the contained filters. This used to be asserted as
+        /// the constant 15, which required a tightening ratio of 1 so that all three
+        /// filters came out the same size -- a ratio the constructor now rejects,
+        /// because it leaves the compound false positive rate unbounded. Summing the
+        /// parts states the contract directly and does not depend on the sizing math.
+        /// </summary>
         [TestMethod]
         public void TestScalableBloomCapacity()
         {
-            var f = new ScalableBloomFilter(1, 0.1, 1);
+            var f = new ScalableBloomFilter(1, 0.1, 0.8);
+            var first = f.Capacity();
+
             f.AddFilter();
             f.AddFilter();
 
-            var capacity = f.Capacity();
-            Assert.AreEqual(15u, capacity);
+            Assert.AreEqual(f.Filters.Sum(x => (long)x.Capacity()), (long)f.Capacity());
+            Assert.IsGreaterThan(first, f.Capacity(),
+                "adding filters should increase the total capacity");
         }
 
         // Ensures that K returns the number of hash functions used in each Bloom filter.

--- a/TestProbabilisticDataStructures/TestStableFilterProperty.cs
+++ b/TestProbabilisticDataStructures/TestStableFilterProperty.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// The property a Stable Bloom Filter exists for: under an unbounded stream its
+    /// false-positive rate approaches a fixed ceiling, where a classic filter's climbs
+    /// to certainty.
+    /// <para>
+    /// The existing coverage asserted the value of FalsePositiveRate(), which checks a
+    /// formula against itself. This measures the rate the filter actually exhibits and
+    /// compares it to what the filter claims.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class TestStableFilterProperty
+    {
+        private const int StreamLength = 500000;
+        private const int Probes = 20000;
+
+        private static byte[] Key(string s) => Encoding.ASCII.GetBytes(s);
+
+        private static double MeasureFalsePositiveRate(Func<byte[], bool> test)
+        {
+            var falsePositives = 0;
+            for (int i = 0; i < Probes; i++)
+            {
+                if (test(Key($"absent-{i}")))
+                {
+                    falsePositives++;
+                }
+            }
+            return (double)falsePositives / Probes;
+        }
+
+        /// <summary>
+        /// Feeding far more elements than the filter has cells must not drive the
+        /// false-positive rate past the bound the filter reports.
+        /// </summary>
+        [TestMethod]
+        public void TestStableFilterHoldsItsFalsePositiveCeiling()
+        {
+            var f = StableBloomFilter.NewDefaultStableBloomFilter(10000, 0.01);
+            var claimed = f.FalsePositiveRate();
+
+            for (int i = 0; i < StreamLength; i++)
+            {
+                f.TestAndAdd(Key($"stream-{i}"));
+            }
+
+            var measured = MeasureFalsePositiveRate(f.Test);
+
+            Assert.IsLessThanOrEqualTo(claimed * 2, measured,
+                $"after {StreamLength:N0} insertions into 10,000 cells the filter measured " +
+                $"{measured:P2} against the {claimed:P2} it reports as its bound. A stable " +
+                "filter's rate must converge rather than climb.");
+        }
+
+        /// <summary>
+        /// The contrast that motivates the structure. The unstable variant is a
+        /// classic Bloom filter -- no eviction -- so the same stream saturates it.
+        /// If this ever stopped saturating, the stable variant's result above would
+        /// no longer be evidence of anything.
+        /// </summary>
+        [TestMethod]
+        public void TestUnstableVariantSaturatesUnderTheSameStream()
+        {
+            var f = StableBloomFilter.NewUnstableBloomFilter(10000, 0.01);
+
+            for (int i = 0; i < StreamLength; i++)
+            {
+                f.TestAndAdd(Key($"stream-{i}"));
+            }
+
+            var measured = MeasureFalsePositiveRate(f.Test);
+
+            Assert.IsGreaterThan(0.9, measured,
+                $"a classic filter given {StreamLength:N0} elements in 10,000 cells should be " +
+                $"effectively full, but measured {measured:P2}.");
+        }
+
+        /// <summary>
+        /// Eviction is biased toward recency: the tail of the stream survives at a
+        /// higher rate than its head. This is a false negative by design, and the
+        /// direction is what matters rather than the magnitude.
+        /// </summary>
+        [TestMethod]
+        public void TestStableFilterFavorsRecentElements()
+        {
+            var f = StableBloomFilter.NewDefaultStableBloomFilter(10000, 0.01);
+
+            for (int i = 0; i < StreamLength; i++)
+            {
+                f.TestAndAdd(Key($"stream-{i}"));
+            }
+
+            var recent = 0;
+            var oldest = 0;
+            for (int i = 0; i < 1000; i++)
+            {
+                if (f.Test(Key($"stream-{StreamLength - 1 - i}"))) recent++;
+                if (f.Test(Key($"stream-{i}"))) oldest++;
+            }
+
+            Assert.IsGreaterThan(oldest, recent,
+                $"recent elements ({recent}/1000) should outlive the oldest ({oldest}/1000).");
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestTopK.cs
+++ b/TestProbabilisticDataStructures/TestTopK.cs
@@ -34,26 +34,28 @@ namespace TestProbabilisticDataStructures
 
             var addedK = topK.Add(BILL_BYTES);
             Assert.AreSame(topK, addedK);
-            // latest one also
-            var expected = new ProbabilisticDataStructures.Element[]{
-                new ProbabilisticDataStructures.Element{Data=BILL_BYTES, Freq=1},
-                new ProbabilisticDataStructures.Element{Data=SARA_BYTES, Freq=2},
-                new ProbabilisticDataStructures.Element{Data=BOB_BYTES, Freq=3},
-                new ProbabilisticDataStructures.Element{Data=ALICE_BYTES, Freq=4},
-                new ProbabilisticDataStructures.Element{Data=TYLER_BYTES, Freq=5},
-            };
 
+            // Counts are tyler 5, alice 4, bob 3, fred 2, sara 2, james 1, bill 1, so
+            // the top five are everything above james and bill. This previously
+            // expected bill, at a frequency of 1, in place of fred, at 2: the heap
+            // evicted by position rather than by frequency, and the test recorded
+            // whatever came out. fred and sara tie, so the order between those two is
+            // not part of the contract and is not asserted.
             var actual = topK.Elements();
 
             Assert.HasCount(5, actual);
 
-            for (int i = 0; i < actual.Length; i++)
-            {
-                var element = actual[i];
-                Assert.IsTrue(Enumerable.SequenceEqual(element.Data, expected[i].Data));
-                // freq check
-                Assert.AreEqual(expected[i].Freq, element.Freq);
-            }
+            var expectedFreqs = new ulong[] { 2, 2, 3, 4, 5 };
+            CollectionAssert.AreEqual(expectedFreqs, actual.Select(e => e.Freq).ToArray(),
+                "Elements returns the top k ordered from lowest to highest frequency");
+
+            var expectedNames = new[] { "alice", "bob", "fred", "sara", "tyler" };
+            var actualNames = actual
+                .Select(e => Encoding.ASCII.GetString(e.Data))
+                .OrderBy(x => x, System.StringComparer.Ordinal)
+                .ToArray();
+            CollectionAssert.AreEqual(expectedNames, actualNames,
+                "the five most frequent elements, and no others");
 
             var resetK = topK.Reset();
             Assert.AreSame(topK, resetK);


### PR DESCRIPTION
## What this is

A correctness audit of every structure in the library, judged against what each one is
supposed to be rather than against the Go implementation this was ported from. It began
as constructor argument validation and grew as the audit turned things up.

**Fourteen defects across nine structures.** Six of them break the defining guarantee of
the structure they are in.

## The ones that matter

| Structure | Defect | Measured |
|---|---|---|
| `InverseBloomFilter` | Retained the caller's array instead of copying, so a reused buffer rewrote the filter's contents | **38.8%** of never-added values reported present, on a filter that must never report any |
| `TopK` | `Pop` removed the root with `List.Remove`, and updates never re-ordered, so the min-heap had no minimum at its root | **89 of 150** configurations returned the wrong set |
| `CountingBloomFilter` | Decremented saturated counters, resuming the count from the ceiling | **745 of 1000** survivors unfindable at 1 bit/counter after deleting unrelated elements |
| `ScalableBloomFilter` | Tightening ratio unvalidated; `r = 1` tightens nothing | **83%** measured against a requested 1% |
| `CountMinSketch` | `delta >= 1` gives a matrix with no rows, and `Count` minimises over nothing | Every element reported as seen **18446744073709551615** times |
| `MinHash` | Returned the Sørensen–Dice coefficient, not Broder's resemblance; the k hash permutations were never read | One-third resemblance reported at one half; 163 ms → 15 µs |
| `DeletableBloomFilter` | Region size rounded down, so the last region indexed past the collision array | `IndexOutOfRangeException` for every `r` divisible by 8 |
| `HyperLogLog` | `b` derived by floating-point logarithm, wrong at m = 2²⁹ | `IndexOutOfRangeException` on first `Add` |

Plus: `Reset()` left the item count stale on three filters (a filter emptied after 800
additions reported a 44% fill ratio); `ScalableBloomFilter.Reset()` discarded a hash set
via `SetHash`; `CountMinSketch.Merge` threw the bare `Exception`; and several
constructors accepted arguments that failed later and elsewhere.

The README claimed the inverse filter was thread-safe three sections after stating that
nothing in the library is, and its thread-safety section had gone stale on our own
account — it blamed a `HashAlgorithm` the filters stopped holding in 3.0.0.

## Why the tests were green throughout

None of this was untested *methods*. It was untested *conditions*. Every existing
deletable-filter test used `r = 10` or `r = 100`, both of which have padding bits that
absorb the out-of-range write. The counting filter's default 4-bit counters do not
saturate at ordinary loads. Line coverage showed all of it as covered.

Three legacy tests asserted the broken behavior and were rewritten: `TestTopk` expected
an element of frequency 1 over one of frequency 2, the counting filter's saturation test
asserted that a saturated element is still removable, and MinHash's allowed a range wide
enough to admit the wrong metric.

## Verification

**201 tests, all green.** Every new regression test was run against the unfixed code to
confirm it fails there.

Sound and unchanged, having been checked: the count-min sketch never undercounts and
stays inside its error bound; scalable honors its compound bound; the stable filter's
decay is correct; `BloomFilter64`'s 128-bit kernel is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9
