### PR TITLE
Settle the hash at construction; seed the two random filters (4.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.0] - Unreleased
+## [4.0.0] - 2026-08-14
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - Unreleased
+
+### Fixed
+
+- **Replacing a populated structure's hash function is refused** rather than silently
+  destroying it. `SetHash` on a filter holding 500 items left it reporting 500 items and
+  finding none of them: everything stored had been placed by the old hash, and replacing
+  it moves none of it, so every lookup goes somewhere else. Nothing raised. The filter
+  did not look broken, it looked empty.
+
+  It now throws `InvalidOperationException` unless the structure holds nothing, which is
+  the only state the call was ever safe in. Emptiness is derived from what the structure
+  holds rather than tracked, so one read back from a payload is not mistaken for
+  untouched.
+
+### Added
+
+- **Every constructor accepts a hash function**, which closes
+  [#1](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/1). It is an
+  optional trailing parameter, so existing calls are unchanged:
+
+  ```C#
+  var filter = new BloomFilter(10000, 0.01, hash: myHashFunction);
+  ```
+
+  This is now the only way to use a hash for everything a structure will ever hold. A
+  scalable filter carries it to the filters it adds as it grows, and a top-k to the
+  sketch it holds.
+
+- **`StableBloomFilter` and `CuckooBloomFilter` accept a seed.** Both make random
+  choices as part of what they are -- one decrements randomly chosen cells to make room,
+  the other evicts a randomly chosen entry when both of an item's buckets are full --
+  and both drew from an unseeded generator, so neither could be asserted against, only
+  described.
+
+  ```C#
+  var filter = new StableBloomFilter(10000, 2, 0.01, seed: 42);
+  ```
+
+  Omitting it still seeds unpredictably. This also makes their persisted bytes
+  comparable, which is why the format fixtures for those two could previously only be
+  checked on reading.
+
+### Changed
+
+- **`SetHash` is a fallback rather than the way to configure hashing.** Prefer the
+  constructor. `SetHash` remains for callers who cannot, and is now valid only before
+  anything has been added.
+
 ## [3.2.0] - 2026-08-14
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          lived nowhere in the repo: AppVeyor patched AssemblyInfo.cs at build time from
          its own build counter, which is how the published package version (1.0.1) and
          the GitHub release tags (v1.0.9) drifted apart. -->
-    <VersionPrefix>3.2.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/ProbabilisticDataStructures/BloomFilter.cs
+++ b/ProbabilisticDataStructures/BloomFilter.cs
@@ -37,7 +37,12 @@ namespace ProbabilisticDataStructures
         /// </summary>
         /// <param name="n">Number of items to store.</param>
         /// <param name="fpRate">Desired false positive rate.</param>
-        public BloomFilter(uint n, double fpRate)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public BloomFilter(uint n, double fpRate, Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidItemCount(n, nameof(n));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
@@ -45,7 +50,7 @@ namespace ProbabilisticDataStructures
             var m = Utils.OptimalM(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             Buckets = new Buckets(m, 1);
-            Hash = Defaults.GetDefaultHashFunction();
+            Hash = hash ?? Defaults.GetDefaultHashFunction();
             this.m = m;
             this.k = k;
         }
@@ -294,6 +299,9 @@ namespace ProbabilisticDataStructures
         // TODO: Add SetHash to the IFilter interface?
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.count == 0, nameof(BloomFilter));
+
             this.Hash = h;
         }
     }

--- a/ProbabilisticDataStructures/BloomFilter64.cs
+++ b/ProbabilisticDataStructures/BloomFilter64.cs
@@ -42,7 +42,12 @@ namespace ProbabilisticDataStructures
         /// </summary>
         /// <param name="n">Number of items to store.</param>
         /// <param name="fpRate">Desired false positive rate.</param>
-        public BloomFilter64(ulong n, double fpRate)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public BloomFilter64(ulong n, double fpRate, Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidItemCount(n, nameof(n));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
@@ -50,7 +55,7 @@ namespace ProbabilisticDataStructures
             var m = Utils.OptimalM64(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             Buckets = new Buckets64(m, 1);
-            Hash = Defaults.GetDefaultHashFunction();
+            Hash = hash ?? Defaults.GetDefaultHashFunction();
             this.m = m;
             this.k = k;
         }
@@ -292,6 +297,9 @@ namespace ProbabilisticDataStructures
         // TODO: Add SetHash to the IFilter interface?
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.count == 0, nameof(BloomFilter64));
+
             this.Hash = h;
         }
     }

--- a/ProbabilisticDataStructures/CountMinSketch.cs
+++ b/ProbabilisticDataStructures/CountMinSketch.cs
@@ -69,7 +69,12 @@ namespace ProbabilisticDataStructures
         /// </summary>
         /// <param name="epsilon">Relative-accuracy factor</param>
         /// <param name="delta">Relative-accuracy probability</param>
-        public CountMinSketch(double epsilon, double delta)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public CountMinSketch(double epsilon, double delta, Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidSketchEpsilon(epsilon, nameof(epsilon));
             Guard.ValidSketchDelta(delta, nameof(delta));
@@ -87,7 +92,7 @@ namespace ProbabilisticDataStructures
             this.Depth = depth;
             this.epsilon = epsilon;
             this.delta = delta;
-            this.Hash = Defaults.GetDefaultHashFunction();
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
         }
 
         /// <summary>
@@ -228,6 +233,9 @@ namespace ProbabilisticDataStructures
         /// <param name="h">The hash function to use.</param>
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.count == 0, nameof(CountMinSketch));
+
             this.Hash = h;
         }
 

--- a/ProbabilisticDataStructures/CountingBloomFilter.cs
+++ b/ProbabilisticDataStructures/CountingBloomFilter.cs
@@ -69,7 +69,12 @@ namespace ProbabilisticDataStructures
         /// <param name="n">Number of items to store.</param>
         /// <param name="b">Bucket size.</param>
         /// <param name="fpRate">Desired false positive rate.</param>
-        public CountingBloomFilter(uint n, byte b, double fpRate)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public CountingBloomFilter(uint n, byte b, double fpRate, Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidItemCount(n, nameof(n));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
@@ -77,7 +82,7 @@ namespace ProbabilisticDataStructures
             var m = Utils.OptimalM(n, fpRate);
             var k = Utils.OptimalK(fpRate);
             this.Buckets =  new Buckets(m, b);
-            this.Hash = Defaults.GetDefaultHashFunction();
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
             this.m = m;
             this.k = k;
             this.indexBuffer = new uint[k];
@@ -359,6 +364,9 @@ namespace ProbabilisticDataStructures
         // TODO: Add SetHash to the IFilter interface?
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.count == 0, nameof(CountingBloomFilter));
+
             this.Hash = h;
         }
     }

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -69,7 +69,18 @@ namespace ProbabilisticDataStructures
         /// </summary>
         /// <param name="n">Number of items to store</param>
         /// <param name="fpRate">Target false-positive rate</param>
-        public CuckooBloomFilter(uint n, double fpRate)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        /// <param name="seed">
+        /// A seed for the random choices this filter makes, or null to seed it
+        /// unpredictably. Supplying one makes the filter reproducible, which is what
+        /// makes its behavior assertable rather than only describable.
+        /// </param>
+        public CuckooBloomFilter(uint n, double fpRate,
+            Func<ReadOnlySpan<byte>, ulong>? hash = null, int? seed = null)
         {
             Guard.ValidItemCount(n, nameof(n));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
@@ -85,7 +96,8 @@ namespace ProbabilisticDataStructures
             }
 
             this.Buckets = buckets;
-            this.Hash = Defaults.GetDefaultHashFunction();
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
+            this.random = seed is null ? new Random() : new Random(seed.Value);
             this.M = m;
             this.B = b;
             this.F = f;
@@ -431,6 +443,9 @@ namespace ProbabilisticDataStructures
         /// <param name="h">The hash function to use.</param>
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.count == 0, nameof(CuckooBloomFilter));
+
             this.Hash = h;
         }
 

--- a/ProbabilisticDataStructures/DeletableBloomFilter.cs
+++ b/ProbabilisticDataStructures/DeletableBloomFilter.cs
@@ -64,7 +64,12 @@ namespace ProbabilisticDataStructures
         /// <param name="n">Number of items</param>
         /// <param name="r">Number of bits to use to store collision information</param>
         /// <param name="fpRate">Desired false positive rate</param>
-        public DeletableBloomFilter(uint n, uint r, double fpRate)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public DeletableBloomFilter(uint n, uint r, double fpRate, Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidItemCount(n, nameof(n));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
@@ -79,7 +84,7 @@ namespace ProbabilisticDataStructures
 
             this.Buckets = new Buckets(m - r, 1);
             this.Collisions = new Buckets(r, 1);
-            this.Hash = Defaults.GetDefaultHashFunction();
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
             this.M = m - r;
             // Rounded up, not down. The data region rarely divides evenly into r
             // regions, and rounding down leaves a remainder that maps to region
@@ -380,6 +385,9 @@ namespace ProbabilisticDataStructures
         // TODO: Add SetHash to the IFilter interface?
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.count == 0, nameof(DeletableBloomFilter));
+
             this.Hash = h;
         }
     }

--- a/ProbabilisticDataStructures/Guard.cs
+++ b/ProbabilisticDataStructures/Guard.cs
@@ -52,6 +52,33 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// A structure's hash function can only be replaced while it holds nothing.
+        /// </summary>
+        /// <remarks>
+        /// Everything a structure has stored was placed by the hash it was holding at
+        /// the time, and replacing that hash does not move any of it. Every lookup then
+        /// goes somewhere else, so the structure answers no to everything it holds while
+        /// still reporting that it holds it. It does not look broken, it looks empty,
+        /// which is the reason this is refused rather than documented.
+        /// <para>
+        /// Prefer passing the hash to the constructor. This exists for callers who
+        /// cannot, and is safe only before anything has been added.
+        /// </para>
+        /// </remarks>
+        internal static void HashMayBeReplaced(bool isEmpty, string structureName)
+        {
+            if (!isEmpty)
+            {
+                throw new InvalidOperationException(
+                    $"The hash function cannot be replaced once a {structureName} holds " +
+                    "anything. What it has stored was placed by the hash it had then, " +
+                    "and replacing that hash does not move it: every lookup would go " +
+                    "somewhere else and the structure would answer no to everything it " +
+                    "holds. Pass the hash function to the constructor instead.");
+            }
+        }
+
+        /// <summary>
         /// A count-min sketch's epsilon fixes the width of its matrix, as e / epsilon,
         /// so it has to be positive and not so small that the width is unbuildable.
         /// </summary>

--- a/ProbabilisticDataStructures/HyperLogLog.cs
+++ b/ProbabilisticDataStructures/HyperLogLog.cs
@@ -52,6 +52,28 @@ namespace ProbabilisticDataStructures
         /// Counter registers
         /// </summary>
         private byte[] Registers { get; set; }
+
+        /// <summary>
+        /// Whether any register has been set, which is what decides if the hash
+        /// can still be replaced. Derived rather than tracked, so that an
+        /// estimator read back from a payload answers this the way the one that
+        /// wrote it would.
+        /// </summary>
+        private bool IsEmpty
+        {
+            get
+            {
+                foreach (var register in this.Registers)
+                {
+                    if (register != 0)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
         /// <summary>
         /// Number of registers
         /// </summary>
@@ -74,7 +96,12 @@ namespace ProbabilisticDataStructures
         /// power of two.
         /// </summary>
         /// <param name="m">Number of registers (must be a power of two)</param>
-        public HyperLogLog(uint m)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public HyperLogLog(uint m, Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             // Zero passes the power-of-two test below, because 0 - 1 underflows to
             // all ones and 0 & anything is 0. It would build an estimator with no
@@ -95,7 +122,7 @@ namespace ProbabilisticDataStructures
             // index derived from it can exceed the register array.
             this.B = (uint)BitOperations.Log2(m);
             this.Alpha = CalculateAlpha(m);
-            this.Hash = Defaults.GetDefaultHashFunction();
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
         }
 
         /// <summary>
@@ -292,6 +319,9 @@ namespace ProbabilisticDataStructures
         /// <param name="h">The hash function to use.</param>
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.IsEmpty, nameof(HyperLogLog));
+
             this.Hash = h;
         }
 

--- a/ProbabilisticDataStructures/InverseBloomFilter.cs
+++ b/ProbabilisticDataStructures/InverseBloomFilter.cs
@@ -65,15 +65,41 @@ namespace ProbabilisticDataStructures
         private uint capacity { get; set; }
 
         /// <summary>
+        /// Whether any slot is occupied, which is what decides if the hash can
+        /// still be replaced. Derived rather than tracked, so that a filter read
+        /// back from a payload answers this the way the one that wrote it would.
+        /// </summary>
+        private bool IsEmpty
+        {
+            get
+            {
+                foreach (var slot in this.Array)
+                {
+                    if (slot is not null)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Instantiates an InverseBloomFilter with the specified capacity.
         /// </summary>
         /// <param name="capacity">The capacity of the filter</param>
-        public InverseBloomFilter(uint capacity)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public InverseBloomFilter(uint capacity, Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidItemCount(capacity, nameof(capacity));
 
             this.Array = new byte[capacity][];
-            this.Hash = Defaults.GetDefaultHashFunction();
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
             this.capacity = capacity;
         }
 
@@ -319,6 +345,9 @@ namespace ProbabilisticDataStructures
         // TODO: Add SetHash to the IFilter interface?
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.IsEmpty, nameof(InverseBloomFilter));
+
             this.Hash = h;
         }
     }

--- a/ProbabilisticDataStructures/PartitionedBloomFilter.cs
+++ b/ProbabilisticDataStructures/PartitionedBloomFilter.cs
@@ -65,7 +65,12 @@ namespace ProbabilisticDataStructures
         /// </summary>
         /// <param name="n">Number of items</param>
         /// <param name="fpRate">Desired false-positive rate</param>
-        public PartitionedBloomFilter(uint n, double fpRate)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public PartitionedBloomFilter(uint n, double fpRate, Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidItemCount(n, nameof(n));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
@@ -81,7 +86,7 @@ namespace ProbabilisticDataStructures
             }
 
             this.Partitions = partitions;
-            this.Hash = Defaults.GetDefaultHashFunction();
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
             this.M = m;
             this.k = k;
             this.S = s;
@@ -368,6 +373,9 @@ namespace ProbabilisticDataStructures
         // TODO: Add SetHash to the IFilter interface?
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.count == 0, nameof(PartitionedBloomFilter));
+
             this.Hash = h;
         }
     }

--- a/ProbabilisticDataStructures/ScalableBloomFilter.cs
+++ b/ProbabilisticDataStructures/ScalableBloomFilter.cs
@@ -62,6 +62,19 @@ namespace ProbabilisticDataStructures
         /// Filter size hint
         /// </summary>
         internal uint Hint { get; set; }
+        /// <summary>
+        /// The hash every contained filter is built with, or null for the default.
+        /// Held because filters are added as the structure grows, long after the
+        /// constructor has run.
+        /// </summary>
+        private Func<ReadOnlySpan<byte>, ulong>? Hash { get; set; }
+
+        /// <summary>
+        /// Whether anything has been added. A scalable filter that has grown holds more
+        /// than the filter it started with; the first one having a count is the other
+        /// way it can be non-empty.
+        /// </summary>
+        private bool IsEmpty => this.Filters.Count == 1 && this.Filters[0].Count() == 0;
 
         /// <summary>
         /// Creates a new Scalable Bloom Filter with the specified target false-positive
@@ -71,7 +84,13 @@ namespace ProbabilisticDataStructures
         /// <param name="hint"></param>
         /// <param name="fpRate"></param>
         /// <param name="r"></param>
-        public ScalableBloomFilter(uint hint, double fpRate, double r)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public ScalableBloomFilter(uint hint, double fpRate, double r,
+            Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidItemCount(hint, nameof(hint));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
@@ -82,6 +101,7 @@ namespace ProbabilisticDataStructures
             this.FP = fpRate;
             this.P = Defaults.FILL_RATIO;
             this.Hint = hint;
+            this.Hash = hash;
 
             this.AddFilter();
         }
@@ -308,6 +328,14 @@ namespace ProbabilisticDataStructures
         // TODO: Add SetHash to the IFilter interface?
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+
+            // Checked here rather than left to the contained filters, so that the
+            // failure names this filter and nothing is half converted before one of
+            // them refuses.
+            Guard.HashMayBeReplaced(this.IsEmpty, nameof(ScalableBloomFilter));
+
+            this.Hash = h;
             foreach (var filter in this.Filters)
             {
                 filter.SetHash(h);
@@ -325,11 +353,10 @@ namespace ProbabilisticDataStructures
             // after the first takes its hash from Filters[0], so dropping the list
             // without carrying the hash across would quietly restore the default and
             // leave a caller who set their own hashing elsewhere than they left it.
-            var hash = this.Filters[0].Hash;
+            this.Hash = this.Filters[0].Hash;
 
             this.Filters = new List<PartitionedBloomFilter>();
             this.AddFilter();
-            this.Filters[0].SetHash(hash);
             return this;
         }
 
@@ -340,11 +367,11 @@ namespace ProbabilisticDataStructures
         internal void AddFilter()
         {
             var fpRate = this.FP * Math.Pow(this.R, this.Filters.Count());
-            var p = new PartitionedBloomFilter(this.Hint, fpRate);
-            if (this.Filters.Count() > 0)
-            {
-                p.SetHash(this.Filters[0].Hash);
-            }
+            // The hash is passed to the filter rather than set on it afterwards: a
+            // filter is only safe to re-hash while empty, and building it with the
+            // right one removes the window entirely.
+            var inherited = this.Filters.Count > 0 ? this.Filters[0].Hash : this.Hash;
+            var p = new PartitionedBloomFilter(this.Hint, fpRate, inherited);
             this.Filters.Add(p);
         }
     }

--- a/ProbabilisticDataStructures/StableBloomFilter.cs
+++ b/ProbabilisticDataStructures/StableBloomFilter.cs
@@ -63,6 +63,27 @@ namespace ProbabilisticDataStructures
         private Random random = new Random();
 
         /// <summary>
+        /// Whether any cell has been set, which is what decides if the hash can
+        /// still be replaced. Derived rather than tracked, so that a filter read
+        /// back from a payload answers this the way the one that wrote it would.
+        /// </summary>
+        private bool IsEmpty
+        {
+            get
+            {
+                for (uint i = 0; i < this.cells.count; i++)
+                {
+                    if (this.cells.Get(i) != 0)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Used by NewUnstableBloomFilter, which populates every member through an
         /// object initializer. The compiler cannot see that, so the members it sets
         /// are marked null-forgiving at their declarations.
@@ -77,7 +98,18 @@ namespace ProbabilisticDataStructures
         /// <param name="m">Number of cells to decrement</param>
         /// <param name="d">Bits per cell</param>
         /// <param name="fpRate">Desired false-positive rate</param>
-        public StableBloomFilter(uint m, byte d, double fpRate)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        /// <param name="seed">
+        /// A seed for the random choices this filter makes, or null to seed it
+        /// unpredictably. Supplying one makes the filter reproducible, which is what
+        /// makes its behavior assertable rather than only describable.
+        /// </param>
+        public StableBloomFilter(uint m, byte d, double fpRate,
+            Func<ReadOnlySpan<byte>, ulong>? hash = null, int? seed = null)
         {
             Guard.ValidItemCount(m, nameof(m));
             Guard.ValidFalsePositiveRate(fpRate, nameof(fpRate));
@@ -94,7 +126,8 @@ namespace ProbabilisticDataStructures
 
             var cells = new Buckets(m, d);
 
-            this.Hash = Defaults.GetDefaultHashFunction();
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
+            this.random = seed is null ? new Random() : new Random(seed.Value);
             this.M = m;
             this.k = k;
             this.p = OptimalStableP(m, k, d, fpRate);
@@ -387,6 +420,9 @@ namespace ProbabilisticDataStructures
         // TODO: Add SetHash to the IFilter interface?
         public void SetHash(Func<ReadOnlySpan<byte>, ulong> h)
         {
+            ArgumentNullException.ThrowIfNull(h);
+            Guard.HashMayBeReplaced(this.IsEmpty, nameof(StableBloomFilter));
+
             this.Hash = h;
         }
 

--- a/ProbabilisticDataStructures/TopK.cs
+++ b/ProbabilisticDataStructures/TopK.cs
@@ -22,11 +22,17 @@ namespace ProbabilisticDataStructures
         /// <param name="delta">Relative-accuracy probability</param>
         /// <param name="k">Number of top elements to track</param>
         /// <returns></returns>
-        public TopK(double epsilon, double delta, uint k)
+        /// <param name="hash">
+        /// The hash function to use, or null for the default. Passing it here is the
+        /// only way to have one hash cover everything the structure will ever hold:
+        /// once anything has been added, the hash can no longer be replaced.
+        /// </param>
+        public TopK(double epsilon, double delta, uint k,
+            Func<ReadOnlySpan<byte>, ulong>? hash = null)
         {
             Guard.ValidItemCount(k, nameof(k));
 
-            this.Cms = new CountMinSketch(epsilon, delta);
+            this.Cms = new CountMinSketch(epsilon, delta, hash);
             this.K = k;
             this.elements = new ElementHeap((int)k);
         }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ var filter = BloomFilter.ReadFrom(file, myHashFunction);
 Without it the read fails. That is deliberate: a filter restored under the wrong hash
 does not look broken, it looks empty, and would answer no to everything it holds.
 
+## Choosing a hash function
+
+Every constructor takes an optional hash function:
+
+```C#
+var filter = new BloomFilter(10000, 0.01, hash: myHashFunction);
+```
+
+Omitting it uses the default, a 64-bit XxHash3. A scalable filter passes it to the
+filters it adds as it grows, and a top-k to the sketch it holds.
+
+**The hash cannot be replaced once a structure holds anything.** `SetHash` throws in that
+case. Everything already stored was placed by the hash in use at the time, and replacing
+it moves none of it, so every lookup would go somewhere else — the structure would report
+items it can no longer find. It would not look broken, it would look empty.
+
+`SetHash` remains available before anything has been added, including after `Reset()`.
+
+## Reproducibility
+
+`StableBloomFilter` and `CuckooBloomFilter` make random choices as part of what they are:
+the first decrements randomly chosen cells to make room, the second evicts a randomly
+chosen entry when both of an item's buckets are full. Both accept a seed:
+
+```C#
+var filter = new StableBloomFilter(10000, 2, 0.01, seed: 42);
+```
+
+Omitting it seeds unpredictably. Every other structure here is already deterministic
+given its inputs.
+
 ## Thread safety
 
 **None of the filters in this library are thread-safe.** No operation is synchronized,

--- a/TestProbabilisticDataStructures/TestHashConfiguration.cs
+++ b/TestProbabilisticDataStructures/TestHashConfiguration.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// The hash a structure uses is settled when it is built. Replacing it afterwards
+    /// is refused, because everything already stored was placed by the old one and
+    /// replacing it moves none of it.
+    /// </summary>
+    [TestClass]
+    public class TestHashConfiguration
+    {
+        private static byte[] Key(string s) => Encoding.ASCII.GetBytes(s);
+
+        /// <summary>
+        /// A different hash from the default, so that a structure built with it differs
+        /// from one that ignored it.
+        /// </summary>
+        private static ulong Alternate(ReadOnlySpan<byte> data)
+        {
+            return System.IO.Hashing.XxHash64.HashToUInt64(data);
+        }
+
+        /// <summary>
+        /// The hash a payload records: 0 for one the caller supplied, 1 for the default.
+        /// Reading it out of the header is an exact check that a structure is holding
+        /// the hash it was given, rather than an inference from how it behaves.
+        /// </summary>
+        private static int RecordedHashId(byte[] payload) => payload[8] | (payload[9] << 8);
+
+        private const int Custom = 0;
+        private const int Default = 1;
+
+        [TestMethod]
+        public void TestEveryStructureUsesAHashGivenToItsConstructor()
+        {
+            Assert.AreEqual(Custom, RecordedHashId(new BloomFilter(100, 0.01, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new BloomFilter64(100, 0.01, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new CountingBloomFilter(100, 4, 0.01, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new DeletableBloomFilter(100, 10, 0.01, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new PartitionedBloomFilter(100, 0.01, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new StableBloomFilter(100, 2, 0.01, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new InverseBloomFilter(64, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new CuckooBloomFilter(100, 0.01, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new CountMinSketch(0.01, 0.01, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new HyperLogLog(64, Alternate).ToByteArray()));
+
+            // The composites have to pass it down to what they hold.
+            Assert.AreEqual(Custom, RecordedHashId(new ScalableBloomFilter(50, 0.01, 0.8, Alternate).ToByteArray()));
+            Assert.AreEqual(Custom, RecordedHashId(new TopK(0.01, 0.01, 5, Alternate).ToByteArray()));
+        }
+
+        [TestMethod]
+        public void TestOmittingTheHashStillGivesTheDefault()
+        {
+            Assert.AreEqual(Default, RecordedHashId(new BloomFilter(100, 0.01).ToByteArray()));
+            Assert.AreEqual(Default, RecordedHashId(new ScalableBloomFilter(50, 0.01, 0.8).ToByteArray()));
+            Assert.AreEqual(Default, RecordedHashId(new TopK(0.01, 0.01, 5).ToByteArray()));
+        }
+
+        /// <summary>
+        /// A scalable filter adds filters as it grows, long after its constructor has
+        /// run, so the hash has to be carried rather than only applied at the start.
+        /// </summary>
+        [TestMethod]
+        public void TestScalableFilterGivesItsHashToFiltersAddedLater()
+        {
+            var f = new ScalableBloomFilter(20, 0.01, 0.8, Alternate);
+            for (int i = 0; i < 500; i++)
+            {
+                f.Add(Key($"item-{i}"));
+            }
+
+            Assert.IsGreaterThan(1, f.Filters.Count, "the filter should have grown");
+            foreach (var contained in f.Filters)
+            {
+                Assert.AreEqual(Custom, RecordedHashId(contained.ToByteArray()),
+                    "a filter added while growing did not inherit the hash");
+            }
+
+            // And still finds everything, which it would not if a later filter had been
+            // built with a different hash from the one its contents were added under.
+            for (int i = 0; i < 500; i++)
+            {
+                Assert.IsTrue(f.Test(Key($"item-{i}")));
+            }
+        }
+
+        /// <summary>
+        /// The defect this closes: replacing the hash of a populated filter left it
+        /// reporting items it could no longer find. 500 added, 500 reported, none
+        /// findable, and nothing raised.
+        /// </summary>
+        [TestMethod]
+        public void TestReplacingTheHashOfAPopulatedStructureIsRefused()
+        {
+            var bloom = new BloomFilter(1000, 0.01);
+            for (int i = 0; i < 500; i++)
+            {
+                bloom.Add(Key($"item-{i}"));
+            }
+
+            Assert.ThrowsExactly<InvalidOperationException>(() => bloom.SetHash(Alternate));
+
+            // And is left as it was, rather than half converted.
+            Assert.AreEqual(500, Enumerable.Range(0, 500).Count(i => bloom.Test(Key($"item-{i}"))));
+            Assert.AreEqual(500u, bloom.Count());
+        }
+
+        [TestMethod]
+        public void TestEveryStructureRefusesToReplaceThHashOnceItHoldsSomething()
+        {
+            var bloom = new BloomFilter(100, 0.01); bloom.Add(Key("a"));
+            var bloom64 = new BloomFilter64(100, 0.01); bloom64.Add(Key("a"));
+            var counting = new CountingBloomFilter(100, 4, 0.01); counting.Add(Key("a"));
+            var deletable = new DeletableBloomFilter(100, 10, 0.01); deletable.Add(Key("a"));
+            var partitioned = new PartitionedBloomFilter(100, 0.01); partitioned.Add(Key("a"));
+            var stable = new StableBloomFilter(100, 2, 0.01); stable.Add(Key("a"));
+            var inverse = new InverseBloomFilter(64); inverse.Add(Key("a"));
+            var cuckoo = new CuckooBloomFilter(100, 0.01); cuckoo.Add(Key("a"));
+            var sketch = new CountMinSketch(0.01, 0.01); sketch.Add(Key("a"));
+            var hll = new HyperLogLog(64); hll.Add(Key("a"));
+            var scalable = new ScalableBloomFilter(50, 0.01, 0.8); scalable.Add(Key("a"));
+
+            Assert.ThrowsExactly<InvalidOperationException>(() => bloom.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => bloom64.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => counting.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => deletable.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => partitioned.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => stable.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => inverse.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => cuckoo.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => sketch.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => hll.SetHash(Alternate));
+            Assert.ThrowsExactly<InvalidOperationException>(() => scalable.SetHash(Alternate));
+        }
+
+        /// <summary>
+        /// Still allowed while a structure holds nothing, which is the case the old API
+        /// was always safe for.
+        /// </summary>
+        [TestMethod]
+        public void TestReplacingTheHashOfAnEmptyStructureIsAllowed()
+        {
+            var bloom = new BloomFilter(100, 0.01);
+            bloom.SetHash(Alternate);
+            bloom.Add(Key("a"));
+            Assert.IsTrue(bloom.Test(Key("a")));
+            Assert.AreEqual(Custom, RecordedHashId(bloom.ToByteArray()));
+
+            // Emptied structures count as empty, so a filter can be repurposed.
+            var reset = new BloomFilter(100, 0.01);
+            reset.Add(Key("a"));
+            reset.Reset();
+            reset.SetHash(Alternate);
+            Assert.AreEqual(Custom, RecordedHashId(reset.ToByteArray()));
+        }
+
+        /// <summary>
+        /// Emptiness is derived from what a structure holds rather than tracked, so a
+        /// structure read back from a payload answers it the way the one that wrote it
+        /// would rather than looking untouched.
+        /// </summary>
+        [TestMethod]
+        public void TestARestoredStructureIsNotTreatedAsEmpty()
+        {
+            var stable = new StableBloomFilter(1000, 2, 0.01);
+            stable.Add(Key("a"));
+            var restoredStable = Persistence.FromByteArray<StableBloomFilter>(stable.ToByteArray());
+            Assert.ThrowsExactly<InvalidOperationException>(() => restoredStable.SetHash(Alternate));
+
+            var inverse = new InverseBloomFilter(64);
+            inverse.Add(Key("a"));
+            var restoredInverse = Persistence.FromByteArray<InverseBloomFilter>(inverse.ToByteArray());
+            Assert.ThrowsExactly<InvalidOperationException>(() => restoredInverse.SetHash(Alternate));
+
+            var hll = new HyperLogLog(64);
+            hll.Add(Key("a"));
+            var restoredHll = Persistence.FromByteArray<HyperLogLog>(hll.ToByteArray());
+            Assert.ThrowsExactly<InvalidOperationException>(() => restoredHll.SetHash(Alternate));
+
+            var bloom = new BloomFilter(100, 0.01);
+            bloom.Add(Key("a"));
+            var restoredBloom = Persistence.FromByteArray<BloomFilter>(bloom.ToByteArray());
+            Assert.ThrowsExactly<InvalidOperationException>(() => restoredBloom.SetHash(Alternate));
+        }
+
+        [TestMethod]
+        public void TestSetHashRejectsNull()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(() => new BloomFilter(100, 0.01).SetHash(null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new ScalableBloomFilter(50, 0.01, 0.8).SetHash(null!));
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestSeededRandomness.cs
+++ b/TestProbabilisticDataStructures/TestSeededRandomness.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Two structures here make random choices as part of what they are: the stable
+    /// filter decrements randomly chosen cells to make room, and the cuckoo filter
+    /// evicts a randomly chosen entry when both of an item's buckets are full. Both can
+    /// now be seeded, which is what makes their behavior assertable at all rather than
+    /// only describable.
+    /// </summary>
+    [TestClass]
+    public class TestSeededRandomness
+    {
+        private static byte[] Key(string s) => Encoding.ASCII.GetBytes(s);
+
+        private static string Fingerprint<T>(T structure) where T : IBinaryPersistable<T>
+        {
+            return Convert.ToHexString(
+                System.IO.Hashing.XxHash3.Hash(structure.ToByteArray()));
+        }
+
+        private static StableBloomFilter FilledStable(int? seed)
+        {
+            var f = new StableBloomFilter(1000, 2, 0.01, seed: seed);
+            for (int i = 0; i < 3000; i++)
+            {
+                f.Add(Key($"w{i}"));
+            }
+
+            return f;
+        }
+
+        /// <summary>
+        /// Enough items that both of some item's buckets fill and the eviction path
+        /// runs. The filter is sized far more generously than its stated capacity --
+        /// 100 items gives 1024 buckets of 4 -- so a load near the stated figure never
+        /// reaches the random choice at all.
+        /// </summary>
+        private static CuckooBloomFilter FilledCuckoo(int? seed)
+        {
+            var f = new CuckooBloomFilter(100, 0.01, seed: seed);
+            for (int i = 0; i < 3000; i++)
+            {
+                f.Add(Key($"w{i}"));
+            }
+
+            return f;
+        }
+
+        [TestMethod]
+        public void TestTheSameSeedGivesTheSameStableFilter()
+        {
+            Assert.AreEqual(Fingerprint(FilledStable(7)), Fingerprint(FilledStable(7)));
+        }
+
+        [TestMethod]
+        public void TestADifferentSeedGivesADifferentStableFilter()
+        {
+            Assert.AreNotEqual(Fingerprint(FilledStable(7)), Fingerprint(FilledStable(8)),
+                "the seed made no difference, so the random decrements are not being seeded");
+        }
+
+        [TestMethod]
+        public void TestTheSameSeedGivesTheSameCuckooFilter()
+        {
+            Assert.AreEqual(Fingerprint(FilledCuckoo(7)), Fingerprint(FilledCuckoo(7)));
+        }
+
+        [TestMethod]
+        public void TestADifferentSeedGivesADifferentCuckooFilter()
+        {
+            Assert.AreNotEqual(Fingerprint(FilledCuckoo(7)), Fingerprint(FilledCuckoo(8)),
+                "the seed made no difference, so the eviction choice is not being seeded");
+        }
+
+        /// <summary>
+        /// Leaving the seed out still gives an unpredictable filter, so seeding is a
+        /// thing a caller asks for rather than something they now have by default.
+        /// </summary>
+        [TestMethod]
+        public void TestOmittingTheSeedLeavesTheFilterUnpredictable()
+        {
+            var fingerprints = Enumerable.Range(0, 4)
+                .Select(_ => Fingerprint(FilledStable(null)))
+                .Distinct()
+                .Count();
+
+            Assert.IsGreaterThan(1, fingerprints,
+                "four unseeded filters over 3000 adds came out identical");
+        }
+
+        /// <summary>
+        /// A seeded filter still behaves like the filter it is. Seeding fixes which
+        /// cells are decremented, not whether the decay happens.
+        /// </summary>
+        [TestMethod]
+        public void TestSeedingDoesNotChangeWhatTheFilterDoes()
+        {
+            var seeded = FilledStable(7);
+            var unseeded = FilledStable(null);
+
+            // The stable filter forgets: after 3000 adds into 1000 cells, the earliest
+            // items are gone from both, and the most recent are in both.
+            Assert.IsFalse(seeded.Test(Key("w0")), "seeded filter should have forgotten w0");
+            Assert.IsFalse(unseeded.Test(Key("w0")), "unseeded filter should have forgotten w0");
+            Assert.IsTrue(seeded.Test(Key("w2999")), "seeded filter should hold the newest item");
+            Assert.IsTrue(unseeded.Test(Key("w2999")), "unseeded filter should hold the newest item");
+
+            // Their stable points agree, being a function of the parameters rather than
+            // of the choices made along the way.
+            Assert.AreEqual(unseeded.StablePoint(), seeded.StablePoint());
+        }
+
+        /// <summary>
+        /// And a seeded cuckoo filter keeps its guarantee: everything it accepted is
+        /// still findable, however the evictions fell out.
+        /// </summary>
+        [TestMethod]
+        public void TestASeededCuckooFilterStillFindsWhatItAccepted()
+        {
+            var f = new CuckooBloomFilter(100, 0.01, seed: 7);
+
+            var accepted = new System.Collections.Generic.List<string>();
+            for (int i = 0; i < 3000; i++)
+            {
+                if (f.Add(Key($"w{i}")))
+                {
+                    accepted.Add($"w{i}");
+                }
+            }
+
+            Assert.IsGreaterThan(0, accepted.Count);
+            foreach (var word in accepted)
+            {
+                Assert.IsTrue(f.Test(Key(word)), $"{word} was accepted and cannot be found");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two things, both about a structure being determined by what it was built with rather than
by what happens to it afterwards. Closes #1, and answers #4.

## The defect

`SetHash` on a populated structure destroyed it, silently:

```
before SetHash: 500/500 found, Count()=500
after  SetHash:   0/500 found, Count()=500
```

Everything stored had been placed by the hash in use at the time, and replacing that hash
moves none of it — every lookup goes somewhere else. Nothing raised. **The filter did not
look broken, it looked empty.**

That is the same failure the persistence format was built to refuse, and it was reachable
at runtime the whole time.

It now throws `InvalidOperationException` unless the structure holds nothing, which is the
only state the call was ever safe in. Emptiness is *derived* from what a structure holds
rather than tracked, so one read back from a payload is not mistaken for untouched.

## Hash at construction (#1)

An optional trailing parameter, so existing calls are unchanged:

```C#
var filter = new BloomFilter(10000, 0.01, hash: myHashFunction);
```

A scalable filter carries it to the filters it adds **as it grows**, rather than setting
it on them afterwards — which removes the unsafe window entirely rather than guarding it.
A top-k passes it to its sketch.

## Seeding (the second item)

`StableBloomFilter` and `CuckooBloomFilter` make random choices as part of what they are —
one decrements randomly chosen cells to make room, the other evicts a randomly chosen
entry when both of an item's buckets are full. Both drew from an unseeded generator, so
neither could be asserted against, only described.

```C#
var filter = new StableBloomFilter(10000, 2, 0.01, seed: 42);
```

Omitting it still seeds unpredictably. This is also why those two structures' format
fixtures could only be checked on reading, while every other structure's could be checked
byte for byte.

### One thing worth knowing about the cuckoo filter

**Its eviction path does not run anywhere near its stated capacity.** A filter asked for
100 items gets 1024 buckets of 4, so 395 items never reach the random choice at all — a
seeded test at that load asserts nothing and passes. It took 1000+ before the seed made
any difference. The tests here use 3000. Recording it because the next person to test that
path will hit the same thing.

## About #4

`SetHash` should **not** go on `IFilter`. It is now valid only before anything has been
added, and an interface method that throws for most of an object's life advertises itself
as the normal way to do something it is not. Constructor injection is the answer to what
#4 was asking for. Happy to close it on that reasoning.

## Verification

**257 tests.** That the constructor hash is actually held is checked by reading the hash id
out of a written payload — exact, rather than inferred from behavior — across all twelve
structures including both composites. Seeding is checked both ways: same seed reproduces,
different seed diverges, no seed stays unpredictable, and a seeded filter still behaves
like the filter it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9
