### PR TITLE
Index TopK's heap instead of scanning it (closes #7)

### DIFF
--- a/Benchmarks/TopKBenchmarks.cs
+++ b/Benchmarks/TopKBenchmarks.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using ProbabilisticDataStructures;
+
+namespace Benchmarks
+{
+    /// <summary>
+    /// Adds into a top-k across a range of k. Deciding whether an arriving element is
+    /// already held used to be a scan of the whole heap, which is the only cost here
+    /// that grows with k; this is what shows whether it still does.
+    /// <para>
+    /// The stream cycles through more distinct keys than the heap can hold, so every
+    /// key keeps the same frequency as every other. That keeps isTop true and sends
+    /// every add through to the lookup, which is the path in question. A stream with a
+    /// heavy head instead is rejected at isTop most of the time and never reaches it.
+    /// </para>
+    /// </summary>
+    [MemoryDiagnoser]
+    public class TopKAddBenchmarks
+    {
+        private const int Batch = 200_000;
+        private const int DistinctKeys = 20_000;
+
+        private byte[][] _keys = null!;
+        private TopK _topK = null!;
+        private int _cursor;
+
+        [Params(10, 100, 1_000, 5_000)]
+        public uint K { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _keys = new byte[DistinctKeys][];
+            for (int i = 0; i < DistinctKeys; i++)
+            {
+                // Long enough that comparing two of them costs something, as the keys
+                // a caller actually has do.
+                _keys[i] = Encoding.ASCII.GetBytes(
+                    $"entity-identifier-{i:D6}-with-realistic-length");
+            }
+        }
+
+        /// <summary>
+        /// A fresh structure per iteration, filled past k so the heap is full and the
+        /// lookup is doing the work it would in a running system. OperationsPerInvoke
+        /// divides by the batch, so the reported figure is per add and the setup stays
+        /// out of the measurement.
+        /// </summary>
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _topK = new TopK(0.0001, 0.001, K);
+            _cursor = 0;
+
+            for (int i = 0; i < K * 2 && i < DistinctKeys; i++)
+            {
+                _topK.Add(_keys[i]);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Batch)]
+        public void Add()
+        {
+            for (int i = 0; i < Batch; i++)
+            {
+                _topK.Add(_keys[_cursor++ % DistinctKeys]);
+            }
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - Unreleased
+
+### Changed
+
+- **`TopK.Add` no longer costs more as `k` grows**, which is
+  [#7](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/7). Deciding
+  whether an arriving element was already held meant comparing its data against every
+  element in the heap. That was the only cost here that scaled with `k`, and past a few
+  hundred it was most of what an add did. The heap is now indexed by element data.
+
+  | k | before | after |
+  | --- | --- | --- |
+  | 10 | 32.71 ns | 35.81 ns |
+  | 100 | 33.71 ns | 35.35 ns |
+  | 1000 | 194.92 ns | 56.70 ns |
+  | 5000 | 4153.29 ns | 82.44 ns |
+
+  Measured over a stream that cycles through more distinct keys than the heap holds, so
+  every add reaches the lookup rather than being turned away before it. A stream with a
+  heavy head is rejected earlier and never reached this. Small `k` pays about three
+  nanoseconds for hashing a key instead of comparing a handful, which is the trade.
+  Allocation is unchanged.
+
+  Behavior is unchanged, including the exact bytes a top-k writes.
+
 ## [4.0.0] - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.1] - Unreleased
+## [4.0.1] - 2026-08-14
 
 ### Changed
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          lived nowhere in the repo: AppVeyor patched AssemblyInfo.cs at build time from
          its own build counter, which is how the published package version (1.0.1) and
          the GitHub release tags (v1.0.9) drifted apart. -->
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/ProbabilisticDataStructures/ElementHeap.cs
+++ b/ProbabilisticDataStructures/ElementHeap.cs
@@ -1,88 +1,84 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace ProbabilisticDataStructures
 {
+    /// <summary>
+    /// A binary min-heap of elements ordered by frequency, with the least frequent at
+    /// the root, alongside an index from an element's data to where it sits.
+    /// </summary>
+    /// <remarks>
+    /// The root is what an arriving element is compared against and what gets evicted
+    /// when the heap is full, so the ordering has to hold after every operation. Both
+    /// operations that maintain it were wrong before 3.1.0: extraction removed the root
+    /// with List.Remove, which slides the array rather than reordering it, and raising
+    /// an element's frequency did not re-order at all.
+    /// <para>
+    /// The index exists because deciding whether an arriving element is already held
+    /// was a scan of the whole heap, comparing its data against every element's. That
+    /// is the cost that grows with k while nothing else here does: measured on a stream
+    /// where every arrival reaches this code, it was around 0.47 ns per element held,
+    /// which at k = 1000 was most of the time an add took.
+    /// </para>
+    /// </remarks>
     internal class ElementHeap
     {
         internal List<Element> Heap { get; set; }
 
         /// <summary>
-        /// Create a new ElementHeap that can store the top-k elements.
+        /// Where each element sits in <see cref="Heap"/>, kept in step with it by every
+        /// operation that moves an element.
         /// </summary>
-        /// <param name="k">The number of top elements to track</param>
+        private readonly Dictionary<byte[], int> positions;
+
         internal ElementHeap(int k)
         {
             this.Heap = new List<Element>(k);
+            this.positions = new Dictionary<byte[], int>(k, ByteArrayComparer.Instance);
         }
 
-        /// <summary>
-        /// Get the count of the number of items on the heap.
-        /// </summary>
-        /// <returns>The number of items on the heap</returns>
         internal int Len()
         {
             return this.Heap.Count;
         }
 
-        /// <summary>
-        /// Return whether or not the item at i-position on the heap is less than the
-        /// item at j-position.
-        /// </summary>
-        /// <param name="i">Item 1</param>
-        /// <param name="j">Item 2</param>
-        /// <returns>
-        /// Whether or not the item at i-position on the heap is less than the item at
-        /// j-position.
-        /// </returns>
         internal bool Less(int i, int j)
         {
             return this.Heap[i].Freq < this.Heap[j].Freq;
         }
 
-        /// <summary>
-        /// Swap the items at i-position and j-position on the heap.
-        /// </summary>
-        /// <param name="i">Item 1</param>
-        /// <param name="j">Item 2</param>
         internal void Swap(int i, int j)
         {
             var temp = this.Heap[i];
             Heap[i] = Heap[j];
             Heap[j] = temp;
+
+            // The index follows the elements. Every path that reorders the heap goes
+            // through here, which is what keeps the two from drifting apart.
+            this.positions[this.Heap[i].Data] = i;
+            this.positions[this.Heap[j].Data] = j;
         }
 
-        /// <summary>
-        /// Push an Element onto the heap.
-        /// </summary>
-        /// <param name="e">The Element to push onto the heap</param>
         internal void Push(Element e)
         {
             this.Heap.Add(e);
+            this.positions[e.Data] = this.Len() - 1;
             this.Up(this.Len() - 1);
         }
 
-        /// <summary>
-        /// Remove the Element at the top of the heap.
-        /// </summary>
-        /// <returns>The Element that was removed</returns>
         internal Element Pop()
         {
-            // Removing the root by List.Remove shifts every later element down one
-            // position, which is not a heap operation: the array that comes back is
-            // the old one slid left, and its parent/child relationships are whatever
-            // that shift happened to produce. The heap has no minimum at the root
-            // afterwards, so the next Pop evicts an arbitrary element.
-            //
-            // Extraction is instead the standard three steps -- take the root, move
-            // the last element into its place, and sift that element down until the
-            // ordering holds again. Down existed for this and was never called.
+            // Standard extraction: take the root, move the last element into its place,
+            // and sift that element back down. Removing the root directly would slide
+            // every later element down a position, which is not a heap operation and
+            // leaves no minimum at the root.
             var min = this.Heap[0];
             var last = this.Len() - 1;
 
             this.Swap(0, last);
             this.Heap.RemoveAt(last);
+            this.positions.Remove(min.Data);
             this.Down(0, this.Len());
 
             return min;
@@ -109,7 +105,7 @@ namespace ProbabilisticDataStructures
                 var j1 = 2 * i + 1;
                 if (j1 >= n || j1 < 0)
                 {
-                    // j1 < - after int overflow
+                    // j1 < 0 after int overflow
                     break;
                 }
                 var j = j1; // left child
@@ -127,48 +123,31 @@ namespace ProbabilisticDataStructures
             }
         }
 
-        /// <summary>
-        /// Returns the top-k elements from lowest to highest frequency.
-        /// </summary>
-        /// <returns>The top-k elements from lowest to highest frequency</returns>
         internal Element[] Elements()
         {
             if (this.Len() == 0)
             {
                 return new Element[0];
             }
-
             return this.Heap
                 .OrderBy(x => x.Freq)
                 .ToArray();
         }
 
-        /// <summary>
-        /// Adds the data to the top-k heap. If the data is already an element, the
-        /// frequency is updated. If the heap already has k elements, the element with
-        /// the minimum frequency is removed.
-        /// </summary>
-        /// <param name="data">The data to insert</param>
-        /// <param name="freq">The frequency to associate with the data</param>
-        /// <param name="k">The maximum number of elements the heap may hold</param>
         internal void insert(byte[] data, UInt64 freq, uint k)
         {
-            for (int i = 0; i < this.Len(); i++)
+            if (this.positions.TryGetValue(data, out var index))
             {
-                var element = this.Heap[i];
-                if (Enumerable.SequenceEqual(data, element.Data))
-                {
-                    // Element already in top-k. Raising its frequency in place leaves
-                    // it possibly greater than a child's, so the ordering has to be
-                    // restored or the root stops being the minimum -- and the root is
-                    // what isTop compares against and what Pop evicts.
-                    //
-                    // Sifting down is enough: a frequency read from the sketch only
-                    // ever grows, so an updated element can only sink.
-                    element.Freq = freq;
-                    this.Down(i, this.Len());
-                    return;
-                }
+                // Element already in top-k. Raising its frequency in place leaves it
+                // possibly greater than a child's, so the ordering has to be restored
+                // or the root stops being the minimum -- and the root is both what
+                // isTop compares against and what Pop evicts.
+                //
+                // Sifting down is enough: a frequency read from the sketch only ever
+                // grows, so an updated element can only sink.
+                this.Heap[index].Freq = freq;
+                this.Down(index, this.Len());
+                return;
             }
 
             if (this.Len() == k)
@@ -179,7 +158,8 @@ namespace ProbabilisticDataStructures
 
             // Add element to top-k. The data is copied rather than retained: it is
             // handed back to callers through Elements(), and a caller reusing the
-            // buffer they added from would otherwise rewrite every entry in the heap.
+            // buffer they added from would otherwise rewrite every entry in the heap
+            // and every key in the index along with them.
             this.Push(new Element
             {
                 Data = (byte[])data.Clone(),
@@ -187,20 +167,35 @@ namespace ProbabilisticDataStructures
             });
         }
 
-        /// <summary>
-        /// Indicates if the given frequency falls within the top-k heap.
-        /// </summary>
-        /// <param name="freq">The frequency to check</param>
-        /// <param name="k">The maximum number of elements the heap may hold</param>
-        /// <returns>Whether or not the frequency falls within the top-k heap</returns>
         internal bool isTop(UInt64 freq, uint k)
         {
             if (this.Len() < k)
             {
                 return true;
             }
-
             return freq >= this.Heap[0].Freq;
+        }
+
+        /// <summary>
+        /// Compares byte arrays by their contents, which is what identifies an element
+        /// here. The default comparer would compare references, so an element added
+        /// twice from two arrays holding the same bytes would be held twice.
+        /// </summary>
+        private sealed class ByteArrayComparer : IEqualityComparer<byte[]>
+        {
+            internal static readonly ByteArrayComparer Instance = new ByteArrayComparer();
+
+            public bool Equals(byte[]? x, byte[]? y)
+            {
+                return x.AsSpan().SequenceEqual(y.AsSpan());
+            }
+
+            public int GetHashCode(byte[] obj)
+            {
+                var hash = new HashCode();
+                hash.AddBytes(obj);
+                return hash.ToHashCode();
+            }
         }
     }
 }

--- a/TestProbabilisticDataStructures/TestFilterSemantics.cs
+++ b/TestProbabilisticDataStructures/TestFilterSemantics.cs
@@ -377,6 +377,73 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// The heap is indexed by element data so that deciding whether an arrival is
+        /// already held does not mean scanning it. That index has to stay in step with
+        /// the heap through every reordering, and the way it can quietly fail is an
+        /// entry left behind for an element that was evicted: a later arrival of the
+        /// same data would then be found at a position holding something else.
+        /// <para>
+        /// Churning far more distinct elements than the heap can hold, so eviction and
+        /// re-arrival happen constantly, and asserting what drift would break.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestTopKHoldsEachElementOnceUnderChurn()
+        {
+            const uint k = 20;
+            var topK = new TopK(0.001, 0.01, k);
+            var rand = new Random(3);
+
+            for (int i = 0; i < 50000; i++)
+            {
+                // A small enough pool that elements are evicted and come back, which is
+                // the case a stale index entry would corrupt.
+                topK.Add(Key($"e{rand.Next(200)}"));
+            }
+
+            var elements = topK.Elements();
+
+            Assert.IsLessThanOrEqualTo((int)k, elements.Length,
+                "the heap holds more than k elements");
+
+            var distinct = elements
+                .Select(e => Encoding.ASCII.GetString(e.Data))
+                .Distinct()
+                .Count();
+
+            Assert.AreEqual(elements.Length, distinct,
+                "the same element is held more than once");
+
+            // Still ordered, which a misplaced update would break.
+            var freqs = elements.Select(e => e.Freq).ToArray();
+            CollectionAssert.AreEqual(freqs.OrderBy(f => f).ToArray(), freqs,
+                "Elements() is no longer ascending by frequency");
+        }
+
+        /// <summary>
+        /// Elements are identified by what their data holds, not by which array it
+        /// arrived in. Indexing on the array itself would hold the same element twice
+        /// for a caller who does not reuse one buffer.
+        /// </summary>
+        [TestMethod]
+        public void TestTopKIdentifiesElementsByContentNotByArray()
+        {
+            var topK = new TopK(0.001, 0.01, 10);
+
+            for (int i = 0; i < 50; i++)
+            {
+                // A fresh array holding the same bytes every time.
+                topK.Add(Encoding.ASCII.GetBytes("recurring"));
+            }
+
+            var elements = topK.Elements();
+
+            Assert.HasCount(1, elements);
+            Assert.AreEqual("recurring", Encoding.ASCII.GetString(elements[0].Data));
+            Assert.AreEqual(50ul, elements[0].Freq);
+        }
+
+        /// <summary>
         /// The inverse filter is a bounded "recently seen" cache rather than a growing
         /// set: an element whose slot is claimed by a later one is forgotten. False
         /// negatives are therefore expected here, which is the opposite of every other


### PR DESCRIPTION
Closes #7.

The heap became a real one in 3.1.0, when extraction stopped removing the root with
`List.Remove` and updates started re-ordering. What was left of the original complaint is
how membership was decided: **an arriving element was compared against every element in
the heap, one at a time.** That was the only cost here that grew with `k`.

The heap is now indexed by element data, so the question is asked once.

| k | before | after | |
| --- | ---: | ---: | --- |
| 10 | 32.71 ns | 35.81 ns | +3.1 ns |
| 100 | 33.71 ns | 35.35 ns | +1.6 ns |
| 1000 | 194.92 ns | 56.70 ns | **3.4× faster** |
| 5000 | 4153.29 ns | 82.44 ns | **50× faster** |

Allocation unchanged. Behavior unchanged, including the exact bytes a top-k writes — the
format fixture from 3.2.0 still matches byte for byte.

## On the benchmark, because it nearly fooled me

The measurement only means anything if adds actually reach the lookup. A stream with a
heavy head is turned away at `isTop` before it ever gets there, and **my first benchmark
was that shape and showed no trend at all** — 299, 303, 456, 266, 301, 795 ns across
increasing `k`. I briefly took that as evidence there was nothing to fix.

The suite here cycles through more distinct keys than the heap can hold, so every key
keeps the same frequency as every other, `isTop` stays true, and every add goes through.

Second trap: at a 10,000-add batch the numbers had standard deviations of 70–87 ns on
means of 95–107 ns, and appeared to show a 5× regression at small `k`. At 200,000 the
standard deviation is under 1 ns and the real figure is +1.6 ns. The apparent regression
was entirely noise.

## Why not `PriorityQueue<TElement, TPriority>`

It has no way to update an element's priority, which is exactly what a top-k does on
every repeat arrival. An indexed heap is the structure this needs.

## Tests

Two added, and **they pass against the old scan too** — that is the point. They describe
what both implementations owe, and exist so the index cannot quietly drift from the heap.
Deleting the one line that removes an evicted element from the index fails both.

- elements are held once each under heavy eviction and re-arrival
- elements are identified by content, not by which array they arrived in

**259 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9
