### PR TITLE
Merge for the Bloom family, CountingBloomFilter and TopK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.0] - Unreleased
+## [5.1.0] - 2026-08-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - Unreleased
+
+### Added
+
+- **`Merge` on `BloomFilter`, `BloomFilter64` and `PartitionedBloomFilter`**, which is
+  [#53](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/53). Two
+  filters with the same dimensions and hash union by OR-ing their bit arrays, giving
+  exactly the filter that adding everything to one of them would have produced.
+
+  Verified by building 20,000 elements across 8 shards and merging: **zero disagreements
+  with a single filter built from all of them, over 200,000 absent keys**, and the same
+  measured false positive rate.
+
+  The item count becomes the sum, which overstates the union whenever the inputs shared
+  elements. There is no way to know how many they shared, so a merged filter's count is
+  an upper bound.
+
+- **`Merge` on `CountingBloomFilter`**, which is
+  [#54](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/54). Counters
+  add rather than max, so a merged filter is removable from as many times as its inputs
+  together were. Sums hold at the counter maximum, which keeps the rule 3.1.0
+  established -- a saturated counter is never decremented -- and means merging can make
+  an element permanently unremovable when neither input had.
+
+- **`Merge` on `TopK`**, which is
+  [#55](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/55).
+  Frequencies are re-read from the merged sketch rather than added, since each
+  structure's recorded frequency is what its own sketch last told it and adding them
+  double-counts everything both already knew.
+
+  A merged top-k is not necessarily the true top-k of the combined stream: only elements
+  one of the heaps was holding are candidates, so an element frequent in both but top in
+  neither stays invisible. That is inherent to merging bounded summaries, and there is a
+  test pinning it.
+
+### Fixed
+
+- **`CountMinSketch.Merge` and `HyperLogLog.Merge` check that both were built with the
+  same hash function.** Neither did. Everything a structure holds sits where its own hash
+  put it, so merging two that hash differently produced something answering confidently
+  about positions neither meant -- and nothing about the result looked wrong afterwards.
+
+  `HyperLogLog.Merge` also rejects null rather than throwing `NullReferenceException`.
+
+### Notes
+
+Delegates compare by method and target, so the default hash, a method group, and one
+delegate passed to both constructors all compare equal. Two separately written lambdas
+with identical bodies do not, and are refused: pass one hash function to both structures
+rather than writing it out twice.
+
+The new methods return the receiver so calls can chain, following `Add` and `Reset`.
+`CountMinSketch.Merge` and `HyperLogLog.Merge` return a `bool` that is always `true`,
+which is left alone rather than changed under anyone.
+
 ## [5.0.0] - 2026-08-14
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          lived nowhere in the repo: AppVeyor patched AssemblyInfo.cs at build time from
          its own build counter, which is how the published package version (1.0.1) and
          the GitHub release tags (v1.0.9) drifted apart. -->
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/ProbabilisticDataStructures/BloomFilter.cs
+++ b/ProbabilisticDataStructures/BloomFilter.cs
@@ -293,6 +293,45 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Combines another filter into this one, so that it holds everything both held.
+        /// </summary>
+        /// <param name="other">The filter to combine in.</param>
+        /// <returns>This filter, so calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="other"/> is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// The two were built with different dimensions or different hash functions, so
+        /// their contents do not describe the same positions.
+        /// </exception>
+        /// <remarks>
+        /// The result is exactly what adding everything to one of them would have
+        /// produced, so the false positive rate is that of a filter holding the union
+        /// rather than either input's.
+        /// <para>
+        /// The item count becomes the sum, which overstates the union whenever the two
+        /// shared elements. There is no way to know how many they shared, so the count
+        /// of a merged filter is an upper bound.
+        /// </para>
+        /// </remarks>
+        public BloomFilter Merge(BloomFilter other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
+
+            if (this.m != other.m || this.k != other.k)
+            {
+                throw new ArgumentException(
+                    $"Cannot merge a filter of {other.m} bits and {other.k} hash " +
+                    $"functions into one of {this.m} and {this.k}. The two describe " +
+                    "different positions.", nameof(other));
+            }
+
+            Guard.SameHashFunction(this.Hash, other.Hash, nameof(other));
+
+            this.Buckets.Union(other.Buckets);
+            this.count += other.count;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
         /// <param name="h">The hash function to use.</param>

--- a/ProbabilisticDataStructures/BloomFilter64.cs
+++ b/ProbabilisticDataStructures/BloomFilter64.cs
@@ -291,6 +291,45 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Combines another filter into this one, so that it holds everything both held.
+        /// </summary>
+        /// <param name="other">The filter to combine in.</param>
+        /// <returns>This filter, so calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="other"/> is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// The two were built with different dimensions or different hash functions, so
+        /// their contents do not describe the same positions.
+        /// </exception>
+        /// <remarks>
+        /// The result is exactly what adding everything to one of them would have
+        /// produced, so the false positive rate is that of a filter holding the union
+        /// rather than either input's.
+        /// <para>
+        /// The item count becomes the sum, which overstates the union whenever the two
+        /// shared elements. There is no way to know how many they shared, so the count
+        /// of a merged filter is an upper bound.
+        /// </para>
+        /// </remarks>
+        public BloomFilter64 Merge(BloomFilter64 other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
+
+            if (this.m != other.m || this.k != other.k)
+            {
+                throw new ArgumentException(
+                    $"Cannot merge a filter of {other.m} bits and {other.k} hash " +
+                    $"functions into one of {this.m} and {this.k}. The two describe " +
+                    "different positions.", nameof(other));
+            }
+
+            Guard.SameHashFunction(this.Hash, other.Hash, nameof(other));
+
+            this.Buckets.Union(other.Buckets);
+            this.count += other.count;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
         /// <param name="h">The hash function to use.</param>

--- a/ProbabilisticDataStructures/Buckets.cs
+++ b/ProbabilisticDataStructures/Buckets.cs
@@ -176,6 +176,78 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Sets every bucket to the larger of its own value and the matching bucket in
+        /// <paramref name="other"/>.
+        /// </summary>
+        /// <remarks>
+        /// For single-bit buckets this is a bitwise OR, which is what unioning two
+        /// Bloom filters means. For wider ones it takes the maximum rather than the
+        /// sum, which is what a set union wants: a bucket records whether something
+        /// landed there, not how many times.
+        /// </remarks>
+        internal Buckets Union(Buckets other)
+        {
+            if (this.count != other.count || this.bucketSize != other.bucketSize)
+            {
+                throw new ArgumentException(
+                    $"Cannot union {this.count} buckets of {this.bucketSize} bits with " +
+                    $"{other.count} of {other.bucketSize}.", nameof(other));
+            }
+
+            if (this.bucketSize == 1)
+            {
+                // The common case, and worth taking whole bytes at a time rather than
+                // one bit at a time.
+                for (int i = 0; i < this.Data.Length; i++)
+                {
+                    this.Data[i] |= other.Data[i];
+                }
+
+                return this;
+            }
+
+            for (uint i = 0; i < this.count; i++)
+            {
+                var theirs = other.Get(i);
+                if (theirs > this.Get(i))
+                {
+                    this.Set(i, (byte)theirs);
+                }
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds each of <paramref name="other"/>'s counters to its counterpart, holding
+        /// at the maximum a bucket can carry.
+        /// </summary>
+        /// <remarks>
+        /// A counter that reaches its maximum has stopped tracking how many elements it
+        /// stands for and is never decremented again, which is what keeps a counting
+        /// filter's deletions from producing false negatives. Adding two filters can
+        /// carry a counter over that line when neither was near it, and the clamp is
+        /// what keeps the invariant.
+        /// </remarks>
+        internal Buckets Add(Buckets other)
+        {
+            if (this.count != other.count || this.bucketSize != other.bucketSize)
+            {
+                throw new ArgumentException(
+                    $"Cannot add {this.count} buckets of {this.bucketSize} bits to " +
+                    $"{other.count} of {other.bucketSize}.", nameof(other));
+            }
+
+            for (uint i = 0; i < this.count; i++)
+            {
+                var sum = this.Get(i) + other.Get(i);
+                this.Set(i, sum > this._max ? this._max : (byte)sum);
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Restores the Buckets to the original state. Returns itself to allow for
         /// chaining.
         /// </summary>

--- a/ProbabilisticDataStructures/Buckets64.cs
+++ b/ProbabilisticDataStructures/Buckets64.cs
@@ -208,6 +208,46 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Sets every bucket to the larger of its own value and the matching bucket in
+        /// <paramref name="other"/>. See <see cref="Buckets.Union"/>.
+        /// </summary>
+        internal Buckets64 Union(Buckets64 other)
+        {
+            if (this.count != other.count || this.bucketSize != other.bucketSize)
+            {
+                throw new ArgumentException(
+                    $"Cannot union {this.count} buckets of {this.bucketSize} bits with " +
+                    $"{other.count} of {other.bucketSize}.", nameof(other));
+            }
+
+            if (this.bucketSize == 1)
+            {
+                for (int a = 0; a < this.Data.Length; a++)
+                {
+                    var mine = this.Data[a];
+                    var theirs = other.Data[a];
+                    for (int i = 0; i < mine.Length; i++)
+                    {
+                        mine[i] |= theirs[i];
+                    }
+                }
+
+                return this;
+            }
+
+            for (ulong i = 0; i < this.count; i++)
+            {
+                var theirs = other.Get(i);
+                if (theirs > this.Get(i))
+                {
+                    this.Set(i, (byte)theirs);
+                }
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Restores the Buckets64 to the original state. Returns itself to allow for
         /// chaining.
         /// </summary>

--- a/ProbabilisticDataStructures/CountMinSketch.cs
+++ b/ProbabilisticDataStructures/CountMinSketch.cs
@@ -179,6 +179,8 @@ namespace ProbabilisticDataStructures
         {
             ArgumentNullException.ThrowIfNull(other);
 
+            Guard.SameHashFunction(this.Hash, other.Hash, nameof(other));
+
             // ArgumentException rather than Exception: a caller who wants to fall back
             // to merging some other way cannot catch the bare one without catching
             // every unrelated failure alongside it.

--- a/ProbabilisticDataStructures/CountingBloomFilter.cs
+++ b/ProbabilisticDataStructures/CountingBloomFilter.cs
@@ -358,6 +358,57 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Combines another filter into this one, adding its counters to their
+        /// counterparts.
+        /// </summary>
+        /// <param name="other">The filter to combine in.</param>
+        /// <returns>This filter, so calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="other"/> is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// The two were built with different dimensions, different counter widths, or
+        /// different hash functions.
+        /// </exception>
+        /// <remarks>
+        /// Counters are added rather than maxed, since a counting filter records how
+        /// many elements landed on each position and a merged filter has to be
+        /// removable from as many times as the two inputs together were.
+        /// <para>
+        /// Sums hold at the maximum a counter can carry. That matters more here than
+        /// elsewhere: a counter which reaches its maximum is never decremented again,
+        /// because it has stopped tracking what it stands for and resuming from the
+        /// ceiling produces false negatives. Merging can carry a counter over that line
+        /// when neither input was near it, so a merged filter can hold elements that
+        /// are permanently unremovable when neither input did. Wider counters saturate
+        /// later.
+        /// </para>
+        /// </remarks>
+        public CountingBloomFilter Merge(CountingBloomFilter other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
+
+            if (this.m != other.m || this.k != other.k)
+            {
+                throw new ArgumentException(
+                    $"Cannot merge a filter of {other.m} counters and {other.k} hash " +
+                    $"functions into one of {this.m} and {this.k}. The two describe " +
+                    "different positions.", nameof(other));
+            }
+
+            if (this.Buckets.BucketSize != other.Buckets.BucketSize)
+            {
+                throw new ArgumentException(
+                    $"Cannot merge {other.Buckets.BucketSize}-bit counters into " +
+                    $"{this.Buckets.BucketSize}-bit ones.", nameof(other));
+            }
+
+            Guard.SameHashFunction(this.Hash, other.Hash, nameof(other));
+
+            this.Buckets.Add(other.Buckets);
+            this.count += other.count;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
         /// <param name="h">The hash function to use.</param>

--- a/ProbabilisticDataStructures/Guard.cs
+++ b/ProbabilisticDataStructures/Guard.cs
@@ -52,6 +52,38 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Two structures can only be combined if they hash the same way.
+        /// </summary>
+        /// <remarks>
+        /// Everything a structure holds sits where its hash function put it, so
+        /// combining two that hash differently produces something that answers
+        /// confidently about positions neither of them meant. Nothing about the result
+        /// looks wrong afterwards, which is why this is checked rather than documented.
+        /// <para>
+        /// Delegates compare by method and target, so two conversions of the same
+        /// method -- including the default, and including one passed to both
+        /// constructors -- are equal. Two separately written lambdas with identical
+        /// bodies are not, and are refused: the fix is to pass one hash function to
+        /// both structures rather than to write it twice.
+        /// </para>
+        /// </remarks>
+        internal static void SameHashFunction(
+            Func<ReadOnlySpan<byte>, ulong> first,
+            Func<ReadOnlySpan<byte>, ulong> second,
+            string paramName)
+        {
+            if (!first.Equals(second))
+            {
+                throw new ArgumentException(
+                    "The two structures use different hash functions. Everything each " +
+                    "one holds sits where its own hash put it, so combining them would " +
+                    "produce a structure that answers about positions neither of them " +
+                    "meant. Build both with the same hash function -- passing the same " +
+                    "one to each, rather than writing it out twice.", paramName);
+            }
+        }
+
+        /// <summary>
         /// A structure's hash function can only be replaced while it holds nothing.
         /// </summary>
         /// <remarks>

--- a/ProbabilisticDataStructures/HyperLogLog.cs
+++ b/ProbabilisticDataStructures/HyperLogLog.cs
@@ -205,10 +205,14 @@ namespace ProbabilisticDataStructures
         /// <returns>Whether or not the merge was successful</returns>
         public bool Merge(HyperLogLog other)
         {
+            ArgumentNullException.ThrowIfNull(other);
+
             if (this.M != other.M)
             {
-                throw new ArgumentException("Number of registers must match");
+                throw new ArgumentException("Number of registers must match", nameof(other));
             }
+
+            Guard.SameHashFunction(this.Hash, other.Hash, nameof(other));
 
             for (int i = 0; i < other.Registers.Count(); i++)
             {

--- a/ProbabilisticDataStructures/PartitionedBloomFilter.cs
+++ b/ProbabilisticDataStructures/PartitionedBloomFilter.cs
@@ -367,6 +367,50 @@ namespace ProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Combines another filter into this one, so that it holds everything both held.
+        /// </summary>
+        /// <param name="other">The filter to combine in.</param>
+        /// <returns>This filter, so calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="other"/> is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// The two were built with different dimensions or different hash functions, so
+        /// their contents do not describe the same positions.
+        /// </exception>
+        /// <remarks>
+        /// The result is exactly what adding everything to one of them would have
+        /// produced, so the false positive rate is that of a filter holding the union
+        /// rather than either input's.
+        /// <para>
+        /// The item count becomes the sum, which overstates the union whenever the two
+        /// shared elements. There is no way to know how many they shared, so the count
+        /// of a merged filter is an upper bound. Partitions are unioned one against its
+        /// counterpart, so an element's bit stays in the partition its hash chose.
+        /// </para>
+        /// </remarks>
+        public PartitionedBloomFilter Merge(PartitionedBloomFilter other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
+
+            if (this.M != other.M || this.k != other.k || this.S != other.S)
+            {
+                throw new ArgumentException(
+                    $"Cannot merge a filter of {other.M} bits in {other.k} partitions of " +
+                    $"{other.S} into one of {this.M} in {this.k} of {this.S}. The two " +
+                    "describe different positions.", nameof(other));
+            }
+
+            Guard.SameHashFunction(this.Hash, other.Hash, nameof(other));
+
+            for (int i = 0; i < this.Partitions.Length; i++)
+            {
+                this.Partitions[i].Union(other.Partitions[i]);
+            }
+
+            this.count += other.count;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the hashing function used in the filter.
         /// </summary>
         /// <param name="h">The hash function to use.</param>

--- a/ProbabilisticDataStructures/TopK.cs
+++ b/ProbabilisticDataStructures/TopK.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
+using System.Collections.Generic;
 namespace ProbabilisticDataStructures
 {
     /// <summary>
@@ -66,6 +68,94 @@ namespace ProbabilisticDataStructures
         public Element[] Elements()
         {
             return elements.Elements();
+        }
+
+        /// <summary>
+        /// Combines another top-k into this one, over the union of what both were
+        /// tracking.
+        /// </summary>
+        /// <param name="other">The structure to combine in.</param>
+        /// <returns>This structure, so calls can be chained.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="other"/> is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// The two track a different number of elements, or their sketches were built
+        /// with different dimensions or different hash functions.
+        /// </exception>
+        /// <remarks>
+        /// Frequencies are re-read from the merged sketch rather than added together.
+        /// Each structure's recorded frequency is what its own sketch last told it,
+        /// and adding two of them counts twice everything both sketches already knew
+        /// about. The merged sketch is the only thing that knows the combined count.
+        /// <para>
+        /// A merged top-k is not necessarily the true top-k of the combined stream. An
+        /// element frequent in both but held by neither heap is not a candidate here,
+        /// and stays invisible -- the merged sketch knows its count, but nothing asks
+        /// the sketch about elements no heap was holding. This is inherent to merging
+        /// bounded summaries, not a shortcut taken here.
+        /// </para>
+        /// </remarks>
+        public TopK Merge(TopK other)
+        {
+            ArgumentNullException.ThrowIfNull(other);
+
+            if (this.K != other.K)
+            {
+                throw new ArgumentException(
+                    $"Cannot merge a top-{other.K} into a top-{this.K}.", nameof(other));
+            }
+
+            // Throws if the sketches disagree about dimensions or hashing, before
+            // anything here has been changed.
+            this.Cms.Merge(other.Cms);
+            this.N += other.N;
+
+            // Every element either was holding is a candidate, and no others can be:
+            // an element neither heap held is one neither considered frequent.
+            var candidates = new Dictionary<byte[], ulong>(ByteContentComparer.Instance);
+
+            foreach (var element in this.elements.Heap)
+            {
+                candidates[element.Data.ToArray()] = 0;
+            }
+
+            foreach (var element in other.elements.Heap)
+            {
+                candidates[element.Data.ToArray()] = 0;
+            }
+
+            var rebuilt = new ElementHeap((int)this.K);
+
+            foreach (var data in candidates.Keys
+                .OrderByDescending(d => this.Cms.Count(d))
+                .Take((int)this.K))
+            {
+                rebuilt.Push(new Element
+                {
+                    Data = data,
+                    Freq = this.Cms.Count(data),
+                });
+            }
+
+            this.elements = rebuilt;
+            return this;
+        }
+
+        /// <summary>
+        /// Compares candidate data by content, so that the same element held by both
+        /// structures is one candidate rather than two.
+        /// </summary>
+        private sealed class ByteContentComparer : IEqualityComparer<byte[]>
+        {
+            internal static readonly ByteContentComparer Instance = new ByteContentComparer();
+
+            public bool Equals(byte[]? x, byte[]? y) => x.AsSpan().SequenceEqual(y.AsSpan());
+
+            public int GetHashCode(byte[] obj)
+            {
+                var hash = new HashCode();
+                hash.AddBytes(obj);
+                return hash.ToHashCode();
+            }
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,32 @@ Packages are published to
 release is also tagged on the
 [releases page](https://github.com/mattlorimor/ProbabilisticDataStructures/releases).
 
+## Merging
+
+Filters built separately can be combined, which is what makes it possible to build them
+across shards or machines and put them together at the end:
+
+```C#
+var merged = shardA.Merge(shardB).Merge(shardC);
+```
+
+The result is exactly the filter that adding everything to one of them would have
+produced, so its false positive rate is that of a filter holding the union.
+
+Available on `BloomFilter`, `BloomFilter64`, `PartitionedBloomFilter`,
+`CountingBloomFilter`, `CountMinSketch`, `HyperLogLog` and `TopK`. Both structures must
+have the same dimensions **and the same hash function** — a merge of two that hash
+differently is refused, because the result would answer confidently about positions
+neither of them meant.
+
+Not available on `InverseBloomFilter` (a slot holds one element, so a merge would have to
+choose between them), `StableBloomFilter` (its contents are a function of the order things
+arrived in) or `CuckooBloomFilter` (fingerprints only combine when both filters happen to
+have placed them compatibly).
+
+A merged filter's `Count()` is the sum of its inputs', which overstates the union whenever
+they shared elements.
+
 ## Persistence
 
 Every structure can be written to a stream and read back.

--- a/TestProbabilisticDataStructures/TestMerge.cs
+++ b/TestProbabilisticDataStructures/TestMerge.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Merging is asserted against the filter you would have got by adding everything to
+    /// one of them, which is the promise. Comparing internal state instead would pass
+    /// for an implementation that combined the bits correctly and the bookkeeping wrong.
+    /// </summary>
+    [TestClass]
+    public class TestMerge
+    {
+        private static byte[] Key(string s) => Encoding.ASCII.GetBytes(s);
+
+        private static readonly string[] First =
+            Enumerable.Range(0, 500).Select(i => $"a-{i}").ToArray();
+
+        private static readonly string[] Second =
+            Enumerable.Range(0, 500).Select(i => $"b-{i}").ToArray();
+
+        private static readonly string[] Absent =
+            Enumerable.Range(0, 3000).Select(i => $"absent-{i}").ToArray();
+
+        [TestMethod]
+        public void TestBloomFilterMergeMatchesAddingEverythingToOne()
+        {
+            var left = new BloomFilter(2000, 0.01);
+            var right = new BloomFilter(2000, 0.01);
+            var combined = new BloomFilter(2000, 0.01);
+
+            foreach (var w in First) { left.Add(Key(w)); combined.Add(Key(w)); }
+            foreach (var w in Second) { right.Add(Key(w)); combined.Add(Key(w)); }
+
+            var merged = left.Merge(right);
+            Assert.AreSame(left, merged, "Merge returns the receiver, for chaining");
+
+            // Identical on every query, including the false positives: a filter that
+            // disagrees there is a different filter even where yes is permitted.
+            foreach (var w in First.Concat(Second).Concat(Absent))
+            {
+                Assert.AreEqual(combined.Test(Key(w)), left.Test(Key(w)),
+                    $"merged filter disagreed with the combined one about {w}");
+            }
+        }
+
+        [TestMethod]
+        public void TestBloomFilter64AndPartitionedMergeTheSameWay()
+        {
+            var left64 = new BloomFilter64(2000, 0.01);
+            var right64 = new BloomFilter64(2000, 0.01);
+            var combined64 = new BloomFilter64(2000, 0.01);
+
+            var leftP = new PartitionedBloomFilter(2000, 0.01);
+            var rightP = new PartitionedBloomFilter(2000, 0.01);
+            var combinedP = new PartitionedBloomFilter(2000, 0.01);
+
+            foreach (var w in First)
+            {
+                left64.Add(Key(w)); combined64.Add(Key(w));
+                leftP.Add(Key(w)); combinedP.Add(Key(w));
+            }
+            foreach (var w in Second)
+            {
+                right64.Add(Key(w)); combined64.Add(Key(w));
+                rightP.Add(Key(w)); combinedP.Add(Key(w));
+            }
+
+            left64.Merge(right64);
+            leftP.Merge(rightP);
+
+            foreach (var w in First.Concat(Second).Concat(Absent))
+            {
+                Assert.AreEqual(combined64.Test(Key(w)), left64.Test(Key(w)),
+                    $"merged BloomFilter64 disagreed about {w}");
+                Assert.AreEqual(combinedP.Test(Key(w)), leftP.Test(Key(w)),
+                    $"merged PartitionedBloomFilter disagreed about {w}");
+            }
+        }
+
+        /// <summary>
+        /// A counting filter's counters add rather than max, because a merged filter has
+        /// to be removable from as many times as the two inputs together were.
+        /// </summary>
+        [TestMethod]
+        public void TestCountingFilterMergeAddsCounters()
+        {
+            var left = new CountingBloomFilter(2000, 8, 0.01);
+            var right = new CountingBloomFilter(2000, 8, 0.01);
+            var combined = new CountingBloomFilter(2000, 8, 0.01);
+
+            // The same elements in both, so the counters genuinely have to sum.
+            foreach (var w in First)
+            {
+                left.Add(Key(w));
+                right.Add(Key(w));
+                combined.Add(Key(w));
+                combined.Add(Key(w));
+            }
+
+            left.Merge(right);
+
+            foreach (var w in First.Concat(Absent))
+            {
+                Assert.AreEqual(combined.Test(Key(w)), left.Test(Key(w)),
+                    $"merged filter disagreed about {w}");
+            }
+
+            // Each element went in twice, so it comes out twice and not once.
+            foreach (var w in First.Take(100))
+            {
+                Assert.IsTrue(left.TestAndRemove(Key(w)), $"{w} should remove once");
+                Assert.IsTrue(left.Test(Key(w)),
+                    $"{w} was added twice across the two filters and should survive one removal");
+                Assert.IsTrue(left.TestAndRemove(Key(w)), $"{w} should remove twice");
+            }
+        }
+
+        /// <summary>
+        /// A top-k's frequencies come from the merged sketch rather than from adding the
+        /// two recorded ones, which would count twice everything both sketches knew.
+        /// </summary>
+        [TestMethod]
+        public void TestTopKMergeReadsFrequenciesFromTheMergedSketch()
+        {
+            var left = new TopK(0.0001, 0.001, 10);
+            var right = new TopK(0.0001, 0.001, 10);
+            var combined = new TopK(0.0001, 0.001, 10);
+
+            // Item i appears i+1 times in each, so 2(i+1) across the two.
+            for (int i = 0; i < 20; i++)
+            {
+                for (int j = 0; j <= i; j++)
+                {
+                    left.Add(Key($"item-{i}"));
+                    right.Add(Key($"item-{i}"));
+                    combined.Add(Key($"item-{i}"));
+                    combined.Add(Key($"item-{i}"));
+                }
+            }
+
+            left.Merge(right);
+
+            var merged = left.Elements()
+                .Select(e => (Encoding.ASCII.GetString(e.Data.Span), e.Freq))
+                .ToArray();
+            var expected = combined.Elements()
+                .Select(e => (Encoding.ASCII.GetString(e.Data.Span), e.Freq))
+                .ToArray();
+
+            CollectionAssert.AreEqual(expected, merged,
+                "the merged top-k differs from one built by adding both streams to it");
+
+            // Concretely: the most frequent appeared 20 times in each.
+            Assert.AreEqual(40ul, merged.Last().Freq,
+                "frequencies were added rather than re-read from the merged sketch");
+        }
+
+        /// <summary>
+        /// A merged top-k is not necessarily the true top-k of the combined stream. Only
+        /// elements one of the heaps was holding are candidates, so an element that was
+        /// frequent in both but top in neither is invisible to the merge and stays so.
+        /// <para>
+        /// Pinned because it is a real limit of merging bounded summaries rather than a
+        /// shortcut, and because it is exactly the kind of thing that would otherwise be
+        /// discovered by someone trusting the result.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestTopKMergeCannotRecoverAnElementNeitherHeapHeld()
+        {
+            var left = new TopK(0.0001, 0.001, 3);
+            var right = new TopK(0.0001, 0.001, 3);
+
+            static void Add(TopK t, string word, int times)
+            {
+                for (int i = 0; i < times; i++)
+                {
+                    t.Add(Key(word));
+                }
+            }
+
+            // Each holds three elements above "shared", but they are different three, so
+            // "shared" tops the combined stream at 140 while sitting fourth in both.
+            Add(left, "a", 100); Add(left, "b", 90); Add(left, "c", 80); Add(left, "shared", 70);
+            Add(right, "d", 100); Add(right, "e", 90); Add(right, "f", 80); Add(right, "shared", 70);
+
+            Assert.IsFalse(
+                left.Elements().Any(e => Encoding.ASCII.GetString(e.Data.Span) == "shared"),
+                "sanity: shared should be outside the left heap");
+            Assert.IsFalse(
+                right.Elements().Any(e => Encoding.ASCII.GetString(e.Data.Span) == "shared"),
+                "sanity: shared should be outside the right heap");
+
+            left.Merge(right);
+
+            var merged = left.Elements()
+                .Select(e => Encoding.ASCII.GetString(e.Data.Span))
+                .ToArray();
+
+            Assert.DoesNotContain("shared", merged,
+                "the merge recovered an element neither heap was holding, which it " +
+                "cannot do; if this now passes, the candidate set has changed");
+
+            // What it does return is the best of what it could see.
+            Assert.HasCount(3, merged);
+            CollectionAssert.IsSubsetOf(merged, new[] { "a", "b", "c", "d", "e", "f" });
+        }
+
+        [TestMethod]
+        public void TestMergeRefusesMismatchedDimensions()
+        {
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new BloomFilter(1000, 0.01).Merge(new BloomFilter(2000, 0.01)));
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new BloomFilter64(1000, 0.01).Merge(new BloomFilter64(2000, 0.01)));
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new PartitionedBloomFilter(1000, 0.01).Merge(new PartitionedBloomFilter(2000, 0.01)));
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new CountingBloomFilter(1000, 4, 0.01).Merge(new CountingBloomFilter(2000, 4, 0.01)));
+
+            // Same dimensions, different counter width.
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new CountingBloomFilter(1000, 4, 0.01).Merge(new CountingBloomFilter(1000, 8, 0.01)));
+
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new TopK(0.001, 0.01, 5).Merge(new TopK(0.001, 0.01, 10)));
+        }
+
+        /// <summary>
+        /// Everything a filter holds sits where its own hash put it, so merging two that
+        /// hash differently produces a filter answering about positions neither meant.
+        /// Nothing looks wrong afterwards, which is why it is refused.
+        /// </summary>
+        [TestMethod]
+        public void TestMergeRefusesDifferentHashFunctions()
+        {
+            Func<ReadOnlySpan<byte>, ulong> alternate =
+                d => System.IO.Hashing.XxHash64.HashToUInt64(d);
+
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new BloomFilter(1000, 0.01).Merge(new BloomFilter(1000, 0.01, alternate)));
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new BloomFilter(1000, 0.01, alternate).Merge(new BloomFilter(1000, 0.01)));
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new CountingBloomFilter(1000, 4, 0.01)
+                    .Merge(new CountingBloomFilter(1000, 4, 0.01, alternate)));
+
+            // The two that already had Merge never checked this.
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new CountMinSketch(0.001, 0.01).Merge(new CountMinSketch(0.001, 0.01, alternate)));
+            Assert.ThrowsExactly<ArgumentException>(
+                () => new HyperLogLog(64).Merge(new HyperLogLog(64, alternate)));
+
+            // The same hash passed to both is fine, however it was written.
+            var left = new BloomFilter(1000, 0.01, alternate);
+            var right = new BloomFilter(1000, 0.01, alternate);
+            left.Add(Key("a"));
+            right.Add(Key("b"));
+            left.Merge(right);
+            Assert.IsTrue(left.Test(Key("a")));
+            Assert.IsTrue(left.Test(Key("b")));
+        }
+
+        [TestMethod]
+        public void TestMergeRejectsNull()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(() => new BloomFilter(100, 0.01).Merge(null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new BloomFilter64(100, 0.01).Merge(null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new PartitionedBloomFilter(100, 0.01).Merge(null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new CountingBloomFilter(100, 4, 0.01).Merge(null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new TopK(0.001, 0.01, 5).Merge(null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new HyperLogLog(64).Merge(null!));
+        }
+
+        /// <summary>
+        /// The count of a merged filter is the sum, which overstates the union whenever
+        /// the inputs shared elements. Pinned so the overstatement is a documented
+        /// property rather than a surprise.
+        /// </summary>
+        [TestMethod]
+        public void TestMergedCountIsTheSumAndSoAnUpperBound()
+        {
+            var left = new BloomFilter(2000, 0.01);
+            var right = new BloomFilter(2000, 0.01);
+
+            foreach (var w in First) { left.Add(Key(w)); right.Add(Key(w)); }
+
+            left.Merge(right);
+
+            Assert.AreEqual(1000u, left.Count(),
+                "the count sums, even though the two filters held the same 500 elements");
+        }
+
+        /// <summary>
+        /// Merging is what a caller does across shards, so a merged filter has to be
+        /// usable afterwards rather than only readable.
+        /// </summary>
+        [TestMethod]
+        public void TestAMergedFilterStillWorks()
+        {
+            var left = new BloomFilter(2000, 0.01);
+            var right = new BloomFilter(2000, 0.01);
+
+            foreach (var w in First) left.Add(Key(w));
+            foreach (var w in Second) right.Add(Key(w));
+
+            left.Merge(right).Add(Key("added-after"));
+
+            Assert.IsTrue(left.Test(Key("added-after")));
+            Assert.IsTrue(left.Test(Key(First[0])));
+            Assert.IsTrue(left.Test(Key(Second[0])));
+
+            // And survives a round trip, since a merged filter is a filter.
+            var restored = Persistence.FromByteArray<BloomFilter>(left.ToByteArray());
+            foreach (var w in First.Concat(Second).Concat(Absent).Take(1000))
+            {
+                Assert.AreEqual(left.Test(Key(w)), restored.Test(Key(w)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #53, #54 and #55.

Two structures could be merged and ten could not. This adds the four that are meaningful.

## #53 — union for the Bloom family

`BloomFilter`, `BloomFilter64` and `PartitionedBloomFilter` union by OR-ing their bit
arrays, giving exactly the filter that adding everything to one of them would have
produced.

Verified by building 20,000 elements across **8 shards** and merging:

```
disagreements over 200,000 absent keys: 0
false positive rate  merged 0.991%   single 0.991%   requested 1.000%
```

## #54 — counting filter

Counters add rather than max, since a merged filter has to be removable from as many
times as its inputs together were. Sums hold at the counter maximum, which keeps the rule
3.1.0 established — a saturated counter is never decremented — and means **merging can
make an element permanently unremovable when neither input had.** Documented on the
method rather than left to be found.

## #55 — TopK

Frequencies are re-read from the merged sketch rather than added. Each structure's
recorded frequency is what its *own* sketch last told it, so adding them double-counts
everything both sketches already knew.

**A merged top-k is not necessarily the true top-k of the combined stream.** Only elements
one of the heaps was holding are candidates.

Worth noting how nearly I got this wrong: my first attempt to demonstrate that limitation
didn't. The element I picked was genuinely below the top three, so its absence proved
nothing and I nearly wrote it up as evidence. It takes two filters that *disagree* about
what else is frequent — an element fourth in both heaps can top the combined stream when
the three above it differ between them:

```
left  top-3: c, b, a          right top-3: f, e, d
'shared' totals 140, more than anything else, and is in neither heap
merged top-3: b=90, d=100, a=100      <- the true top element is absent
```

There is a test pinning exactly that shape.

## Also fixed

**`CountMinSketch.Merge` and `HyperLogLog.Merge` never checked that both structures hash
the same way.** Everything a structure holds sits where its own hash put it, so merging
two that hash differently produced something answering confidently about positions neither
meant — with nothing about the result looking wrong afterwards. Both check now.
`HyperLogLog.Merge` also rejects null rather than throwing `NullReferenceException`.

## The hash check

Delegates compare by method and target, so the default hash, a method group, and one
delegate passed to both constructors all compare equal. Two separately written lambdas
with identical bodies do **not**, and are refused.

That is a false rejection, with an easy fix the message states: pass one hash function to
both structures rather than writing it out twice. I preferred it to the alternative of
only rejecting what can be *proven* different, which would have let the
custom-versus-different-custom case through silently — the failure this whole check
exists to prevent.

## Not added, deliberately

`InverseBloomFilter` (a slot holds one element, so a merge would have to choose),
`StableBloomFilter` (contents are a function of arrival order), `CuckooBloomFilter`
(fingerprints only combine when both filters happen to place them compatibly).

**280 tests.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9
