### PR TITLE
Pack the cuckoo filter's fingerprints into one array (closes #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.2.0] - Unreleased
+## [5.2.0] - 2026-08-14
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0] - Unreleased
+
+### Changed
+
+- **`CuckooBloomFilter` stores its fingerprints in one packed array**, which is
+  [#52](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/52). They were
+  individual `byte[]` instances in a jagged array, so every two-byte fingerprint carried a
+  24-byte object header and every bucket was an array of references besides.
+
+  | n = 100,000 at 1% | before | after |
+  | --- | --- | --- |
+  | empty | 3,847 KB | **291 KB** |
+  | holding 100,000 items | 11,501 KB | **291 KB** |
+  | `Test` | 43.0 ns | **31.3 ns** |
+
+  Storage is now allocated once and does not depend on load, which is why the two rows
+  agree. 5.0.0 fixed the filter's sizing; this fixes what the sizing was spent on.
+
+  Occupancy is tracked in a separate bit per entry rather than by treating an all-zero
+  fingerprint as empty. That would be smaller, but a fingerprint comes from a hash and
+  can legitimately be all zero, so it would need forcing to something else — which
+  changes which bucket an element's alternate index resolves to, and so could not be
+  applied to fingerprints already written by an earlier version. Six percent of the
+  fingerprint bytes buys reading every payload ever written, unchanged.
+
+- **Relocation no longer allocates per attempt.** Displacing a fingerprint copied it to a
+  fresh array, up to 500 times per insert and again to unwind, so an insert into a full
+  filter allocated **32 KB**. It now allocates 32 bytes, the same as an insert with room
+  to spare.
+
+### Fixed
+
+- **The fingerprint width is capped at eight bytes.** The hash supplies 64 bits, so a
+  wider fingerprint was storage reserved for bits that never arrived. Only reachable at
+  false positive rates below about 1e-27.
+
 ## [5.1.0] - 2026-08-14
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
          lived nowhere in the repo: AppVeyor patched AssemblyInfo.cs at build time from
          its own build counter, which is how the published package version (1.0.1) and
          the GitHub release tags (v1.0.9) drifted apart. -->
-    <VersionPrefix>5.1.0</VersionPrefix>
+    <VersionPrefix>5.2.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/ProbabilisticDataStructures/CuckooBloomFilter.cs
+++ b/ProbabilisticDataStructures/CuckooBloomFilter.cs
@@ -35,7 +35,31 @@ namespace ProbabilisticDataStructures
         /// </summary>
         private const int MAX_NUM_KICKS = 500;
 
-        internal byte[]?[][] Buckets { get; set; }
+        /// <summary>
+        /// Every fingerprint, packed end to end. Entry j of bucket i begins at
+        /// (i * B + j) * F.
+        /// </summary>
+        /// <remarks>
+        /// One array rather than a jagged one. Holding each fingerprint in its own
+        /// byte[] cost a 24-byte object header on two bytes of payload, plus an array
+        /// of references per bucket: a filter sized for 100,000 items took 3.8 MB
+        /// holding nothing and 11.5 MB holding them, against 256 KB of actual
+        /// fingerprints.
+        /// </remarks>
+        internal byte[] Fingerprints { get; set; }
+
+        /// <summary>
+        /// One bit per entry, saying whether it holds a fingerprint.
+        /// </summary>
+        /// <remarks>
+        /// A separate bit rather than treating an all-zero fingerprint as empty. That
+        /// would be smaller, but a fingerprint is taken from a hash and can legitimately
+        /// be all zero, so it would need forcing to something else -- which changes
+        /// which bucket the element's alternate index resolves to, and so cannot be
+        /// applied to fingerprints already written by an earlier version. Six percent of
+        /// the fingerprint bytes buys reading every payload ever written unchanged.
+        /// </remarks>
+        internal Buckets Occupied { get; set; }
         /// <summary>
         /// Hash algorithm.
         /// </summary>
@@ -101,14 +125,16 @@ namespace ProbabilisticDataStructures
             // for 100,000 items allocated 122 MB while holding nothing, against 124 KB
             // for a Bloom filter of the same capacity and rate.
             var m = Power2((uint)Math.Ceiling(n / (b * LoadFactor)));
-            var buckets = new byte[m][][];
-
-            for (uint i = 0; i < m; i++)
+            var entries = (ulong)m * b;
+            if (entries * f > int.MaxValue)
             {
-                buckets[i] = new byte[b][];
+                throw new ArgumentOutOfRangeException(nameof(n), n,
+                    $"A filter for {n} items at this rate needs {entries * f} bytes of " +
+                    "fingerprints, which cannot be held in a single array.");
             }
 
-            this.Buckets = buckets;
+            this.Fingerprints = new byte[entries * f];
+            this.Occupied = new Buckets((uint)entries, 1);
             this.Hash = hash ?? Defaults.GetDefaultHashFunction();
             this.random = seed is null ? new Random() : new Random(seed.Value);
             this.M = m;
@@ -167,22 +193,8 @@ namespace ProbabilisticDataStructures
             var i2 = components.Hash2;
             var f = components.Fingerprint;
 
-            // If either bucket containsf, it's a member.
-            var b1 = this.Buckets[i1 % this.M];
-            foreach (var sequence in b1)
-            {
-                if (sequence != null)
-                    if (Enumerable.SequenceEqual(sequence, f))
-                        return true;
-            }
-            var b2 = this.Buckets[i2 % this.M];
-            foreach (var sequence in b2)
-            {
-                if (sequence != null)
-                    if (Enumerable.SequenceEqual(sequence, f))
-                        return true;
-            }
-            return false;
+            // If either bucket contains f, it's a member.
+            return Contains(i1 % this.M, f) || Contains(i2 % this.M, f);
         }
 
         /// <summary>
@@ -226,27 +238,9 @@ namespace ProbabilisticDataStructures
             var f = components.Fingerprint;
 
             // If either bucket contains f, it's a member.
-            var b1 = this.Buckets[i1 % this.M];
-            foreach (var sequence in b1)
+            if (Contains(i1 % this.M, f) || Contains(i2 % this.M, f))
             {
-                if (sequence != null)
-                { 
-                    if (Enumerable.SequenceEqual(sequence, f))
-                    {
-                        return TestAndAddReturnValue.Create(true, false);
-                    }
-                }
-            }
-            var b2 = this.Buckets[i2 % this.M];
-            foreach (var sequence in b2)
-            {
-                if (sequence != null)
-                {
-                    if (Enumerable.SequenceEqual(sequence, f))
-                    {
-                        return TestAndAddReturnValue.Create(true, false);
-                    }
-                }
+                return TestAndAddReturnValue.Create(true, false);
             }
 
             return TestAndAddReturnValue.Create(false, this.Insert(i1, i2, f));
@@ -267,24 +261,18 @@ namespace ProbabilisticDataStructures
             var i2 = components.Hash2;
             var f = components.Fingerprint;
 
-            // Try to remove from bucket[i1].
-            var b1 = this.Buckets[i1 % this.M];
-            var idx = IndexOf(b1, f);
-            if (idx != -1)
+            // Try bucket[i1], then bucket[i2]. Clearing the occupancy bit is what
+            // empties an entry; the fingerprint bytes are left where they are and
+            // overwritten by whatever lands there next.
+            foreach (var bucket in stackalloc[] { i1 % this.M, i2 % this.M })
             {
-                b1[idx] = null;
-                this.count--;
-                return true;
-            }
-
-            // Try to remove from bucket[i2].
-            var b2 = this.Buckets[i2 % this.M];
-            idx = IndexOf(b2, f);
-            if (idx != -1)
-            {
-                b2[idx] = null;
-                this.count--;
-                return true;
+                var idx = IndexOf(bucket, f);
+                if (idx != -1)
+                {
+                    SetOccupied(bucket, (uint)idx, false);
+                    this.count--;
+                    return true;
+                }
             }
 
             return false;
@@ -297,12 +285,9 @@ namespace ProbabilisticDataStructures
         /// <returns>The CuckooBloomFilter</returns>
         public CuckooBloomFilter Reset()
         {
-            var buckets = new byte[this.M][][];
-            for (uint i = 0; i < this.M; i++)
-            {
-                buckets[i] = new byte[this.B][];
-            }
-            this.Buckets = buckets;
+            // Only the occupancy needs clearing: an entry nothing claims is never
+            // read, so the fingerprint bytes left behind are unreachable.
+            this.Occupied.Reset();
             this.count = 0;
             return this;
         }
@@ -329,7 +314,7 @@ namespace ProbabilisticDataStructures
             {
                 for (uint j = 0; j < this.B; j++)
                 {
-                    if (this.Buckets[i][j] is not null)
+                    if (IsOccupied(i, j))
                     {
                         occupied++;
                     }
@@ -341,12 +326,11 @@ namespace ProbabilisticDataStructures
             {
                 for (uint j = 0; j < this.B; j++)
                 {
-                    var fingerprint = this.Buckets[i][j];
-                    if (fingerprint is not null)
+                    if (IsOccupied(i, j))
                     {
                         payload.WriteUInt32(i);
                         payload.WriteUInt32(j);
-                        payload.WriteBytes(fingerprint);
+                        payload.WriteBytes(EntryAt(i, j));
                     }
                 }
             }
@@ -407,11 +391,16 @@ namespace ProbabilisticDataStructures
                     $"Filter claims {m} buckets, beyond anything this library builds.");
             }
 
-            var buckets = new byte[m][][];
-            for (uint i = 0; i < m; i++)
+            var entries = (ulong)m * b;
+            if (entries * f > int.MaxValue)
             {
-                buckets[i] = new byte[b][];
+                throw new InvalidDataException(
+                    $"Filter claims {m} buckets of {b} entries at {f} bytes, which " +
+                    "cannot be held in a single array.");
             }
+
+            var fingerprints = new byte[entries * f];
+            var occupancy = new Buckets((uint)entries, 1);
 
             var occupied = reader.ReadUInt32();
             if (occupied > m * (ulong)b)
@@ -432,14 +421,24 @@ namespace ProbabilisticDataStructures
                         $"its {m} buckets of {b}.");
                 }
 
-                buckets[bucket][entry] = reader.ReadBytes();
+                var fingerprint = reader.ReadBytes();
+                if (fingerprint.Length != f)
+                {
+                    throw new InvalidDataException(
+                        $"Filter holds a {fingerprint.Length}-byte fingerprint where its " +
+                        $"own fingerprint size is {f}.");
+                }
+
+                fingerprint.CopyTo(fingerprints.AsSpan((int)((bucket * b + entry) * f)));
+                occupancy.Set(bucket * b + entry, 1);
             }
 
             reader.ExpectEnd();
 
             return new CuckooBloomFilter
             {
-                Buckets = buckets,
+                Fingerprints = fingerprints,
+                Occupied = occupancy,
                 M = m,
                 B = b,
                 F = f,
@@ -454,7 +453,8 @@ namespace ProbabilisticDataStructures
         /// </summary>
         private CuckooBloomFilter()
         {
-            this.Buckets = null!;
+            this.Fingerprints = null!;
+            this.Occupied = null!;
         }
 
         /// <summary>
@@ -473,12 +473,34 @@ namespace ProbabilisticDataStructures
         /// Indicates if the given fingerprint is contained in one of the bucket's
         /// entries.
         /// </summary>
-        /// <param name="bucket">The bucket to search.</param>
-        /// <param name="f">Fingerprint</param>
         /// <returns>
         /// Whether or not the fingerprint is contained in one of the bucket's entries.
         /// </returns>
-        private static bool Contains(byte[]?[] bucket, byte[] f)
+        /// <summary>
+        /// The bytes of one entry, addressed directly in the packed array.
+        /// </summary>
+        private Span<byte> EntryAt(uint bucket, uint entry)
+        {
+            return this.Fingerprints.AsSpan((int)((bucket * this.B + entry) * this.F), (int)this.F);
+        }
+
+        /// <summary>
+        /// Whether an entry holds a fingerprint.
+        /// </summary>
+        private bool IsOccupied(uint bucket, uint entry)
+        {
+            return this.Occupied.Get(bucket * this.B + entry) != 0;
+        }
+
+        private void SetOccupied(uint bucket, uint entry, bool occupied)
+        {
+            this.Occupied.Set(bucket * this.B + entry, occupied ? (byte)1 : (byte)0);
+        }
+
+        /// <summary>
+        /// Whether a bucket holds this fingerprint.
+        /// </summary>
+        private bool Contains(uint bucket, ReadOnlySpan<byte> f)
         {
             return IndexOf(bucket, f) != -1;
         }
@@ -487,23 +509,21 @@ namespace ProbabilisticDataStructures
         /// Returns the entry index of the given fingerprint or -1 if it's not in the
         /// bucket.
         /// </summary>
-        /// <param name="bucket">The bucket to search.</param>
-        /// <param name="f">Fingerprint</param>
         /// <returns>The entry index of the fingerprint or -1 if it's not in the
         /// bucket</returns>
-        private static int IndexOf(byte[]?[] bucket, byte[] f)
+        /// <summary>
+        /// Where this fingerprint sits in a bucket, or -1.
+        /// </summary>
+        private int IndexOf(uint bucket, ReadOnlySpan<byte> f)
         {
-            for (int i = 0; i < bucket.Count(); i++)
+            for (uint entry = 0; entry < this.B; entry++)
             {
-                var sequence = bucket[i];
-                if (sequence != null)
+                if (IsOccupied(bucket, entry) && EntryAt(bucket, entry).SequenceEqual(f))
                 {
-                    if (Enumerable.SequenceEqual(f, sequence))
-                    {
-                        return i;
-                    }
+                    return (int)entry;
                 }
             }
+
             return -1;
         }
 
@@ -512,15 +532,19 @@ namespace ProbabilisticDataStructures
         /// full.
         /// </summary>
         /// <returns></returns>
-        private static int GetEmptyEntry(byte[]?[] bucket)
+        /// <summary>
+        /// A free entry in a bucket, or -1 if it is full.
+        /// </summary>
+        private int GetEmptyEntry(uint bucket)
         {
-            for (int i = 0; i < bucket.Count(); i++)
+            for (uint entry = 0; entry < this.B; entry++)
             {
-                if (bucket[i] == null)
+                if (!IsOccupied(bucket, entry))
                 {
-                    return i;
+                    return (int)entry;
                 }
             }
+
             return -1;
         }
 
@@ -528,44 +552,44 @@ namespace ProbabilisticDataStructures
         /// Will insert the fingerprint into the filter returning false if the filter is
         /// full.
         /// </summary>
-        /// <param name="i1"></param>
-        /// <param name="i2"></param>
-        /// <param name="f"></param>
+        /// <param name="i1">The element's first candidate bucket.</param>
+        /// <param name="i2">The element's second candidate bucket.</param>
+        /// <param name="f">The fingerprint to insert.</param>
         /// <returns>
         /// True if the insert was successful. False if the filter is full
         /// </returns>
         private bool Insert(uint i1, uint i2, byte[] f)
         {
-            // Try to insert into bucket[i1].
-            var b1 = this.Buckets[i1 % this.M];
-            var idx = GetEmptyEntry(b1);
-            if (idx != -1)
+            // Try to insert into bucket[i1], then bucket[i2].
+            foreach (var bucket in stackalloc[] { i1 % this.M, i2 % this.M })
             {
-                b1[idx] = f;
-                this.count++;
-                return true;
+                var free = GetEmptyEntry(bucket);
+                if (free != -1)
+                {
+                    Place(bucket, (uint)free, f);
+                    this.count++;
+                    return true;
+                }
             }
 
-            // Try to insert into bucket[i2].
-            var b2 = this.Buckets[i2 % this.M];
-            var idx2 = GetEmptyEntry(b2);
-            if (idx2 != -1)
-            {
-                b2[idx2] = f;
-                this.count++;
-                return true;
-            }
-
-            // Must relocate existing items. Each step displaces whatever is in a
-            // chosen entry, puts the fingerprint in hand there, and looks for a home
-            // for what was displaced.
+            // Must relocate existing items. Each step displaces whatever is in a chosen
+            // entry, puts the fingerprint in hand there, and looks for a home for what
+            // was displaced.
             //
-            // Where each displacement happened is recorded, because the loop can run
-            // out of kicks while still holding one. Dropping it there loses an element
-            // the filter had already accepted, which is a false negative -- the one
-            // thing this filter, like every other here, promises not to produce.
+            // Where each displacement happened is recorded, because the loop can run out
+            // of kicks while still holding one. Dropping it there loses an element the
+            // filter had already accepted, which is a false negative -- the one thing
+            // this filter, like every other here, promises not to produce.
             Span<uint> trailBucket = stackalloc uint[MAX_NUM_KICKS];
             Span<uint> trailEntry = stackalloc uint[MAX_NUM_KICKS];
+
+            // The fingerprint in hand and the one just displaced, both on the stack.
+            // Copying between them rather than allocating a fresh array per kick: the
+            // loop runs up to MAX_NUM_KICKS times and again to unwind, so an allocation
+            // here is a thousand of them on a filter that is refusing the insert anyway.
+            Span<byte> current = stackalloc byte[(int)this.F];
+            Span<byte> displaced = stackalloc byte[(int)this.F];
+            f.CopyTo(current);
 
             var i = i1;
             var depth = 0;
@@ -574,26 +598,24 @@ namespace ProbabilisticDataStructures
             {
                 var bucketIdx = i % this.M;
                 var entryIdx = (uint)random.Next((int)this.B);
-                var tempF = f;
 
-                // The loop only relocates out of a bucket with no free entry, so
-                // every slot in it is occupied. Reaching a null here would have
-                // thrown before these annotations existed, so this records the
-                // existing invariant rather than assuming a new one.
-                f = this.Buckets[bucketIdx][entryIdx]!;
-                this.Buckets[bucketIdx][entryIdx] = tempF;
+                // The loop only relocates out of a bucket with no free entry, so every
+                // entry in it is occupied and what comes out is a real fingerprint.
+                EntryAt(bucketIdx, entryIdx).CopyTo(displaced);
+                Place(bucketIdx, entryIdx, current);
 
                 trailBucket[depth] = bucketIdx;
                 trailEntry[depth] = entryIdx;
                 depth++;
 
-                i = i ^ ComputeHashSum32(f);
-                var b = this.Buckets[i % this.M];
+                displaced.CopyTo(current);
+                i = i ^ ComputeHashSum32(current);
 
-                idx = GetEmptyEntry(b);
-                if (idx != -1)
+                var alternate = i % this.M;
+                var free = GetEmptyEntry(alternate);
+                if (free != -1)
                 {
-                    b[idx] = f;
+                    Place(alternate, (uint)free, current);
                     this.count++;
                     return true;
                 }
@@ -607,14 +629,21 @@ namespace ProbabilisticDataStructures
                 var bucket = trailBucket[n];
                 var entry = trailEntry[n];
 
-                // Every entry on the trail was written to on the way in, so none of
-                // them is empty.
-                var occupant = this.Buckets[bucket][entry]!;
-                this.Buckets[bucket][entry] = f;
-                f = occupant;
+                EntryAt(bucket, entry).CopyTo(displaced);
+                Place(bucket, entry, current);
+                displaced.CopyTo(current);
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Writes a fingerprint into an entry and marks it occupied.
+        /// </summary>
+        private void Place(uint bucket, uint entry, ReadOnlySpan<byte> f)
+        {
+            f.CopyTo(EntryAt(bucket, entry));
+            SetOccupied(bucket, entry, true);
         }
 
         /// <summary>
@@ -704,7 +733,10 @@ namespace ProbabilisticDataStructures
             var bits = Math.Ceiling(Math.Log2(2 * b / epsilon));
             var bytes = (uint)Math.Ceiling(bits / 8);
 
-            return bytes < 1 ? 1 : bytes;
+            // The hash supplies 64 bits, so a fingerprint cannot be wider than eight
+            // bytes however small a rate is asked for. Anything past that would be
+            // storage reserved for bits that never arrive.
+            return Math.Clamp(bytes, 1u, 8u);
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestCuckooBloomFilter.cs
+++ b/TestProbabilisticDataStructures/TestCuckooBloomFilter.cs
@@ -183,13 +183,15 @@ namespace TestProbabilisticDataStructures
             var resetFilter = f.Reset();
             Assert.AreSame(f, resetFilter);
 
-            for (int i = 0; i < f.BucketCount(); i++)
+            // Occupancy is what says an entry holds something; the fingerprint bytes
+            // behind a cleared entry are unreachable and are not cleared.
+            for (uint i = 0; i < f.BucketCount(); i++)
             {
                 for (uint j = 0; j < f.B; j++)
                 {
-                    if (f.Buckets[i][j] != null)
+                    if (f.Occupied.Get(i * f.B + j) != 0)
                     {
-                        Assert.Fail("Exected all buckets to be cleared");
+                        Assert.Fail($"Expected all entries to be cleared; bucket {i} entry {j} is not");
                     }
                 }
             }

--- a/TestProbabilisticDataStructures/TestFilterSemantics.cs
+++ b/TestProbabilisticDataStructures/TestFilterSemantics.cs
@@ -512,6 +512,41 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// The filter's storage is allocated once, so what it costs does not depend on
+        /// how much it holds. Fingerprints used to be individual byte arrays, which meant
+        /// a 24-byte object header on two bytes of payload and a bucket-sized array of
+        /// references besides: a filter for 100,000 items took 3.8 MB holding nothing and
+        /// 11.5 MB holding them, against 291 KB now either way.
+        /// </summary>
+        [TestMethod]
+        public void TestCuckooFilterStorageDoesNotGrowWithLoad()
+        {
+            var empty = new CuckooBloomFilter(2000, 0.01, seed: 4);
+            var loaded = new CuckooBloomFilter(2000, 0.01, seed: 4);
+
+            for (int i = 0; i < 5000; i++)
+            {
+                loaded.Add(Key($"item-{i}"));
+            }
+
+            // Same dimensions, so the same fixed storage, however much is in it.
+            Assert.AreEqual(empty.Fingerprints.Length, loaded.Fingerprints.Length);
+            Assert.AreEqual(empty.Occupied.count, loaded.Occupied.count);
+
+            // And adding allocates nothing that the filter keeps.
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 5000; i < 5100; i++)
+            {
+                loaded.Add(Key($"later-{i}"));
+            }
+            var perAdd = (GC.GetAllocatedBytesForCurrentThread() - before) / 100;
+
+            Assert.IsLessThan(512, perAdd,
+                $"Add allocated {perAdd} bytes per call; the filter's storage is fixed, " +
+                "so anything here is scratch and should stay small");
+        }
+
+        /// <summary>
         /// The inverse filter is a bounded "recently seen" cache rather than a growing
         /// set: an element whose slot is claimed by a later one is forgotten. False
         /// negatives are therefore expected here, which is the opposite of every other


### PR DESCRIPTION
Closes #52. 5.0.0 fixed how many buckets the filter allocates; this fixes what those
buckets cost.

Fingerprints were individual `byte[]` instances in a jagged array, so every two-byte
fingerprint carried a 24-byte object header, and every bucket was an array of references
besides.

| n = 100,000 at 1% | before | after |
| --- | --- | --- |
| empty | 3,847 KB | **291 KB** |
| holding 100,000 items | 11,501 KB | **291 KB** |
| `Test` | 43.0 ns | **31.3 ns** |

The two rows agree because storage is now allocated once and does not depend on load.

## Why occupancy is a separate bit

Treating an all-zero fingerprint as "empty" would be smaller, and is what most
implementations do. But a fingerprint comes from a hash and can legitimately be all zero,
so it would have to be forced to something else — and that changes what an element's
alternate bucket index resolves to, which cannot be applied to fingerprints already
written by an earlier version.

Six percent of the fingerprint bytes buys reading every payload ever written, unchanged.
The stored format is untouched and the 3.2.0 fixture still reads.

## Two things worth flagging

**A regex rewrite silently deleted two public methods.** The pattern that rewrote `Test`'s
body matched again inside the text it had just inserted, and swallowed `Add` and
`TestAndAdd` whole. The compiler caught it immediately — `Test` was left returning a
`TestAndAddReturnValue` — but a rewrite that removes two public methods and *still
compiles* is exactly what wouldn't be caught. Both were restored from `HEAD` rather than
retyped from memory.

**The new test failed on its first run, correctly.** `Add` was allocating **32 KB per
call**: displacing a fingerprint copied it to a fresh array, up to 500 times per insert
and again to unwind the trail, so a filter refusing an insert allocated a thousand small
arrays doing it. Both paths now copy between two stack buffers.

```
Add over capacity: 32 bytes per call     (was 32,152)
Add with room:     32 bytes per call
```

The remaining 32 bytes is the fingerprint from `GetComponents`, which an existing test
already bounds.

## Also

The fingerprint width is capped at eight bytes — the hash supplies 64 bits, so anything
wider was storage reserved for bits that never arrive. Only reachable below about 1e-27.

## Verification

**281 tests.** Correctness at load, deletion, the eviction rollback from 5.0.0, the
persistence round trip and the stored fixtures all covered by tests that already existed;
one added for storage not growing with load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9
