### PR TITLE
Say what happened when a filter is sized past 32 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A filter sized past what 32 bits can address now says so.** `BloomFilter`,
+  `CountingBloomFilter`, `PartitionedBloomFilter` and `DeletableBloomFilter` address at
+  most 4.29 billion bits, which is about 448 million items at 1% and fewer at a tighter
+  rate. Asking for more arrived as `OverflowException: Value was either too large or too
+  small for a UInt32` from inside the sizing arithmetic -- the same defect 3.0.0 fixed for
+  the false positive rate, and the same complaint: it reported something true about the
+  machinery and nothing about the mistake. It is now an `ArgumentOutOfRangeException` that
+  gives the bits needed against the bits available, and names `BloomFilter64` and
+  `ScalableBloomFilter` as the two ways out.
+
 - **`CuckooBloomFilter.SizeInBytes()`**, reporting the storage the filter actually holds.
   `Capacity()` reports how many items it is sized for, which is a different number and was
   the only one available -- so the README's comparison of the membership structures could

--- a/ProbabilisticDataStructures/Utils.cs
+++ b/ProbabilisticDataStructures/Utils.cs
@@ -29,6 +29,23 @@ namespace ProbabilisticDataStructures
         {
             var optimalM = Math.Ceiling((double)n / ((Math.Log(Defaults.FILL_RATIO) *
                 Math.Log(1 - Defaults.FILL_RATIO)) / Math.Abs(Math.Log(fpRate))));
+
+            // A 32-bit filter addresses at most uint.MaxValue bits, which is about 448
+            // million items at 1% and fewer at a tighter rate. Left to the conversion
+            // this arrives as an OverflowException from inside the sizing arithmetic,
+            // which says something true about the machinery and nothing about the
+            // mistake or about the two structures that would work.
+            if (optimalM > uint.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(n), n,
+                    $"Holding {n} items at a false positive rate of {fpRate} needs " +
+                    $"{optimalM:N0} bits, and a 32-bit filter addresses at most " +
+                    $"{uint.MaxValue:N0}. Use BloomFilter64, which sizes in 64 bits, or " +
+                    "ScalableBloomFilter, which grows by adding filters rather than by " +
+                    "making one larger.");
+            }
+
             return Convert.ToUInt32(optimalM);
         }
 

--- a/README.md
+++ b/README.md
@@ -287,11 +287,22 @@ bool wasAlreadyThere = filter.TestAndAdd(bytes);
 
 The same structure with 64-bit sizing throughout.
 
-**Reach for it when** the filter needs more than about 4 billion bits — roughly 500 million
-items at 1%. `BloomFilter` sizes with 32-bit arithmetic and cannot address past that.
+**Reach for it when** the filter needs more than 4.29 billion bits — about **448 million
+items at 1%**, and fewer at a tighter rate. `BloomFilter`, `CountingBloomFilter`,
+`PartitionedBloomFilter` and `DeletableBloomFilter` all size in 32 bits and refuse past
+that, naming this structure when they do.
 
 **Look elsewhere otherwise.** Below that ceiling it is the same filter with wider
-arithmetic, so `BloomFilter` is the plainer choice.
+arithmetic, so `BloomFilter` is the plainer choice. And above it, consider
+`ScalableBloomFilter` instead: it grows by adding filters rather than by making one
+larger, so it has no single-filter ceiling at all, and it does not need you to know the
+size in advance.
+
+Only the Bloom family has this ceiling. `CuckooBloomFilter` and `BinaryFuseFilter` hold
+around 2.1 billion entries before they run into .NET's 2 GB array limit, and the sketches —
+`HyperLogLogPlus`, `ThetaSketch`, `CountMinSketch`, `TopK`, `DDSketch` — are a few hundred
+kilobytes at their largest sensible settings however much data passes through them. Their
+counters are already 64-bit.
 
 ### `PartitionedBloomFilter`
 

--- a/TestProbabilisticDataStructures/TestErrorPaths.cs
+++ b/TestProbabilisticDataStructures/TestErrorPaths.cs
@@ -183,5 +183,56 @@ namespace TestProbabilisticDataStructures
             var f = new DeletableBloomFilter(100, 10, 0.01);
             Assert.IsLessThanOrEqualTo(m, f.Capacity());
         }
+        /// <summary>
+        /// A 32-bit filter cannot size itself past about 4.29 billion bits, which is
+        /// roughly 448 million items at 1%. Asking for more used to surface as an
+        /// <see cref="OverflowException"/> from a numeric conversion deep in the sizing
+        /// math -- the same defect this class already fixes for the false positive rate,
+        /// and the same complaint: it reports something true about the machinery and
+        /// nothing about the mistake, or about the two structures that would work.
+        /// </summary>
+        [TestMethod]
+        public void TestFilterRejectsAnItemCountItCannotSize()
+        {
+            foreach (var (name, construct) in new (string, Action)[]
+            {
+                ("BloomFilter", () => new BloomFilter(1_000_000_000, 0.01)),
+                ("CountingBloomFilter", () => new CountingBloomFilter(1_000_000_000, 4, 0.01)),
+                ("PartitionedBloomFilter", () => new PartitionedBloomFilter(1_000_000_000, 0.01)),
+                ("DeletableBloomFilter", () => new DeletableBloomFilter(1_000_000_000, 10, 0.01)),
+            })
+            {
+                var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                    () => construct(), $"{name} did not refuse an item count it cannot size");
+
+                // The message has to name the way out, or it is only marginally better
+                // than the overflow it replaces.
+                StringAssert.Contains(ex.Message, "BloomFilter64");
+                StringAssert.Contains(ex.Message, "ScalableBloomFilter");
+            }
+
+            // A count it can size is still accepted, and the boundary is not moved by
+            // this check -- 400 million items at 1% is under the ceiling.
+            _ = Utils.OptimalM(400_000_000, 0.01);
+
+            // And the 64-bit filter takes what the 32-bit ones refuse.
+            Assert.IsGreaterThan(uint.MaxValue, Utils.OptimalM64(1_000_000_000, 0.01));
+        }
+
+        /// <summary>
+        /// A tighter rate needs more bits per item, so the ceiling moves down with it.
+        /// The check has to be against the bits actually needed rather than a fixed
+        /// item count.
+        /// </summary>
+        [TestMethod]
+        public void TestTheCeilingDependsOnTheRateAsWellAsTheCount()
+        {
+            // Comfortable at 1%, impossible at one in a million.
+            _ = new BloomFilter(400_000_000, 0.01);
+
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new BloomFilter(400_000_000, 0.000001));
+        }
+
     }
 }


### PR DESCRIPTION
Found while evaluating whether the other structures want 64-bit variants. **They don't** —
the reasoning is in the reply — but the evaluation turned this up.

## The defect

`BloomFilter`, `CountingBloomFilter`, `PartitionedBloomFilter` and `DeletableBloomFilter`
address at most 4.29 billion bits: about **448 million items at 1%**, fewer at a tighter
rate. Asking for more gave you:

```
OverflowException: Value was either too large or too small for a UInt32.
```

…from `Convert.ToUInt32` inside the sizing arithmetic. That is the same defect 3.0.0 fixed
for the false positive rate, and `TestErrorPaths.cs` already states the complaint in as
many words:

> Previously these surfaced as an OverflowException from a numeric conversion deep in the
> sizing math, which reported something true about the machinery and nothing about the
> mistake.

It also said nothing about the two structures that would have worked.

## Now

```
Holding 1000000000 items at a false positive rate of 0.01 needs 9,585,058,378 bits, and a
32-bit filter addresses at most 4,294,967,295. Use BloomFilter64, which sizes in 64 bits,
or ScalableBloomFilter, which grows by adding filters rather than by making one larger.
```

The check is against the **bits needed**, not a fixed item count, because the ceiling moves
with the rate — 400 million items is comfortable at 1% and impossible at one in a million.
There is a test for exactly that, since a check written against the count alone would pass
it while still overflowing.

## Also

README now states where the ceiling is and, as importantly, where it *isn't*:
`CuckooBloomFilter` and `BinaryFuseFilter` hold ~2.1 billion entries before .NET's 2 GB
array limit binds, and the sketches are a few hundred KB at their largest sensible settings
however much data goes through them.

402 tests. Release build clean under `-warnaserror`.