### PR TITLE
Add MinHashIndex and SimHashIndex (closes #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`MinHashIndex` and `SimHashIndex`**, so that the signatures this library produces can
+  be searched rather than only compared, which is
+  [#74](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/74). Without an
+  index, finding near-duplicates among a million documents is a trillion comparisons; #62
+  noted at the time that this was probably worth more than another fingerprint.
+
+  **They are the first structures here whose failure is a missing answer.** Everything else
+  errs towards saying yes. An index can fail to offer a pair that really is similar, and
+  checking the candidates afterwards does not recover it. `RecallAt` exposes how often that
+  happens rather than leaving it to be discovered.
+
+  `ForThreshold` errs towards returning too much for the same reason. Only the divisors of
+  the signature length are available, so the S-curve lands near the requested threshold
+  rather than on it -- and at 128 values and a threshold of 0.8, choosing the nearest
+  configuration regardless of side gives **20% recall at the threshold itself**. Choosing
+  the other side gives 95% and costs extra candidates the caller discards.
+
+  `SimHashIndex` carries a guarantee its sibling cannot: cutting 64 bits into *b* bands
+  means anything differing in fewer than *b* bits must share a band, so retrieval within
+  that distance is certain rather than probable.
+
+  Neither is persistable, deliberately -- an index is derived data, rebuildable from the
+  signatures already stored. `SimHashSignature`'s constructor is now public, so a
+  fingerprint held elsewhere can be wrapped and queried.
+
 - **`BloomierFilter`**, an approximate key-to-value map, which is
   [#78](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/78). Chazelle,
   Kilian, Rubinfeld and Tal (2004), built on the peeling construction `BinaryFuseFilter`

--- a/ProbabilisticDataStructures/MinHashIndex.cs
+++ b/ProbabilisticDataStructures/MinHashIndex.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Hashing;
+
+namespace ProbabilisticDataStructures
+{
+    /// <summary>
+    /// Finds which stored signatures are worth comparing against a query, so that
+    /// near-duplicate search does not have to compare every pair.
+    /// </summary>
+    /// <remarks>
+    /// The banding scheme from Rajaraman and Ullman, <i>Mining of Massive Datasets</i>,
+    /// chapter 3.
+    /// <para>
+    /// A signature is cut into <c>bands</c> bands of <c>rows</c> values each, and each
+    /// band is hashed into a bucket. Two signatures are candidates if <b>any</b> band
+    /// matches exactly. Since a band matches with probability s^rows for resemblance s,
+    /// at least one of them matches with probability 1 - (1 - s^rows)^bands -- an
+    /// S-curve, which rises steeply near a threshold the two parameters put wherever you
+    /// want it.
+    /// </para>
+    /// <para>
+    /// <b>This is the first structure here whose failure is a missing answer.</b>
+    /// Everything else may say yes when it should say no. An index may fail to return a
+    /// pair that really is similar, and no amount of checking the candidates afterwards
+    /// recovers it -- it was never offered. Choose the threshold below the similarity you
+    /// actually care about, and read <see cref="RecallAt"/> before assuming a setting is
+    /// safe.
+    /// </para>
+    /// <para>
+    /// It returns <b>candidates</b>, not answers. Compare them properly with
+    /// <see cref="MinHash.Similarity(MinHashSignature, MinHashSignature)"/>; the point is
+    /// turning a billion comparisons into a few hundred, not skipping them.
+    /// </para>
+    /// </remarks>
+    public class MinHashIndex
+    {
+        private readonly int bands;
+        private readonly int rows;
+        private readonly Dictionary<ulong, List<string>> buckets = new Dictionary<ulong, List<string>>();
+
+        /// <summary>
+        /// Creates an index over signatures of <c>bands * rows</c> values.
+        /// </summary>
+        /// <param name="bands">How many bands each signature is cut into.</param>
+        /// <param name="rows">How many values are in each band.</param>
+        public MinHashIndex(int bands, int rows)
+        {
+            if (bands < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(bands), bands, "An index needs at least one band.");
+            }
+
+            if (rows < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(rows), rows, "A band needs at least one row.");
+            }
+
+            this.bands = bands;
+            this.rows = rows;
+        }
+
+        /// <summary>
+        /// Creates an index tuned to retrieve pairs at or above a resemblance, choosing
+        /// the bands and rows that put the S-curve's steep part near it.
+        /// </summary>
+        /// <param name="threshold">
+        /// The resemblance to tune for. Pairs above it are usually returned and pairs
+        /// below it usually are not, with "usually" softening either side of the
+        /// threshold rather than switching at it.
+        /// </param>
+        /// <param name="signatureLength">
+        /// The length of the signatures to be indexed. The bands must divide it.
+        /// </param>
+        /// <returns>An index tuned for that threshold.</returns>
+        public static MinHashIndex ForThreshold(double threshold, int signatureLength)
+        {
+            if (!(threshold > 0 && threshold < 1))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(threshold), threshold,
+                    "A resemblance threshold sits strictly between zero and one.");
+            }
+
+            if (signatureLength < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(signatureLength), signatureLength,
+                    "A signature has at least one value.");
+            }
+
+            // The curve's steep point is near (1/bands)^(1/rows), and only the divisors
+            // of the signature length are available, so it lands near the threshold
+            // rather than on it. Which side it lands on matters a great deal.
+            //
+            // Rounding the steep point *above* the threshold means a pair at the
+            // threshold is usually missed -- at 128 values and a threshold of 0.8, the
+            // nearest configuration by distance alone gives 20% recall there. Rounding it
+            // below costs extra candidates, which the caller then discards. This index
+            // errs towards returning too much, because too much is work and too little is
+            // a silently wrong answer.
+            var bestBands = 0;
+            var bestRows = 0;
+            var bestDistance = double.MaxValue;
+
+            for (var candidate = 1; candidate <= signatureLength; candidate++)
+            {
+                if (signatureLength % candidate != 0)
+                {
+                    continue;
+                }
+
+                var rows = signatureLength / candidate;
+                var steepAt = Math.Pow(1.0 / candidate, 1.0 / rows);
+
+                if (steepAt > threshold)
+                {
+                    continue;
+                }
+
+                var distance = threshold - steepAt;
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    bestBands = candidate;
+                    bestRows = rows;
+                }
+            }
+
+            // A threshold below anything the divisors reach: take the most permissive
+            // configuration available, which is one value per band.
+            if (bestBands == 0)
+            {
+                bestBands = signatureLength;
+                bestRows = 1;
+            }
+
+            return new MinHashIndex(bestBands, bestRows);
+        }
+
+        /// <summary>
+        /// The chance a pair of the given resemblance is offered as a candidate.
+        /// </summary>
+        /// <param name="resemblance">The Jaccard resemblance of the pair.</param>
+        /// <returns>The probability the index returns it.</returns>
+        /// <remarks>
+        /// Worth reading before trusting a setting. This is the number that says how much
+        /// the index will silently miss.
+        /// </remarks>
+        public double RecallAt(double resemblance)
+        {
+            return 1 - Math.Pow(1 - Math.Pow(resemblance, this.rows), this.bands);
+        }
+
+        /// <summary>
+        /// Adds a signature under an identifier.
+        /// </summary>
+        /// <param name="id">What to return when this signature is a candidate.</param>
+        /// <param name="signature">The signature to index.</param>
+        public void Add(string id, MinHashSignature signature)
+        {
+            ArgumentNullException.ThrowIfNull(id);
+            ArgumentNullException.ThrowIfNull(signature);
+            this.RequireCorrectLength(signature);
+
+            foreach (var band in this.BandsOf(signature))
+            {
+                if (!this.buckets.TryGetValue(band, out var members))
+                {
+                    members = new List<string>();
+                    this.buckets[band] = members;
+                }
+
+                if (!members.Contains(id))
+                {
+                    members.Add(id);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The identifiers worth comparing against this signature.
+        /// </summary>
+        /// <param name="signature">The signature to look for neighbours of.</param>
+        /// <returns>
+        /// Candidates, in no particular order. Some will not be similar; compare them
+        /// properly. Some genuinely similar signatures may be missing -- see the remarks
+        /// on this type.
+        /// </returns>
+        public IReadOnlyCollection<string> Query(MinHashSignature signature)
+        {
+            ArgumentNullException.ThrowIfNull(signature);
+            this.RequireCorrectLength(signature);
+
+            var found = new HashSet<string>();
+
+            foreach (var band in this.BandsOf(signature))
+            {
+                if (this.buckets.TryGetValue(band, out var members))
+                {
+                    foreach (var member in members)
+                    {
+                        found.Add(member);
+                    }
+                }
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        /// One bucket key per band: the hash of that band's values, mixed with the band's
+        /// position so that two bands holding the same values do not collide.
+        /// </summary>
+        private ulong[] BandsOf(MinHashSignature signature)
+        {
+            // Materialised rather than yielded: Values is a ReadOnlySpan, which cannot
+            // live across a yield boundary.
+            var values = signature.Values;
+            var keys = new ulong[this.bands];
+
+            for (var band = 0; band < this.bands; band++)
+            {
+                var bytes = new byte[(this.rows + 1) * sizeof(ulong)];
+                System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(bytes, (ulong)band);
+
+                for (var row = 0; row < this.rows; row++)
+                {
+                    System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(
+                        bytes.AsSpan((row + 1) * sizeof(ulong)),
+                        values[(band * this.rows) + row]);
+                }
+
+                keys[band] = XxHash3.HashToUInt64(bytes);
+            }
+
+            return keys;
+        }
+
+        private void RequireCorrectLength(MinHashSignature signature)
+        {
+            if (signature.Length != this.bands * this.rows)
+            {
+                throw new ArgumentException(
+                    $"This index is {this.bands} bands of {this.rows}, so it holds " +
+                    $"signatures of {this.bands * this.rows} values, and this one has " +
+                    $"{signature.Length}.",
+                    nameof(signature));
+            }
+        }
+
+        /// <summary>The number of bands each signature is cut into.</summary>
+        public int Bands() => this.bands;
+
+        /// <summary>The number of values in each band.</summary>
+        public int Rows() => this.rows;
+
+        /// <summary>The number of identifiers indexed.</summary>
+        public int Count()
+        {
+            var all = new HashSet<string>();
+            foreach (var bucket in this.buckets.Values)
+            {
+                foreach (var member in bucket)
+                {
+                    all.Add(member);
+                }
+            }
+
+            return all.Count;
+        }
+    }
+}

--- a/ProbabilisticDataStructures/SimHashIndex.cs
+++ b/ProbabilisticDataStructures/SimHashIndex.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProbabilisticDataStructures
+{
+    /// <summary>
+    /// Finds which stored SimHash fingerprints are worth comparing against a query.
+    /// </summary>
+    /// <remarks>
+    /// The bit-sampling counterpart of <see cref="MinHashIndex"/>, and it has a guarantee
+    /// its sibling cannot offer. A 64-bit fingerprint cut into <c>b</c> bands means two
+    /// fingerprints differing in fewer than <c>b</c> bits must agree on at least one band
+    /// -- there are only <c>b - 1</c> differing bits to spread over <c>b</c> bands, so one
+    /// band gets none. Within that distance retrieval is <b>certain</b>, not probable.
+    /// <para>
+    /// Past it, retrieval falls away quickly, so choose the band count from the Hamming
+    /// distance you consider a near-duplicate. Eight bands guarantees everything within
+    /// seven bits, which on a 64-bit fingerprint is a cosine similarity of about 0.95.
+    /// </para>
+    /// <para>
+    /// As with <see cref="MinHashIndex"/>, this returns <b>candidates</b>. Compare them
+    /// with <see cref="SimHash.HammingDistance"/>; the index exists to make that
+    /// comparison cheap, not to replace it.
+    /// </para>
+    /// </remarks>
+    public class SimHashIndex
+    {
+        private const int FingerprintBits = 64;
+
+        private readonly int bands;
+        private readonly int bandBits;
+        private readonly Dictionary<ulong, List<string>> buckets = new Dictionary<ulong, List<string>>();
+
+        /// <summary>
+        /// Creates an index cutting each fingerprint into the given number of bands.
+        /// </summary>
+        /// <param name="bands">
+        /// How many bands, which must divide 64. Anything differing in fewer than this
+        /// many bits is guaranteed to be returned.
+        /// </param>
+        public SimHashIndex(int bands)
+        {
+            if (bands < 1 || bands > FingerprintBits || FingerprintBits % bands != 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(bands), bands,
+                    "The band count has to divide 64 evenly, so that every band is the " +
+                    "same width and the guarantee holds for all of them.");
+            }
+
+            this.bands = bands;
+            this.bandBits = FingerprintBits / bands;
+        }
+
+        /// <summary>
+        /// The Hamming distance within which retrieval is certain.
+        /// </summary>
+        public int GuaranteedWithin() => this.bands - 1;
+
+        /// <summary>
+        /// Adds a fingerprint under an identifier.
+        /// </summary>
+        /// <param name="id">What to return when this fingerprint is a candidate.</param>
+        /// <param name="signature">The fingerprint to index.</param>
+        public void Add(string id, SimHashSignature signature)
+        {
+            ArgumentNullException.ThrowIfNull(id);
+            ArgumentNullException.ThrowIfNull(signature);
+
+            foreach (var key in this.BandsOf(signature.Value))
+            {
+                if (!this.buckets.TryGetValue(key, out var members))
+                {
+                    members = new List<string>();
+                    this.buckets[key] = members;
+                }
+
+                if (!members.Contains(id))
+                {
+                    members.Add(id);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The identifiers worth comparing against this fingerprint.
+        /// </summary>
+        /// <param name="signature">The fingerprint to look for neighbours of.</param>
+        /// <returns>Candidates, in no particular order.</returns>
+        public IReadOnlyCollection<string> Query(SimHashSignature signature)
+        {
+            ArgumentNullException.ThrowIfNull(signature);
+
+            var found = new HashSet<string>();
+
+            foreach (var key in this.BandsOf(signature.Value))
+            {
+                if (this.buckets.TryGetValue(key, out var members))
+                {
+                    foreach (var member in members)
+                    {
+                        found.Add(member);
+                    }
+                }
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        /// One bucket key per band: the band's bits, tagged with which band they came
+        /// from so that identical bits in different positions do not collide.
+        /// </summary>
+        private ulong[] BandsOf(ulong fingerprint)
+        {
+            var keys = new ulong[this.bands];
+            var mask = this.bandBits == 64 ? ulong.MaxValue : (1UL << this.bandBits) - 1;
+
+            for (var band = 0; band < this.bands; band++)
+            {
+                var bits = (fingerprint >> (band * this.bandBits)) & mask;
+                keys[band] = (bits << 8) | (uint)band;
+            }
+
+            return keys;
+        }
+
+        /// <summary>The number of bands each fingerprint is cut into.</summary>
+        public int Bands() => this.bands;
+
+        /// <summary>The number of identifiers indexed.</summary>
+        public int Count()
+        {
+            var all = new HashSet<string>();
+            foreach (var bucket in this.buckets.Values)
+            {
+                foreach (var member in bucket)
+                {
+                    all.Add(member);
+                }
+            }
+
+            return all.Count;
+        }
+    }
+}

--- a/ProbabilisticDataStructures/SimHashSignature.cs
+++ b/ProbabilisticDataStructures/SimHashSignature.cs
@@ -14,7 +14,16 @@ namespace ProbabilisticDataStructures
     /// </remarks>
     public sealed class SimHashSignature : IBinaryPersistable<SimHashSignature>
     {
-        internal SimHashSignature(ulong value)
+        /// <summary>
+        /// Wraps a fingerprint that has already been computed, or stored elsewhere.
+        /// </summary>
+        /// <param name="value">The fingerprint.</param>
+        /// <remarks>
+        /// A fingerprint is only comparable against one built the same way, so this is
+        /// for a value that came from <see cref="SimHash.Signature"/> -- here, or in
+        /// another process, or out of a column in a database.
+        /// </remarks>
+        public SimHashSignature(ulong value)
         {
             this.Value = value;
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Probabilistic Data Structures for C<span>#</span> [![CI](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml/badge.svg)](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml) [![NuGet](https://img.shields.io/nuget/v/MattLorimor.ProbabilisticDataStructures.svg)](https://www.nuget.org/packages/MattLorimor.ProbabilisticDataStructures/)
 
-Twenty-two structures that answer questions about data too large to keep, by keeping
+Twenty-four structures that answer questions about data too large to keep, by keeping
 something much smaller and being approximately right.
 
 Each one trades exactness for space. What makes them usable is that the trade is
@@ -44,6 +44,7 @@ eleven structures the Go library does not have.
 | What are the most common things? | `TopK` | [Frequency](#frequency) |
 | How alike are these two **sets**? | `MinHash` | [Similarity](#similarity) |
 | Are these two **documents** near-duplicates? | `SimHash` | [Similarity](#similarity) |
+| …across a corpus, without comparing every pair | `MinHashIndex`, `SimHashIndex` | [Similarity](#similarity) |
 | What does this distribution look like? p50, p99? | `DDSketch` | [Distributions](#distributions) |
 
 ### If you only read one thing
@@ -788,10 +789,47 @@ float similarity = SimHash.Similarity(a, b);
 From Charikar,
 [Similarity Estimation Techniques from Rounding Algorithms](https://dl.acm.org/doi/10.1145/509907.509965).
 
-> **Both are still O(n²) to search.** Neither ships an index, so finding near-duplicates
-> among a million documents is a trillion comparisons. That gap is tracked in
-> [#74](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/74) and is
-> probably the most useful thing left to add.
+### `MinHashIndex` and `SimHashIndex`
+
+Signatures answer "are these two alike". An index answers "which of these million are
+worth asking about", without comparing every pair.
+
+```C#
+var index = MinHashIndex.ForThreshold(0.8, signatureLength: 128);
+foreach (var (id, signature) in corpus) index.Add(id, signature);
+
+foreach (var candidate in index.Query(query))
+{
+    // now compare properly -- these are candidates, not answers
+}
+```
+
+**Reach for them when** you are searching a corpus rather than comparing a pair. That is
+the difference between a trillion comparisons and a few hundred.
+
+**Look elsewhere if** you have two things and want to know how alike they are. Use the
+signatures directly.
+
+> **These are the only structures here whose failure is a *missing* answer.** Everything
+> else errs towards saying yes; an index can fail to offer a pair that really is similar,
+> and no amount of checking candidates afterwards recovers it — it was never offered.
+> `MinHashIndex.RecallAt(resemblance)` tells you how often that happens, and is worth
+> reading before trusting a setting.
+
+`ForThreshold` deliberately errs towards **returning too much**. Only the divisors of the
+signature length are available, so the curve lands near the threshold rather than on it,
+and rounding the wrong way is expensive: at 128 values and a threshold of 0.8, picking the
+nearest configuration regardless of side gives **20% recall at the threshold itself**.
+Rounding the other way gives 95% and costs some extra candidates, which you discard.
+
+`SimHashIndex` has a guarantee its sibling cannot offer. Cutting a 64-bit fingerprint into
+*b* bands means two fingerprints differing in fewer than *b* bits **must** agree on at
+least one band — there are only *b*−1 differing bits to spread across *b* bands, so one
+band gets none. Within that distance retrieval is certain rather than probable. Eight bands
+guarantees everything within seven bits.
+
+Neither index is persistable, deliberately: an index is derived data, rebuildable from the
+signatures you already store, and storing it would mean keeping two things in step.
 
 ---
 

--- a/TestProbabilisticDataStructures/TestSignatureIndexes.cs
+++ b/TestProbabilisticDataStructures/TestSignatureIndexes.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    [TestClass]
+    public class TestSignatureIndexes
+    {
+        /// <summary>A document sharing a given fraction of its terms with a base one.</summary>
+        private static string[] Document(int id, int terms = 200, int sharedWith = -1, int shared = 0)
+        {
+            if (sharedWith < 0)
+            {
+                return Enumerable.Range(0, terms).Select(i => $"doc{id}-term{i}").ToArray();
+            }
+
+            return Enumerable.Range(0, shared).Select(i => $"doc{sharedWith}-term{i}")
+                .Concat(Enumerable.Range(0, terms - shared).Select(i => $"doc{id}-term{i}"))
+                .ToArray();
+        }
+
+        [TestMethod]
+        public void TestASignatureFindsItself()
+        {
+            var index = new MinHashIndex(bands: 16, rows: 8);
+            var signature = MinHash.Signature(Document(1), 128);
+
+            index.Add("doc1", signature);
+
+            CollectionAssert.AreEquivalent(new[] { "doc1" }, index.Query(signature).ToArray());
+        }
+        /// <summary>
+        /// The point: a near-duplicate is found without comparing against everything.
+        /// </summary>
+        [TestMethod]
+        public void TestANearDuplicateIsFoundAmongManyDocuments()
+        {
+            var index = MinHashIndex.ForThreshold(0.7, signatureLength: 128);
+
+            // A thousand unrelated documents.
+            for (var i = 0; i < 1000; i++)
+            {
+                index.Add($"doc{i}", MinHash.Signature(Document(i), 128));
+            }
+
+            // One that shares 90% of its terms with doc7.
+            var nearDuplicate = MinHash.Signature(Document(9999, sharedWith: 7, shared: 180), 128);
+            var candidates = index.Query(nearDuplicate);
+
+            Assert.Contains("doc7", candidates.ToArray(),
+                "the near-duplicate's neighbour was not offered as a candidate");
+
+            // And it did not simply return everything, which would be a correct but
+            // useless index.
+            Assert.IsLessThan(50, candidates.Count,
+                $"the index returned {candidates.Count} of 1000 documents, which is not " +
+                "narrowing anything down");
+        }
+
+        /// <summary>
+        /// The failure mode is a <b>missing</b> answer, which is new here -- everything
+        /// else in this library errs towards saying yes. Recall is a number the caller
+        /// has to look at, so it is exposed rather than buried, and this pins its shape.
+        /// </summary>
+        [TestMethod]
+        public void TestRecallRisesSteeplyAroundTheThreshold()
+        {
+            var index = MinHashIndex.ForThreshold(0.8, signatureLength: 128);
+
+            // At the threshold itself, recall must already be high. Choosing the
+            // configuration by nearest steep point regardless of side gave 20% here,
+            // which is a silently lossy index sold as a threshold of 0.8.
+            Assert.IsGreaterThan(0.9, index.RecallAt(0.8),
+                $"pairs at exactly the 0.8 threshold are returned only " +
+                $"{index.RecallAt(0.8):P0} of the time");
+
+            // Above it, near certainty.
+            Assert.IsGreaterThan(0.99, index.RecallAt(0.95),
+                $"pairs at 0.95 are returned only {index.RecallAt(0.95):P0} of the time");
+
+            // Well below it, few -- or the index is not narrowing anything down.
+            Assert.IsLessThan(0.15, index.RecallAt(0.5),
+                $"pairs at 0.5 resemblance are returned {index.RecallAt(0.5):P0} of the " +
+                "time, which is not a threshold at 0.8");
+
+            // And it is monotonic, or it is not a threshold at all.
+            var previous = 0.0;
+            for (var s = 0.0; s <= 1.0; s += 0.05)
+            {
+                var recall = index.RecallAt(s);
+                Assert.IsGreaterThanOrEqualTo(previous, recall, $"recall fell at {s}");
+                previous = recall;
+            }
+        }
+
+        [TestMethod]
+        public void TestTheIndexRefusesSignaturesItCannotHold()
+        {
+            var index = new MinHashIndex(16, 8);
+
+            var ex = Assert.ThrowsExactly<ArgumentException>(
+                () => index.Add("a", MinHash.Signature(Document(1), 64)));
+            StringAssert.Contains(ex.Message, "128 values");
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => index.Add(null!, MinHash.Signature(Document(1), 128)));
+            Assert.ThrowsExactly<ArgumentNullException>(() => index.Add("a", null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => index.Query(null!));
+
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new MinHashIndex(0, 8));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new MinHashIndex(8, 0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => MinHashIndex.ForThreshold(0, 128));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => MinHashIndex.ForThreshold(1, 128));
+        }
+
+        /// <summary>
+        /// The SimHash index has a guarantee its MinHash counterpart cannot: splitting a
+        /// 64-bit fingerprint into b bands means two fingerprints differing in fewer than
+        /// b bits must agree on at least one band, by the pigeonhole principle. So within
+        /// that distance retrieval is <b>certain</b> rather than probable.
+        /// </summary>
+        [TestMethod]
+        public void TestSimHashNeighboursWithinTheBandCountAreAlwaysFound()
+        {
+            var index = new SimHashIndex(bands: 8);
+            var reference = SimHash.Signature(Document(1));
+            index.Add("doc1", reference);
+
+            // Every fingerprint within 7 bits of the reference, by construction.
+            for (var bit = 0; bit < 64; bit++)
+            {
+                var flipped = new SimHashSignature(reference.Value ^ (1UL << bit));
+                Assert.Contains("doc1", index.Query(flipped).ToArray(),
+                    $"a fingerprint one bit away was not found when flipping bit {bit}");
+            }
+
+            // Seven flips is still guaranteed with eight bands.
+            var sevenAway = reference.Value;
+            for (var bit = 0; bit < 7; bit++)
+            {
+                sevenAway ^= 1UL << (bit * 9);
+            }
+
+            Assert.Contains("doc1", index.Query(new SimHashSignature(sevenAway)).ToArray(),
+                "a fingerprint seven bits away was not found by an eight-band index");
+        }
+
+        [TestMethod]
+        public void TestSimHashIndexNarrowsDownACorpus()
+        {
+            var index = new SimHashIndex(bands: 8);
+
+            for (var i = 0; i < 2000; i++)
+            {
+                index.Add($"doc{i}", SimHash.Signature(Document(i)));
+            }
+
+            var nearDuplicate = SimHash.Signature(Document(9999, sharedWith: 7, shared: 190));
+            var candidates = index.Query(nearDuplicate);
+
+            Assert.Contains("doc7", candidates.ToArray(), "the near-duplicate was not found");
+            Assert.IsLessThan(100, candidates.Count,
+                $"the index offered {candidates.Count} of 2000 documents");
+        }
+
+        [TestMethod]
+        public void TestSimHashIndexRefusesABandCountItCannotUse()
+        {
+            foreach (var bad in new[] { 0, 3, 5, 7, 65 })
+            {
+                Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new SimHashIndex(bad));
+            }
+
+            _ = new SimHashIndex(1);
+            _ = new SimHashIndex(64);
+
+            var index = new SimHashIndex(8);
+            Assert.ThrowsExactly<ArgumentNullException>(() => index.Add("a", null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => index.Add(null!, SimHash.Signature(Document(1))));
+            Assert.ThrowsExactly<ArgumentNullException>(() => index.Query(null!));
+        }
+
+    }
+}


### PR DESCRIPTION
Fourth of the five. The library produced two kinds of similarity fingerprint and no way to
use them at scale — finding near-duplicates among a million documents was still a trillion
comparisons. #62 noted at the time that an index was probably worth more than another
fingerprint. This is that.

```C#
var index = MinHashIndex.ForThreshold(0.8, signatureLength: 128);
foreach (var (id, signature) in corpus) index.Add(id, signature);

foreach (var candidate in index.Query(query)) { /* now compare properly */ }
```

## These are the first structures here that can be silently wrong by omission

Everything else in this library errs towards saying yes. An index can **fail to offer a
pair that really is similar**, and checking the candidates afterwards does not recover it —
it was never offered. `RecallAt(resemblance)` exposes how often that happens rather than
leaving it to be discovered.

## A test caught the design getting that backwards

My first `ForThreshold` picked the configuration whose S-curve steep point was nearest the
requested threshold, regardless of which side it fell on. For 128 values at a threshold of
0.8 that chose 8 bands — steep point 0.87 — giving **20% recall at exactly the threshold
asked for**. An index sold as "0.8" that misses four fifths of the pairs at 0.8.

It now rounds the other way: 95% recall at the threshold, at the cost of extra candidates
the caller discards. **Too many candidates is work; too few is a wrong answer that never
announces itself**, and for these two structures that asymmetry should decide every close
call.

## `SimHashIndex` gets a guarantee its sibling cannot

Cutting a 64-bit fingerprint into *b* bands means two fingerprints differing in fewer than
*b* bits **must** agree on at least one band — there are only *b*−1 differing bits to
spread across *b* bands, so one band gets none. Retrieval within that distance is
**certain**, not probable. There is a test flipping every single bit of a fingerprint and
asserting all 64 neighbours are found.

## Deliberately not persistable

An index is derived data, rebuildable from signatures that already persist. Storing it
would mean keeping two things in step, and the structures it indexes are the source of
truth. `SimHashSignature`'s constructor is now public so a fingerprint held elsewhere — a
database column, another process — can be wrapped and queried.

441 tests. Release build clean under `-warnaserror`.