### PR TITLE
Add SlidingWindow (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`SlidingWindow<T>`**, so questions can be asked about recent data rather than about
+  everything since the structure was made, which is
+  [#75](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/75). It holds one
+  structure per time bucket and combines the live ones on demand.
+
+  A wrapper rather than a family of windowed structures, because 5.1.0 and 6.0.0 made most
+  of the library merge exactly -- a ring of sub-structures gets the same answer from one
+  implementation instead of a paper's worth of work per structure. It costs memory, one
+  structure per bucket, and precision at the edge: the window is only as sharp as a bucket
+  is wide.
+
+  **`TopK` is refused by name.** Its merge is approximate -- an element genuinely in the
+  top-k of the whole window can be absent from every bucket's own top-k -- so a window over
+  it would drop elements as buckets rolled and nothing about the result would look wrong.
+  The exception says to window a `CountMinSketch` instead.
+
+  The clock is injectable, which is what makes a window's behaviour testable without
+  waiting for it.
+
 - **`MinHashIndex` and `SimHashIndex`**, so that the signatures this library produces can
   be searched rather than only compared, which is
   [#74](https://github.com/mattlorimor/ProbabilisticDataStructures/issues/74). Without an

--- a/ProbabilisticDataStructures/SlidingWindow.cs
+++ b/ProbabilisticDataStructures/SlidingWindow.cs
@@ -1,0 +1,179 @@
+using System;
+
+namespace ProbabilisticDataStructures
+{
+    /// <summary>
+    /// Keeps a structure over a moving window of recent time, by holding one of them per
+    /// time bucket and combining the live ones on demand.
+    /// </summary>
+    /// <typeparam name="T">The structure being windowed.</typeparam>
+    /// <remarks>
+    /// Everything else here answers about the whole stream since it was created. This
+    /// answers "in the last hour", which is how most of these questions are actually
+    /// asked: distinct users today, top paths this minute, the p99 of the last five.
+    /// <para>
+    /// It is a wrapper rather than a family of windowed structures because 5.1.0 and
+    /// 6.0.0 made most of the library mergeable, and a ring of sub-structures merged on
+    /// query gets the same answer for one implementation instead of a paper's worth of
+    /// work per structure. What it costs is memory -- one structure per bucket -- and
+    /// precision at the edge: the window is only as sharp as a bucket is wide.
+    /// </para>
+    /// <para>
+    /// <b>Only use this over a structure whose merge is exact.</b> Merging is what makes
+    /// the window's answer mean anything, so a structure that merges approximately gives
+    /// a window that is wrong in a way no amount of bucketing fixes.
+    /// <see cref="TopK"/> is the one in this library that does, and is refused by name.
+    /// </para>
+    /// </remarks>
+    public class SlidingWindow<T>
+        where T : class
+    {
+        private readonly TimeSpan bucketWidth;
+        private readonly int buckets;
+        private readonly Func<T> create;
+        private readonly Func<T, T, T> merge;
+        private readonly Func<DateTimeOffset> clock;
+
+        private readonly T[] ring;
+        private readonly long[] ages;
+
+        /// <summary>
+        /// Creates a window of the given length, divided into buckets.
+        /// </summary>
+        /// <param name="window">How far back the window reaches.</param>
+        /// <param name="buckets">
+        /// How many buckets to divide it into. The window's edge is only as sharp as one
+        /// bucket, and memory is one structure per bucket, so this is the trade and it is
+        /// the caller's to make.
+        /// </param>
+        /// <param name="create">Makes a fresh, empty structure for a new bucket.</param>
+        /// <param name="merge">
+        /// Combines two structures. Must be exact -- see the remarks on this type.
+        /// </param>
+        /// <param name="clock">
+        /// Where the current time comes from, or null for the system clock. Supplying one
+        /// is what makes a window's behaviour testable without waiting for it.
+        /// </param>
+        public SlidingWindow(
+            TimeSpan window,
+            int buckets,
+            Func<T> create,
+            Func<T, T, T> merge,
+            Func<DateTimeOffset>? clock = null)
+        {
+            ArgumentNullException.ThrowIfNull(create);
+            ArgumentNullException.ThrowIfNull(merge);
+
+            if (window <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(window), window, "A window covers a positive span of time.");
+            }
+
+            if (buckets < 1)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(buckets), buckets, "A window needs at least one bucket.");
+            }
+
+            // Refused by name rather than left to be discovered. TopK.Merge is documented
+            // as approximate -- two sketches can disagree about what was frequent, and an
+            // element in the top-k of the union can be missing from both inputs' top-k --
+            // so a window built on it would drop elements as buckets rolled, and nothing
+            // about the result would look wrong.
+            if (typeof(T) == typeof(TopK))
+            {
+                throw new ArgumentException(
+                    "A sliding window cannot be built over TopK. Its merge is " +
+                    "approximate: an element genuinely in the top-k of the whole window " +
+                    "can be absent from every bucket's own top-k, so combining the " +
+                    "buckets would lose it silently. Window a CountMinSketch instead and " +
+                    "take the heavy hitters from that.",
+                    nameof(T));
+            }
+
+            this.bucketWidth = TimeSpan.FromTicks(Math.Max(1, window.Ticks / buckets));
+            this.buckets = buckets;
+            this.create = create;
+            this.merge = merge;
+            this.clock = clock ?? (() => DateTimeOffset.UtcNow);
+
+            this.ring = new T[buckets];
+            this.ages = new long[buckets];
+
+            var now = this.CurrentBucket();
+            for (var i = 0; i < buckets; i++)
+            {
+                this.ring[i] = create();
+
+                // Older than any live bucket, so an untouched slot is expired rather
+                // than counted as part of the first window.
+                this.ages[i] = now - buckets;
+            }
+        }
+
+        /// <summary>
+        /// The structure covering the current moment, to add to.
+        /// </summary>
+        /// <remarks>
+        /// Reading this rolls the window: whichever bucket now covers the present is
+        /// emptied first if it was holding something from a previous lap.
+        /// </remarks>
+        public T Current
+        {
+            get
+            {
+                var bucket = this.CurrentBucket();
+                var slot = (int)(((bucket % this.buckets) + this.buckets) % this.buckets);
+
+                if (this.ages[slot] != bucket)
+                {
+                    this.ring[slot] = this.create();
+                    this.ages[slot] = bucket;
+                }
+
+                return this.ring[slot];
+            }
+        }
+
+        /// <summary>
+        /// A structure combining every bucket still inside the window.
+        /// </summary>
+        /// <returns>
+        /// A new structure. Buckets that have fallen out of the window are not included,
+        /// and neither is anything written to them before they did.
+        /// </returns>
+        public T Merged()
+        {
+            var newest = this.CurrentBucket();
+            var oldest = newest - this.buckets + 1;
+
+            var combined = this.create();
+
+            for (var slot = 0; slot < this.buckets; slot++)
+            {
+                if (this.ages[slot] >= oldest && this.ages[slot] <= newest)
+                {
+                    combined = this.merge(combined, this.ring[slot]);
+                }
+            }
+
+            return combined;
+        }
+
+        /// <summary>
+        /// Which bucket the present falls in, counted from the epoch so that the number
+        /// increases forever and expiry is a comparison rather than bookkeeping.
+        /// </summary>
+        private long CurrentBucket()
+        {
+            return this.clock().UtcTicks / this.bucketWidth.Ticks;
+        }
+
+        /// <summary>How wide each bucket is, which is the window's precision.</summary>
+        public TimeSpan BucketWidth => this.bucketWidth;
+
+        /// <summary>How many buckets the window is divided into.</summary>
+        public int Buckets => this.buckets;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Probabilistic Data Structures for C<span>#</span> [![CI](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml/badge.svg)](https://github.com/mattlorimor/ProbabilisticDataStructures/actions/workflows/ci.yml) [![NuGet](https://img.shields.io/nuget/v/MattLorimor.ProbabilisticDataStructures.svg)](https://www.nuget.org/packages/MattLorimor.ProbabilisticDataStructures/)
 
-Twenty-four structures that answer questions about data too large to keep, by keeping
+Twenty-five structures that answer questions about data too large to keep, by keeping
 something much smaller and being approximately right.
 
 Each one trades exactness for space. What makes them usable is that the trade is
@@ -46,6 +46,7 @@ eleven structures the Go library does not have.
 | Are these two **documents** near-duplicates? | `SimHash` | [Similarity](#similarity) |
 | …across a corpus, without comparing every pair | `MinHashIndex`, `SimHashIndex` | [Similarity](#similarity) |
 | What does this distribution look like? p50, p99? | `DDSketch` | [Distributions](#distributions) |
+| …but only about the **last hour** | `SlidingWindow<T>` | [Recent data](#recent-data) |
 
 ### If you only read one thing
 
@@ -868,6 +869,43 @@ bytes, and so the only one that never hashes.
 
 From Masson, Rim and Lee,
 [DDSketch](https://arxiv.org/abs/1908.10693).
+
+---
+
+## Recent data
+
+Every structure above answers about the whole stream since it was created. `SlidingWindow<T>`
+answers about the recent past instead, which is how most of these questions are actually
+asked: distinct users today, the p99 of the last five minutes, top paths this hour.
+
+```C#
+var window = new SlidingWindow<HyperLogLogPlus>(
+    window: TimeSpan.FromHours(1),
+    buckets: 60,
+    create: () => new HyperLogLogPlus(14),
+    merge: (a, b) => a.Merge(b));
+
+window.Current.Add(item);              // writes to the bucket covering now
+ulong lastHour = window.Merged().Count();   // combines the buckets still in the window
+```
+
+**Reach for it when** the age of the data matters. **Look elsewhere if** it does not — a
+plain structure is one object rather than sixty.
+
+It is a wrapper rather than a family of windowed structures because so much of this library
+merges exactly. A ring of sub-structures combined on query gets the same answer from one
+implementation, instead of a paper's worth of work per structure. What it costs is memory —
+one structure per bucket — and precision at the edge: **the window is only as sharp as a
+bucket is wide**. Sixty buckets over an hour means the boundary is accurate to a minute.
+
+> **Only window a structure whose merge is exact.** Merging is what makes the answer mean
+> anything, so an approximate merge gives a window that is wrong in a way no amount of
+> bucketing fixes. `TopK` is the one here that qualifies, and it is **refused by name** —
+> an element genuinely in the top-k of the whole window can be absent from every bucket's
+> own top-k, so combining them would lose it and nothing about the result would look wrong.
+> Window a `CountMinSketch` and take the heavy hitters from that.
+
+Pass a clock to the constructor to test a window's behaviour without waiting for it.
 
 ---
 

--- a/TestProbabilisticDataStructures/TestSlidingWindow.cs
+++ b/TestProbabilisticDataStructures/TestSlidingWindow.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Buffers.Binary;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    [TestClass]
+    public class TestSlidingWindow
+    {
+        private static byte[] Item(long i)
+        {
+            var key = new byte[8];
+            BinaryPrimitives.WriteInt64LittleEndian(key, i);
+            return key;
+        }
+
+        /// <summary>A clock the test moves by hand, since the behaviour is about time.</summary>
+        private sealed class TestClock
+        {
+            internal DateTimeOffset Now { get; set; } = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+            internal void Advance(TimeSpan by) => this.Now += by;
+        }
+
+        [TestMethod]
+        public void TestWhatWasAddedIsVisible()
+        {
+            var clock = new TestClock();
+            var window = new SlidingWindow<HyperLogLogPlus>(
+                TimeSpan.FromMinutes(60), buckets: 60,
+                () => new HyperLogLogPlus(12), (a, b) => a.Merge(b), () => clock.Now);
+
+            for (var i = 0; i < 500; i++)
+            {
+                window.Current.Add(Item(i));
+            }
+
+            Assert.AreEqual(500ul, window.Merged().Count());
+        }
+        /// <summary>
+        /// Precision 14, so that every count these tests take stays inside the
+        /// estimator's exact sparse form -- it keeps hashes rather than registers below
+        /// 2,048 distinct items, and the assertions here are exact equalities.
+        /// <para>
+        /// Precision 12 was the first choice and was wrong: its sparse form ends at 512,
+        /// so a test counting 600 items compared an exact expectation against an estimate
+        /// and failed at 607. The window was right; the test was asserting the wrong kind
+        /// of thing.
+        /// </para>
+        /// </summary>
+        private static SlidingWindow<HyperLogLogPlus> Estimator(TestClock clock, int minutes = 60, int buckets = 60)
+        {
+            return new SlidingWindow<HyperLogLogPlus>(
+                TimeSpan.FromMinutes(minutes), buckets,
+                () => new HyperLogLogPlus(14), (a, b) => a.Merge(b), () => clock.Now);
+        }
+
+        /// <summary>
+        /// The whole point: what happened long enough ago stops counting.
+        /// </summary>
+        [TestMethod]
+        public void TestWhatFallsOutOfTheWindowStopsCounting()
+        {
+            var clock = new TestClock();
+            var window = Estimator(clock);
+
+            for (var i = 0; i < 500; i++)
+            {
+                window.Current.Add(Item(i));
+            }
+
+            Assert.AreEqual(500ul, window.Merged().Count());
+
+            // Past the end of the window, so none of it is left.
+            clock.Advance(TimeSpan.FromMinutes(61));
+            Assert.AreEqual(0ul, window.Merged().Count(),
+                "items an hour past a one-hour window were still counted");
+
+            // And the window still works afterwards, rather than being spent.
+            for (var i = 1000; i < 1300; i++)
+            {
+                window.Current.Add(Item(i));
+            }
+
+            Assert.AreEqual(300ul, window.Merged().Count());
+        }
+
+        /// <summary>
+        /// A window is not a switch: as it rolls, the oldest bucket leaves and the rest
+        /// stay, so the count falls gradually rather than all at once.
+        /// </summary>
+        [TestMethod]
+        public void TestTheWindowRollsRatherThanResetting()
+        {
+            var clock = new TestClock();
+            var window = Estimator(clock, minutes: 60, buckets: 6);
+
+            // A hundred distinct items per ten-minute bucket, advancing *between* writes
+            // rather than after the last -- one more step and the first bucket would
+            // already have rolled off, which is what the window is for.
+            for (var bucket = 0; bucket < 6; bucket++)
+            {
+                if (bucket > 0)
+                {
+                    clock.Advance(TimeSpan.FromMinutes(10));
+                }
+
+                for (var i = 0; i < 100; i++)
+                {
+                    window.Current.Add(Item((bucket * 1000) + i));
+                }
+            }
+
+            Assert.AreEqual(600ul, window.Merged().Count(),
+                "six buckets of a hundred did not come to six hundred");
+
+            // Each further step drops exactly one bucket's worth, rather than the whole
+            // window going at once.
+            for (var expected = 500ul; ; expected -= 100)
+            {
+                clock.Advance(TimeSpan.FromMinutes(10));
+
+                Assert.AreEqual(expected, window.Merged().Count(),
+                    $"the window should have held {expected} after rolling");
+
+                if (expected == 0)
+                {
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The wrapper works over anything that merges exactly, not just one structure.
+        /// </summary>
+        [TestMethod]
+        public void TestItWindowsOtherStructuresToo()
+        {
+            var clock = new TestClock();
+            var window = new SlidingWindow<CountMinSketch>(
+                TimeSpan.FromMinutes(10), buckets: 10,
+                () => new CountMinSketch(0.01, 0.01), (a, b) => { a.Merge(b); return a; },
+                () => clock.Now);
+
+            for (var i = 0; i < 50; i++)
+            {
+                window.Current.Add(Item(1));
+            }
+
+            Assert.AreEqual(50ul, window.Merged().Count(Item(1)));
+
+            clock.Advance(TimeSpan.FromMinutes(11));
+            Assert.AreEqual(0ul, window.Merged().Count(Item(1)));
+        }
+
+        /// <summary>
+        /// <see cref="TopK"/> is refused by name, because its merge is approximate and a
+        /// window built on it would drop elements as buckets rolled without anything
+        /// about the result looking wrong.
+        /// </summary>
+        [TestMethod]
+        public void TestAStructureThatDoesNotMergeExactlyIsRefused()
+        {
+            var ex = Assert.ThrowsExactly<ArgumentException>(() => new SlidingWindow<TopK>(
+                TimeSpan.FromMinutes(10), 10, () => new TopK(0.001, 0.01, 10),
+                (a, b) => a.Merge(b)));
+
+            StringAssert.Contains(ex.Message, "approximate");
+            StringAssert.Contains(ex.Message, "CountMinSketch");
+        }
+
+        [TestMethod]
+        public void TestBadArgumentsAreRefused()
+        {
+            var clock = new TestClock();
+
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new SlidingWindow<HyperLogLogPlus>(
+                TimeSpan.Zero, 10, () => new HyperLogLogPlus(12), (a, b) => a.Merge(b)));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new SlidingWindow<HyperLogLogPlus>(
+                TimeSpan.FromMinutes(-1), 10, () => new HyperLogLogPlus(12), (a, b) => a.Merge(b)));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new SlidingWindow<HyperLogLogPlus>(
+                TimeSpan.FromMinutes(10), 0, () => new HyperLogLogPlus(12), (a, b) => a.Merge(b)));
+
+            Assert.ThrowsExactly<ArgumentNullException>(() => new SlidingWindow<HyperLogLogPlus>(
+                TimeSpan.FromMinutes(10), 10, null!, (a, b) => a.Merge(b)));
+            Assert.ThrowsExactly<ArgumentNullException>(() => new SlidingWindow<HyperLogLogPlus>(
+                TimeSpan.FromMinutes(10), 10, () => new HyperLogLogPlus(12), null!));
+
+            // The precision is what the caller asked for, and is worth being able to read.
+            var window = Estimator(clock, minutes: 60, buckets: 6);
+            Assert.AreEqual(TimeSpan.FromMinutes(10), window.BucketWidth);
+            Assert.AreEqual(6, window.Buckets);
+        }
+
+        /// <summary>
+        /// A window that has never been written to holds nothing, rather than counting
+        /// its empty buckets as part of the first window.
+        /// </summary>
+        [TestMethod]
+        public void TestAFreshWindowHoldsNothing()
+        {
+            Assert.AreEqual(0ul, Estimator(new TestClock()).Merged().Count());
+        }
+
+    }
+}


### PR DESCRIPTION
Last of the five. Every structure here answered about the whole stream since it was
created; this answers about the last hour.

```C#
var window = new SlidingWindow<HyperLogLogPlus>(
    TimeSpan.FromHours(1), buckets: 60,
    () => new HyperLogLogPlus(14), (a, b) => a.Merge(b));

window.Current.Add(item);
ulong lastHour = window.Merged().Count();
```

## The design decision

I filed #75 saying it needed one before any code. Here it is: **a wrapper, not a family of
windowed structures.**

5.1.0 and 6.0.0 made most of this library merge exactly, so a ring of sub-structures
combined on query reaches the same answer from **one** implementation instead of a paper's
worth of work per structure. The cost is memory — one structure per bucket — and precision
at the edge, since the window is only as sharp as a bucket is wide.

## `TopK` is refused by name

Its merge is approximate: an element genuinely in the top-k of the whole window can be
absent from every bucket's own top-k, so combining them would lose it and **nothing about
the result would look wrong**. The exception says to window a `CountMinSketch` and take the
heavy hitters from that.

A runtime type check is inelegant, but the alternative is a silently lossy window, and this
seemed like the wrong place to prefer elegance.

## Two of my tests were wrong before the code was

Worth recording, because in both cases the structure was right and the test was not.

**The first advanced the clock after the last write**, then asserted the window still held
all six buckets. It had rolled — correctly — and dropped the oldest. Off-by-one in the
test, not the ring.

**The second asserted exact counts against a `HyperLogLogPlus` at precision 12**, whose
exact sparse form ends at 512 items. A count of 600 came back as 607 — a perfectly good
estimate, compared against an exact expectation. Precision 14 keeps every count in these
tests inside the exact range, and the helper now says why so the next person does not
re-learn it.

The clock is injectable, which is what makes any of this testable without waiting an hour.

448 tests. Release build clean under `-warnaserror`.