### PR TITLE
Per-release notes on GitHub Releases and NuGet packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,15 +45,38 @@ jobs:
             exit 1
           fi
 
+      # The changelog section for this version becomes the GitHub release body
+      # and the package's release notes. No section means the changelog was not
+      # updated for this release, which is worth failing over.
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="${version}" '
+            index($0, "## [" ver "]") == 1 { found = 1; next }
+            found && /^## \[/ { exit }
+            found && /^\[[^]]*\]: / { exit }
+            found { print }
+          ' CHANGELOG.md | sed -e '/./,$!d' > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::CHANGELOG.md has no section for ${version}. Add '## [${version}]' with the release's changes, then retag."
+            exit 1
+          fi
+          printf '\nFull history: https://github.com/%s/blob/%s/CHANGELOG.md\n' \
+            "${GITHUB_REPOSITORY}" "${GITHUB_REF_NAME}" >> release-notes.md
+
       - name: Build
         run: dotnet build --configuration Release -warnaserror
 
       - name: Test
         run: dotnet test --configuration Release --no-build
 
+      # The notes travel by file, not by -p:PackageReleaseNotes=..., because
+      # MSBuild's command line splits property values on semicolons and commas.
       - name: Pack
         run: dotnet pack ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
           --configuration Release --no-build --output artifacts
+          -p:PackageReleaseNotesFile="${PWD}/release-notes.md"
 
       - name: Upload packages as build artifacts
         uses: actions/upload-artifact@v7
@@ -96,5 +119,5 @@ jobs:
           gh release create "${GITHUB_REF_NAME}"
           --repo "${GITHUB_REPOSITORY}"
           --title "${GITHUB_REF_NAME}"
-          --notes "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${GITHUB_REF_NAME}/CHANGELOG.md)."
+          --notes-file release-notes.md
           artifacts/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1061,7 +1061,17 @@ This release modernizes the entire build. The library had not been touched since
 - Initial release: a C# port of [Tyler Treat's](https://github.com/tylertreat)
   [BoomFilters](https://github.com/tylertreat/BoomFilters) Go project.
 
-[3.1.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v6.1.0...HEAD
+[6.1.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v6.0.1...v6.1.0
+[6.0.1]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v6.0.0...v6.0.1
+[6.0.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v5.2.0...v6.0.0
+[5.2.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v5.1.0...v5.2.0
+[5.1.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v5.0.0...v5.1.0
+[5.0.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v4.0.1...v5.0.0
+[4.0.1]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v4.0.0...v4.0.1
+[4.0.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v3.2.0...v4.0.0
+[3.2.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v3.1.0...v3.2.0
+[3.1.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v2.0.1...v3.0.0
 [2.0.1]: https://github.com/mattlorimor/ProbabilisticDataStructures/compare/v2.0.0...v2.0.1

--- a/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
+++ b/ProbabilisticDataStructures/ProbabilisticDataStructures.csproj
@@ -22,6 +22,9 @@
     <!-- NuGet's guidance is "Copyright (c) <name> <year>". LICENSE.txt deliberately
          differs: Apache-2.0's own boilerplate mandates "Copyright [yyyy] [name]". -->
     <Copyright>Copyright (c) Matthew Lorimor 2015</Copyright>
+    <!-- The release workflow overrides this with the version's CHANGELOG.md
+         section via -p:PackageReleaseNotesFile=...; the link is the fallback
+         for packs made outside that workflow. -->
     <PackageReleaseNotes>See the changelog for this release: https://github.com/mattlorimor/ProbabilisticDataStructures/blob/v$(VersionPrefix)/CHANGELOG.md</PackageReleaseNotes>
     <Description>A probabilistic data structures library for C#, ported from Tyler Treat's BoomFilters project for Go. Includes Bloom filters (classic, counting, deletable, inverse, partitioned, scalable, and stable), Cuckoo filters, Count-Min Sketch, HyperLogLog, MinHash, and Top-K.</Description>
     <PackageTags>bloom-filter;cuckoo-filter;count-min-sketch;hyperloglog;minhash;topk;probabilistic-data-structures</PackageTags>
@@ -32,6 +35,15 @@
     <RepositoryUrl>https://github.com/mattlorimor/ProbabilisticDataStructures</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
+
+  <!-- Notes arrive by file rather than as a property value because MSBuild's
+       command line splits property values on semicolons and commas. -->
+  <Target Name="ReadPackageReleaseNotesFromFile" BeforeTargets="GenerateNuspec"
+          Condition="'$(PackageReleaseNotesFile)' != ''">
+    <PropertyGroup>
+      <PackageReleaseNotes>$([System.IO.File]::ReadAllText('$(PackageReleaseNotesFile)'))</PackageReleaseNotes>
+    </PropertyGroup>
+  </Target>
 
   <!-- Source Link and symbols, so consumers can step into this code while debugging.
        Source Link ships in the SDK; no PackageReference is required. -->


### PR DESCRIPTION
Releases have carried only a link to CHANGELOG.md — on the GitHub release page and in the NuGet package's release-notes field alike. The changelog is already written per release, so both now carry it.

**What changes**

- `release.yml` gains an extraction step: the tagged version's `## [X.Y.Z]` section is pulled from CHANGELOG.md, a full-history link is appended, and the result becomes the GitHub release body via `--notes-file`. A tag whose version has no changelog section fails the release, the same way a tag that disagrees with `VersionPrefix` already does.
- The same file feeds `dotnet pack` through `-p:PackageReleaseNotesFile=...`; a small MSBuild target reads it into `PackageReleaseNotes` before `GenerateNuspec`. It travels by file because MSBuild's command line splits inline property values on semicolons and commas. Packs made outside the workflow keep the existing changelog-link fallback.
- The changelog's link-reference block, which stopped at 3.1.0 (itself comparing against `HEAD`), is completed: every released version now has its compare link, plus an `[Unreleased]` reference for the section the next feature branch reintroduces.

**Verified locally**

- Extraction run against the real changelog for 6.1.0 (top section) and 1.0.0 (bounded by the link-reference block, not another heading).
- `dotnet pack` with the notes file: the `.nupkg`'s nuspec carries the full section text plus the link.
- `dotnet pack` without the property: fallback link unchanged.

NuGet renders release notes as plain text and published versions are immutable, so the package side applies from the next release onward. Existing GitHub releases can be backfilled with `gh release edit` if wanted — not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9