### PR TITLE
Make the contributor docs describe the repository that exists

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,35 +1,35 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-
+about: Something behaves differently from what is documented
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**What happened, and what did you expect instead?**
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**Why do you believe this is a defect rather than the documented error rate?**
+<!-- Worth a moment's thought, because it is the question that decides whether this is
+     a bug at all. These structures are allowed to be wrong: a Bloom filter says yes to
+     things it never saw, a sketch's counts are estimates, an UltraLogLog's answer moves
+     by a percent or so either way. What is *not* allowed is being wrong in a direction
+     or at a rate the documentation does not claim -- a false negative from a filter, an
+     estimate outside its stated bound, an answer that changes across a save and reload.
+     If you are not sure which side of that line you are on, say so and open it anyway;
+     working that out is the useful part. -->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Minimal reproduction**
+<!-- Code we can run. If the structure takes a seed, please pass one -- without it the
+     behaviour is not reproducible and we will be chasing a different sequence than you
+     were. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+```csharp
+```
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Versions**
+- `MattLorimor.ProbabilisticDataStructures`:
+- Target framework (e.g. net10.0):
+- OS:
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Which structure?**
 
-**Additional context**
-Add any other context about the problem here.
+**Anything else**
+<!-- The scale it appears at, whether it survives a round trip through WriteTo/ReadFrom,
+     whether it happens with a different seed. Any of those narrow it a lot. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,30 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
-
+about: A structure, or a capability of one, that the library is missing
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**What question do you need answered that nothing here answers?**
+<!-- The library is organised around questions -- membership, cardinality, frequency,
+     quantiles, ranges, sampling -- rather than around algorithms, so the most useful
+     framing is the question you are stuck on. If an existing structure nearly does it,
+     say which and where it falls short. -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**If you have a specific structure in mind**
+<!-- A link to the paper, and to a reference implementation if one exists. The
+     reference matters more than it might seem: papers and their own implementations
+     disagree surprisingly often, and where they do, the implementation is usually the
+     one consistent with the published constants. A structure with no reference is
+     still worth proposing -- it just costs a great deal more to get right, and it is
+     fair to say so up front. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**When should someone *not* use it?**
+<!-- Every structure documented here says what it is bad at, because the honest answer
+     is usually "use the dedicated thing instead". A proposal that cannot name its own
+     weakness is usually one that has not been compared to what already exists. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**What does it cost, and what does it buy?**
+<!-- Bits per key, error rate, whether it merges, whether it can be updated after it is
+     built. Rough numbers are fine. "Smaller than X at the same accuracy" is the
+     comparison that tends to decide these. -->
+
+**Anything else**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,60 @@
-If you think a change would be useful, make a PR! I would only care that you inquire about a change before wirting it if it seems like a oh-man-this-is-changing-everything type of change.
+# Contributing
+
+If you think a change would be useful, make a PR. The only thing I would ask you to
+raise first is an oh-man-this-is-changing-everything sort of change, where it is worth
+agreeing on the shape before either of us spends a weekend on it.
+
+Everything below is about how this repository is tested, which is unusual enough to be
+worth two minutes of your time before you write the tests rather than after.
+
+## Testing is the hard part here
+
+[`TESTING.md`](TESTING.md) is the real document. The short version:
+
+- **Watch every test fail before you watch it pass.** A test that has never been seen
+  to fail proves nothing. Twice in this repository a test that *named* a constant
+  turned out to be unable to detect that constant changing.
+- **Break the implementation on purpose** to prove the new test catches it, then put it
+  back, and record what you broke in the commit message. Commit *before* you start
+  breaking things — the obvious way to undo a deliberate break also discards everything
+  else uncommitted.
+- **Say what survived.** If you tried a mutation and the suite did not catch it, that
+  belongs in the commit message too, along with why you decided it was acceptable. A
+  documented survivor is worth more than a tidy story.
+- **Measure before you assert.** For anything with an error rate or a bound, probe what
+  the code actually does, then pin it with slack you can justify — and pair the bound
+  with a check that it is not passing vacuously.
+
+This sounds like a lot. In practice it is the difference between a suite that catches
+defects and one that only records that somebody once ran the code, and most of it was
+learned here by getting it wrong first.
+
+## Stored data must keep loading
+
+[`FORMAT.md`](FORMAT.md) specifies the byte layout. A payload written by any version is
+readable by every later version, or is refused with an explanation — never guessed at.
+If you change what a structure stores, bump its format version, keep the old reader
+working, and add a fixture pinning the new bytes. The suite reads fixtures checked in at
+the version that introduced each format, so a change that would strand somebody's stored
+data fails in CI rather than in their storage.
+
+## Practical bits
+
+```
+dotnet clean -c Release && dotnet build -c Release -warnaserror; echo "exit: $?"
+dotnet test -c Release
+```
+
+Read that exit code rather than the build summary. Analyzers do not run on a project
+MSBuild thinks is up to date, so an incremental `-warnaserror` build can report success
+on code that will not compile from scratch — which is exactly how a real defect got
+through several green checks in a row.
+
+New structures follow the pattern of the existing ones: a class with the same shape of
+API, span overloads beside the array ones, persistence with a golden fixture, an entry
+in the README's decision table, and a `CHANGELOG.md` line.
+
+## Asking is fine
+
+If any of this is unclear, or does not fit what you are trying to do, open the PR and
+say so. None of it is meant to keep people out.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,31 @@
-### What is this PR?
-THIS_IS_A_PR_THAT_DOES_X_Y_Z
+### What does this change, and why?
 
-### Things to consider:
-- [ ] I added tests for my changes
-- [ ] I ran the tests locally and they all passed
-- [x] I am awesome for making a contribution
+<!-- What the change does, and what it is for. If it fixes something, say what was
+     wrong rather than only what is now right -- the next reader is usually trying to
+     understand the defect, not the patch. -->
+
+### How do you know it works?
+
+<!-- Not "the tests pass" but what the tests would have caught. If you added a bound,
+     an error rate, or an estimate, say what you measured and against what. If you
+     broke the implementation on purpose to prove a test bites (see TESTING.md), the
+     mutation table belongs in the commit message; a pointer to it here is enough. -->
+
+### Anything you are unsure about?
+
+<!-- Survivors of a mutation you decided were equivalent, a tolerance you picked by
+     feel, a case you could not reach. This section being empty on a non-trivial
+     change is usually a sign it was not looked for. Honest uncertainty here is worth
+     more than a clean checklist. -->
+
+---
+
+- [ ] Tests were watched failing before they were watched passing (`TESTING.md`)
+- [ ] `dotnet clean -c Release && dotnet build -c Release -warnaserror; echo "exit: $?"` — read the exit code, not the summary
+- [ ] `dotnet test -c Release` passes
+- [ ] If the persistence format changed: payloads written by earlier versions still read, and a fixture pins the new one (`FORMAT.md`)
+- [ ] If a public API changed: the README says so, and `CHANGELOG.md` has an entry
+
+<!-- New to the repository? CONTRIBUTING.md is a two-minute read and explains why this
+     asks for more than most projects do. None of it is meant to be a barrier: open the
+     PR, and ask if something here does not fit what you are doing. -->


### PR DESCRIPTION
All three templates predated the standard this repository actually holds itself to.

The PR template asked "I added tests for my changes" and awarded a pre-ticked box for being awesome. The bug report asked for screenshots, a browser version, and an iPhone model — for a .NET library. Someone arriving today had no way to learn that tests here are watched failing before they are watched passing, that mutations are hand-applied and recorded in the commit message, or that stored payloads must keep loading forever.

**Pull request template.** Three prose prompts instead of a checklist that invites ticking: what changed and why, how you know it works, and what you are unsure about. That third one is deliberate — a mutation survivor you judged equivalent or a tolerance picked by feel is worth more in review than a clean list of boxes. The remaining checkboxes are the ones that are genuinely binary, including the clean-build-and-read-the-exit-code incantation from TESTING.md, since reading the summary instead of the exit code is how a real defect got through several green checks in a row.

**Bug report.** Now leads with the question that decides whether a report is a bug at all: *why do you believe this is a defect rather than the documented error rate?* These structures are allowed to be wrong — a Bloom filter says yes to things it never saw. Being wrong in a direction or at a rate the documentation does not claim is the actual defect. It also asks for a seed, without which the behaviour is not reproducible, and for the package version and target framework rather than a browser.

**Feature request.** Asks what question you need answered rather than what algorithm you want, since the library is organised around questions. It asks for a reference implementation as well as a paper — four structures went in over the last few days and three of them turned up a paper disagreeing with its own reference implementation, so whether one exists changes the cost of the work considerably. And it asks the proposer to name the structure's weakness, which every structure in the README already does.

**CONTRIBUTING.md** was one sentence (with a typo) and never mentioned TESTING.md, so the bar was invisible to anyone who had not read the commit history. It keeps its welcome and its invitation to just open a PR, and now explains in a paragraph why the testing bar is where it is, plus the persistence-compatibility rule and the two commands that verify a change.

## Verification

- All referenced files exist (`TESTING.md`, `FORMAT.md`, `CHANGELOG.md`, `README.md`), the package ID matches the csproj, and the target framework named in the bug template matches the build.
- The commands the docs tell contributors to run were run: clean `-warnaserror` build exits 0, `dotnet test -c Release` is 637/637.
- No stale boilerplate remains — grep for screenshot/smartphone/browser/"I am awesome" comes back empty, and the "wirting" typo is gone.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9