### PR TITLE
Seed the stable filter test that failed about one run in four

### DIFF
--- a/TestProbabilisticDataStructures/TestStableBloomFilter.cs
+++ b/TestProbabilisticDataStructures/TestStableBloomFilter.cs
@@ -59,7 +59,13 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void TestStableTestAndAdd()
         {
-            var f = StableBloomFilter.NewDefaultStableBloomFilter(10000, 0.01);
+            // Seeded, and it matters here more than it looks. This filter evicts as it
+            // goes: every add decays cells chosen at random, so an earlier item can
+            // stop being a member because a later one displaced it. That is the
+            // structure working, not failing. What this test is actually about is the
+            // mechanics of Test, Add and TestAndAdd, so the eviction is pinned rather
+            // than left to chance -- unseeded, it removed 'a' about one run in four.
+            var f = new StableBloomFilter(10000, 1, 0.01, seed: 1);
 
             // 'a' is not in the filter.
             if (f.Test(A_BYTES))


### PR DESCRIPTION
`TestStableTestAndAdd` is flaky on master. Found while verifying something unrelated, then pinned down rather than shrugged off.

**What happens.** The test builds its filter with `NewDefaultStableBloomFilter`, which seeds unpredictably. A stable Bloom filter evicts as it goes — every add decays cells chosen at random — so adding `'b'` can displace `'a'`, and the assertion that `'a'` is still a member fails at line 94. **The structure is working exactly as designed; the test asserts something it was never promised.**

**Rate.** One failure in eight full-suite runs, then reproduced with the name captured on the third of four targeted runs. Roughly a quarter.

**Fix.** The test is about the mechanics of `Test`, `Add` and `TestAndAdd`, not about eviction, so the eviction is pinned with a seed rather than left to chance. `NewDefaultStableBloomFilter(m, rate)` is just `new StableBloomFilter(m, 1, rate)`, so the seeded form was already available.

**Verified, not assumed:**

- Eight full-suite runs clean afterwards (688/688 each).
- Six targeted runs of the file clean.
- The seeded test still **fails when `Add` is stubbed out**, so seeding did not make it pass vacuously.

This is what TESTING.md's "deterministic randomness only" rule exists for. A red check that goes green on a re-run is worse than a red check — it teaches people to re-run red checks.

Other tests in the file construct filters unseeded too, but their assertions do not depend on which cells decay, and none flaked across the runs above. I have left them alone rather than making a larger diff on evidence I do not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9