### PR TITLE
Add DPSW-Sketch: differentially private frequency over a sliding window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`DpswSketch`** and **`PrivateCountMinSketch`**, frequency estimation over a sliding
+  window that is differentially private (Wang, Wang and Chen, KDD 2024). The first
+  structures here whose contract is a privacy guarantee rather than an error rate.
+  `PrivateCountMinSketch` is a Count-Min Sketch whose counters start at a draw from a
+  normal distribution rather than at nought — the Gaussian mechanism at the sketch's
+  l2-sensitivity, giving event-level zero-concentrated differential privacy — and the
+  noise is drawn once at construction, so repeated queries cannot average it away.
+  `DpswSketch` cuts the stream into substreams, builds private sketches over nested
+  ranges chosen by a smooth histogram, and answers a window query by summing one sketch
+  per substream, splitting the budget so that everything covering any one item comes to
+  no more than the whole.
+  <br><br>
+  The privacy guarantee is the authors' theorem and nothing here proves it. What the
+  tests hold is the distribution the theorem assumes — variance of depth over budget to
+  within five percent, kurtosis within 0.2 of a Gaussian's three, tail masses within a
+  point at one, two and three deviations, variance scaling with the budget and the depth
+  and not the width — and the structural condition it rests on, that no item is charged
+  more than the whole budget. Estimates are two-sided: unlike a plain Count-Min Sketch
+  this can read below the truth, and below nought.
+  <br><br>
+  Small checkpoint factors are refused rather than merely discouraged. The budget for
+  the j-th checkpoint falls as the factor to the power of j while the range it covers
+  falls only as one minus the factor, so at 0.25 on a window of four thousand the
+  leanest sketch carries noise of half a million: over 351 query points the median error
+  was -46 and the fifth percentile -6150. Not yet persistable. (#104)
+
 - **`TupleSketch`**, a `ThetaSketch` that carries a value alongside every distinct key,
   so one pass answers both "how many distinct users" and "what did they spend between
   them". The sampling is what makes both possible at once: a hash is kept when it falls

--- a/ProbabilisticDataStructures/DpswSketch.cs
+++ b/ProbabilisticDataStructures/DpswSketch.cs
@@ -1,0 +1,568 @@
+using System;
+using System.Collections.Generic;
+
+namespace ProbabilisticDataStructures
+{
+    /// <summary>
+    /// Frequency estimation over a sliding window that is differentially private:
+    /// DPSW-Sketch, from Wang, Wang and Chen (KDD 2024).
+    /// </summary>
+    /// <remarks>
+    /// Two hard things at once. A sliding window means only the most recent items
+    /// count, and an ordinary sketch cannot forget. Differential privacy means the
+    /// published state must not reveal whether any one item was there, and the obvious
+    /// way to combine the two -- one private sketch per window position -- spends the
+    /// privacy budget many times over on the same item.
+    /// <para>
+    /// The framework's answer is to cut the stream into substreams and, within each,
+    /// build a set of <see cref="PrivateCountMinSketch"/>es over nested ranges chosen
+    /// by a smooth histogram: some running from the start of the substream to a
+    /// checkpoint, others from a checkpoint to its end. A query then finds, for each
+    /// substream the window touches, the one sketch whose range best fits inside the
+    /// window, and adds the answers up. The window is approximated rather than exact,
+    /// which is the price of not keeping the items.
+    /// </para>
+    /// <para>
+    /// The budget is split across those sketches so that everything covering any one
+    /// item adds up to the whole budget and no more, which is what lets the composition
+    /// argument go through. The split is a geometric series arranged to sum exactly:
+    /// the whole-substream sketch takes 2a - a^2 of it and each checkpoint pair takes
+    /// a^(j-2)(1-a)^3/2, and those come to one.
+    /// </para>
+    /// <para>
+    /// <b>What is guaranteed and by whom.</b> The privacy claim is the authors'
+    /// theorem, and it holds if the noise is what the mechanism requires and the budget
+    /// is split as above. This library tests both of those -- see
+    /// <see cref="PrivateCountMinSketch"/> for the noise and the budget test alongside
+    /// this class -- and proves neither. It is also event-level: one item, not one
+    /// person's whole history.
+    /// </para>
+    /// </remarks>
+    public class DpswSketch
+    {
+        /// <summary>One private sketch and the range of the substream it covers.</summary>
+        private sealed class Segment
+        {
+            internal Segment(int from, int to, PrivateCountMinSketch sketch, double budget)
+            {
+                this.From = from;
+                this.To = to;
+                this.Sketch = sketch;
+                this.Budget = budget;
+            }
+
+            /// <summary>The first position in the substream this covers, counting from one.</summary>
+            internal int From { get; }
+
+            /// <summary>The last position in the substream this covers.</summary>
+            internal int To { get; }
+
+            internal PrivateCountMinSketch Sketch { get; }
+
+            internal double Budget { get; }
+        }
+
+        /// <summary>A substream, and the sketches built over ranges within it.</summary>
+        private sealed class Substream
+        {
+            internal Substream(long start)
+            {
+                this.Start = start;
+                this.Segments = new List<Segment>();
+            }
+
+            /// <summary>The stream position of this substream's first item.</summary>
+            internal long Start { get; }
+
+            /// <summary>How many items it has taken so far.</summary>
+            internal int Held { get; set; }
+
+            internal List<Segment> Segments { get; }
+        }
+
+        private readonly long window;
+        private readonly double rho;
+        private readonly double alpha;
+        private readonly int substreamSize;
+        private readonly uint width;
+        private readonly uint depth;
+        private readonly int[] checkpoints;
+        private readonly List<Substream> substreams = new List<Substream>();
+        private readonly Func<ReadOnlySpan<byte>, ulong>? hash;
+        private SeededRandom seeds;
+        private long position;
+
+        /// <summary>
+        /// Builds a sketch over a sliding window.
+        /// </summary>
+        /// <param name="window">How many of the most recent items a query covers.</param>
+        /// <param name="rho">
+        /// The zero-concentrated privacy budget for the whole structure. See
+        /// <see cref="PrivateCountMinSketch.BudgetFor"/> to pick one from an epsilon and
+        /// delta.
+        /// </param>
+        /// <param name="alpha">
+        /// How finely each substream is checkpointed. Smaller means more checkpoints
+        /// and a closer approximation of the window -- and much more noise, because the
+        /// budget for the j-th checkpoint falls as this to the power of j while the
+        /// range it covers only falls as one minus this. The two decay at different
+        /// rates, so the last checkpoints end up with almost no budget at all.
+        /// <para>
+        /// Measured over 351 query points on a window of four thousand, with a true
+        /// answer of 1333: at 0.5 the error ran between -77 and -37, at 0.4 between -97
+        /// and -18, at 0.75 between -107 and -65. At 0.25 the median error was -46 and
+        /// the fifth percentile -6150, because now and then a query lands on the
+        /// checkpoint holding a sixty-billionth of the budget. That is why small values
+        /// here are refused rather than merely discouraged.
+        /// </para>
+        /// </param>
+        /// <param name="beta">
+        /// Sets the substream size as the window raised to this power. Smaller means
+        /// more, shorter substreams -- and a query adds one noisy answer per substream,
+        /// so more of them is more accumulated noise as well as more memory. Measured
+        /// on a window of five thousand, the estimate of a quarter-share item ran 714,
+        /// 1125, 1179, 1211, 1167 and 1078 against a truth of 1250 as this went 0.4,
+        /// 0.5, 0.6, 0.7, 0.8 and 0.9, while the memory fell from 80 MB to 3 MB. The
+        /// default is where those two stop pulling in the same direction.
+        /// </param>
+        /// <param name="width">How many counters each sketch row holds.</param>
+        /// <param name="depth">How many rows each sketch has.</param>
+        /// <param name="seed">
+        /// The seed for the noise. For tests only: a deployment must not supply one,
+        /// since anyone who knows it can subtract the noise back off.
+        /// </param>
+        /// <param name="hash">The hash function to use, or null for the default.</param>
+        public DpswSketch(
+            long window,
+            double rho,
+            double alpha = 0.5,
+            double beta = 0.7,
+            uint width = 512,
+            uint depth = 5,
+            ulong? seed = null,
+            Func<ReadOnlySpan<byte>, ulong>? hash = null)
+        {
+            if (window < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(window),
+                    "A window covers at least one item.");
+            }
+            if (double.IsNaN(rho) || rho <= 0 || double.IsInfinity(rho))
+            {
+                throw new ArgumentOutOfRangeException(nameof(rho),
+                    $"The privacy budget is {rho}, and it has to be a positive number.");
+            }
+            if (double.IsNaN(alpha) || alpha <= 0 || alpha >= 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(alpha),
+                    "The checkpoint factor lies strictly between nought and one.");
+            }
+            if (double.IsNaN(beta) || beta <= 0 || beta >= 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(beta),
+                    "The substream factor lies strictly between nought and one.");
+            }
+
+            this.window = window;
+            this.rho = rho;
+            this.alpha = alpha;
+            this.width = width;
+            this.depth = depth;
+            this.hash = hash;
+            this.seeds = seed.HasValue
+                ? new SeededRandom(seed.Value)
+                : SeededRandom.Unpredictable();
+
+            this.substreamSize = (int)Math.Max(1, Math.Ceiling(Math.Pow(window, beta)));
+            this.checkpoints = Checkpoints(this.substreamSize, alpha);
+
+            // The budget for the j-th checkpoint falls as alpha to the power of j, and
+            // the number of checkpoints grows as alpha shrinks, so the last of them can
+            // be left with a budget small enough that its noise dwarfs anything it
+            // could be asked. A query that lands on such a sketch does not come back
+            // slightly wrong, it comes back wrong by thousands -- and it does so only
+            // sometimes, which is worse than doing it always.
+            var leanest = BudgetAt(this.checkpoints.Length, rho, alpha);
+            var worstDeviation = Math.Sqrt(depth / leanest);
+
+            if (worstDeviation > window)
+            {
+                throw new ArgumentOutOfRangeException(nameof(alpha),
+                    $"A checkpoint factor of {alpha} gives {this.checkpoints.Length} " +
+                    $"checkpoints in a substream, and the last of them a budget of " +
+                    $"{leanest:E2}, whose noise has a standard deviation of " +
+                    $"{worstDeviation:E2} -- against a window of {window} items. A " +
+                    "sketch whose noise exceeds everything it could be counting " +
+                    "contributes nothing but noise. Use a larger checkpoint factor, or " +
+                    "a smaller substream factor to shorten the substreams.");
+            }
+
+            // Refuse a shape whose sketches would be so many that none of them has a
+            // usable budget rather than discovering it in the estimates.
+            if (width == 0 || depth == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(width),
+                    "A sketch needs at least one counter and one row.");
+            }
+        }
+
+        /// <summary>How many of the most recent items a query covers.</summary>
+        public long Window => this.window;
+
+        /// <summary>The privacy budget for the whole structure.</summary>
+        public double Rho => this.rho;
+
+        /// <summary>How many items have been added in all.</summary>
+        public long Position => this.position;
+
+        /// <summary>How many items each substream holds.</summary>
+        internal int SubstreamSize => this.substreamSize;
+
+        /// <summary>The checkpoint offsets within a substream, largest first.</summary>
+        internal int[] Checkpointing => this.checkpoints;
+
+        /// <summary>
+        /// How many bytes the sketches occupy.
+        /// </summary>
+        /// <remarks>
+        /// This structure is not small. It keeps a private sketch per checkpoint per
+        /// substream, and a window holds many substreams, so the count of sketches runs
+        /// into the hundreds and the memory into megabytes. That is what buying a
+        /// private sliding window costs: the framework cannot forget by overwriting,
+        /// because a counter that could be overwritten is a counter whose history could
+        /// be inferred, so it forgets by keeping separate sketches and dropping whole
+        /// ones.
+        /// </remarks>
+        public long SizeInBytes =>
+            (long)this.SketchesHeld * this.width * this.depth * sizeof(double);
+
+        /// <summary>How many private sketches are currently being kept.</summary>
+        public int SketchesHeld
+        {
+            get
+            {
+                var total = 0;
+                foreach (var substream in this.substreams)
+                {
+                    total += substream.Segments.Count;
+                }
+                return total;
+            }
+        }
+
+        /// <summary>
+        /// The budgets given to the sketches covering each position of a substream.
+        /// </summary>
+        /// <remarks>
+        /// The privacy argument needs the budgets spent on any single item to come to
+        /// no more than the whole. This is what a test checks that against.
+        /// </remarks>
+        internal double BudgetSpentAt(int positionInSubstream)
+        {
+            var total = 0.0;
+            foreach (var segment in PlanFor(0))
+            {
+                if (segment.From <= positionInSubstream && positionInSubstream <= segment.To)
+                {
+                    total += segment.Budget;
+                }
+            }
+            return total;
+        }
+
+        /// <summary>
+        /// Adds an item to the stream.
+        /// </summary>
+        /// <param name="data">The item.</param>
+        public DpswSketch Add(byte[] data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            return this.Add(data.AsSpan());
+        }
+
+        /// <inheritdoc cref="Add(byte[])"/>
+        public DpswSketch Add(ReadOnlySpan<byte> data)
+        {
+            this.position++;
+
+            if (this.substreams.Count == 0
+                || this.substreams[^1].Held >= this.substreamSize)
+            {
+                this.substreams.Add(Begin(this.position));
+            }
+
+            var current = this.substreams[^1];
+            current.Held++;
+            var offset = current.Held;
+
+            foreach (var segment in current.Segments)
+            {
+                if (segment.From <= offset && offset <= segment.To)
+                {
+                    segment.Sketch.Add(data);
+                }
+            }
+
+            Expire();
+            return this;
+        }
+
+        /// <summary>
+        /// The estimated number of times an item appeared in the window.
+        /// </summary>
+        /// <remarks>
+        /// One sketch is chosen from each substream the window touches: for the oldest,
+        /// the one starting as late as possible but no later than the window's start;
+        /// for the newest, the one ending as late as possible but no later than now;
+        /// and for those wholly inside, the one covering the substream entire. Their
+        /// answers are added.
+        /// <para>
+        /// Nothing is clamped. The estimate can fall below nought, both because the
+        /// counters carry noise and because it is a sum of several noisy answers.
+        /// </para>
+        /// </remarks>
+        /// <param name="data">The item to estimate.</param>
+        public double Count(byte[] data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            return this.Count(data.AsSpan());
+        }
+
+        /// <inheritdoc cref="Count(byte[])"/>
+        public double Count(ReadOnlySpan<byte> data)
+        {
+            var windowStart = Math.Max(1, this.position - this.window + 1);
+            var total = 0.0;
+
+            for (var s = 0; s < this.substreams.Count; s++)
+            {
+                var substream = this.substreams[s];
+                var last = substream.Start + substream.Held - 1;
+
+                if (last < windowStart)
+                {
+                    continue;
+                }
+
+                var chosen = Choose(substream, windowStart, s == this.substreams.Count - 1);
+                if (chosen is not null)
+                {
+                    total += chosen.Sketch.Count(data);
+                }
+            }
+
+            return total;
+        }
+
+        /// <summary>
+        /// The items estimated to make up at least the given share of the window.
+        /// </summary>
+        /// <param name="candidates">The items to consider.</param>
+        /// <param name="share">The share of the window an item must reach.</param>
+        public IReadOnlyList<byte[]> HeavyHitters(
+            IEnumerable<byte[]> candidates, double share)
+        {
+            ArgumentNullException.ThrowIfNull(candidates);
+
+            if (double.IsNaN(share) || share <= 0 || share > 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(share),
+                    "A share of the window lies above nought and at most one.");
+            }
+
+            var covered = Math.Min(this.window, this.position);
+            var threshold = share * covered;
+
+            var found = new List<byte[]>();
+            foreach (var candidate in candidates)
+            {
+                ArgumentNullException.ThrowIfNull(candidate);
+
+                if (this.Count(candidate) >= threshold)
+                {
+                    found.Add(candidate);
+                }
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        /// Which sketch in a substream best fits the window.
+        /// </summary>
+        private Segment? Choose(Substream substream, long windowStart, bool isCurrent)
+        {
+            Segment? best = null;
+
+            foreach (var segment in substream.Segments)
+            {
+                var from = substream.Start + segment.From - 1;
+                var to = substream.Start + segment.To - 1;
+
+                // Never count an item the window has already passed, and never count
+                // one that has not arrived.
+                if (from < windowStart || segment.From > substream.Held)
+                {
+                    continue;
+                }
+
+                if (isCurrent && segment.To > substream.Held)
+                {
+                    // In the substream being filled, only ranges already complete can
+                    // be trusted -- a range still taking items is not the count it will
+                    // eventually be.
+                    continue;
+                }
+
+                if (best is null
+                    || from < substream.Start + best.From - 1
+                    || (from == substream.Start + best.From - 1 && to > substream.Start + best.To - 1))
+                {
+                    best = segment;
+                }
+            }
+
+            return best;
+        }
+
+        /// <summary>
+        /// Starts a substream and builds the sketches over its ranges.
+        /// </summary>
+        private Substream Begin(long start)
+        {
+            var substream = new Substream(start);
+
+            foreach (var planned in PlanFor(start))
+            {
+                substream.Segments.Add(new Segment(
+                    planned.From, planned.To,
+                    new PrivateCountMinSketch(
+                        this.width, this.depth, planned.Budget,
+                        this.seeds.Next(), this.hash),
+                    planned.Budget));
+            }
+
+            return substream;
+        }
+
+        /// <summary>
+        /// The ranges a substream is covered by, and the budget each gets.
+        /// </summary>
+        /// <remarks>
+        /// The first covers the whole substream. Each checkpoint after it contributes a
+        /// pair: one range from the start of the substream to the checkpoint, and one
+        /// from the mirror of that checkpoint to the end. The budgets are a geometric
+        /// series chosen so that the whole comes to the budget for the structure.
+        /// </remarks>
+        private List<Segment> PlanFor(long unused)
+        {
+            _ = unused;
+
+            var planned = new List<Segment>
+            {
+                new Segment(1, this.substreamSize, null!,
+                    this.rho * ((2 * this.alpha) - (this.alpha * this.alpha))),
+            };
+
+            for (var j = 2; j <= this.checkpoints.Length; j++)
+            {
+                var budget = BudgetAt(j, this.rho, this.alpha);
+
+                var checkpoint = this.checkpoints[j - 1];
+
+                // From the start of the substream to this checkpoint.
+                planned.Add(new Segment(1, checkpoint, null!, budget));
+
+                // And from the mirror of it to the end.
+                planned.Add(new Segment(
+                    this.substreamSize - checkpoint + 1, this.substreamSize,
+                    null!, budget));
+            }
+
+            return planned;
+        }
+
+        /// <summary>
+        /// Drops substreams every item of which has left the window.
+        /// </summary>
+        private void Expire()
+        {
+            var windowStart = Math.Max(1, this.position - this.window + 1);
+
+            while (this.substreams.Count > 0)
+            {
+                var oldest = this.substreams[0];
+                var last = oldest.Start + oldest.Held - 1;
+
+                if (last >= windowStart)
+                {
+                    break;
+                }
+
+                this.substreams.RemoveAt(0);
+            }
+        }
+
+        /// <summary>
+        /// The budget the j-th checkpoint pair is given.
+        /// </summary>
+        /// <remarks>
+        /// The whole-substream sketch takes 2a - a^2 of the budget and each checkpoint
+        /// pair takes a^(j-2)(1-a)^3/2 of it, twice over since there is a pair. Those
+        /// come to exactly the budget:
+        /// (2a - a^2) + 2 * (1-a)^3/2 * 1/(1-a) = (2a - a^2) + (1-a)^2 = 1.
+        /// <para>
+        /// The exponent on the second factor is worth reading twice. As three halves
+        /// rather than three-over-two, which is how the paper's typesetting can be
+        /// taken, the same series sums to about twice the budget -- meaning half the
+        /// noise the mechanism requires, and a structure that is not private at the
+        /// rate it says. The test that no item is charged more than the whole budget is
+        /// what holds this to the arithmetic above.
+        /// </para>
+        /// </remarks>
+        private static double BudgetAt(int j, double rho, double alpha) =>
+            rho * Math.Pow(alpha, j - 2) * Math.Pow(1 - alpha, 3) / 2;
+
+        /// <summary>
+        /// The checkpoint offsets within a substream, chosen by the smooth histogram's
+        /// thinning rule.
+        /// </summary>
+        /// <remarks>
+        /// Start with every offset from the substream's length down to one, then repeatedly
+        /// drop everything between an offset and the last one still at least
+        /// (1 - alpha) times it. What survives is a list where consecutive offsets
+        /// differ by at most that factor, which is what bounds how badly the chosen
+        /// range can miss the window's true start.
+        /// </remarks>
+        private static int[] Checkpoints(int substreamSize, double alpha)
+        {
+            var indices = new List<int>();
+            for (var i = substreamSize; i >= 1; i--)
+            {
+                indices.Add(i);
+            }
+
+            var j = 0;
+            while (j < indices.Count - 2)
+            {
+                var furthest = j;
+                for (var k = j + 1; k < indices.Count; k++)
+                {
+                    if (indices[k] >= (1 - alpha) * indices[j])
+                    {
+                        furthest = k;
+                    }
+                }
+
+                if (furthest > j + 1)
+                {
+                    indices.RemoveRange(j + 1, furthest - j - 1);
+                }
+
+                j++;
+            }
+
+            return indices.ToArray();
+        }
+    }
+}

--- a/ProbabilisticDataStructures/DpswSketch.cs
+++ b/ProbabilisticDataStructures/DpswSketch.cs
@@ -344,7 +344,7 @@ namespace ProbabilisticDataStructures
                     continue;
                 }
 
-                var chosen = Choose(substream, windowStart, s == this.substreams.Count - 1);
+                var chosen = Choose(substream, windowStart);
                 if (chosen is not null)
                 {
                     total += chosen.Sketch.Count(data);
@@ -390,7 +390,24 @@ namespace ProbabilisticDataStructures
         /// <summary>
         /// Which sketch in a substream best fits the window.
         /// </summary>
-        private Segment? Choose(Substream substream, long windowStart, bool isCurrent)
+        /// <remarks>
+        /// The one starting as late as possible without starting before the window,
+        /// and among those the one running furthest.
+        /// <para>
+        /// This departs from the paper's query rule in one way. Algorithm 3 restricts
+        /// the substream still being filled to ranges that have already ended, which
+        /// leaves it reading a short checkpoint sketch holding a small share of the
+        /// budget. A range that has not ended yet holds exactly the items that have
+        /// arrived, which are exactly the ones the window wants, so reading the
+        /// whole-substream sketch instead is both correct and much quieter -- it holds
+        /// the largest share of the budget of any sketch there. Choosing which existing
+        /// sketch to read costs no privacy, since anything computed from a private
+        /// result stays private, and the paper's error bound is an upper bound that
+        /// this only moves further inside: measured over 351 query points, the mean
+        /// error went from -51 to -30 and the fifth percentile from -77 to -60.
+        /// </para>
+        /// </remarks>
+        private Segment? Choose(Substream substream, long windowStart)
         {
             Segment? best = null;
 
@@ -403,14 +420,6 @@ namespace ProbabilisticDataStructures
                 // one that has not arrived.
                 if (from < windowStart || segment.From > substream.Held)
                 {
-                    continue;
-                }
-
-                if (isCurrent && segment.To > substream.Held)
-                {
-                    // In the substream being filled, only ranges already complete can
-                    // be trusted -- a range still taking items is not the count it will
-                    // eventually be.
                     continue;
                 }
 

--- a/ProbabilisticDataStructures/PrivateCountMinSketch.cs
+++ b/ProbabilisticDataStructures/PrivateCountMinSketch.cs
@@ -1,0 +1,289 @@
+using System;
+
+namespace ProbabilisticDataStructures
+{
+    /// <summary>
+    /// A Count-Min Sketch whose counters are seeded with Gaussian noise, so that what it
+    /// holds reveals almost nothing about whether any one record was in the stream.
+    /// </summary>
+    /// <remarks>
+    /// This is the private Count-Min Sketch of Zhao et al., as used by Wang, Wang and
+    /// Chen in DPSW-Sketch (KDD 2024). Every counter starts at a draw from a normal
+    /// distribution rather than at nought, and counting proceeds exactly as a
+    /// <see cref="CountMinSketch"/> does. The noise is added once, at construction, not
+    /// per query: a caller who asks the same question twice gets the same answer, which
+    /// is what stops repeated queries from averaging the noise away.
+    /// <para>
+    /// <b>What the guarantee is.</b> The sketch satisfies rho-zero-concentrated
+    /// differential privacy at the event level: adding, removing or changing any single
+    /// record changes the distribution of the whole sketch by a bounded amount.
+    /// Concretely, each counter is seeded from a normal distribution of variance
+    /// depth / rho, which is the Gaussian mechanism at the l2-sensitivity of a
+    /// Count-Min Sketch. Smaller rho means more noise and a stronger guarantee.
+    /// </para>
+    /// <para>
+    /// <b>What this library verifies, and what it does not.</b> The tests here hold the
+    /// noise to its stated distribution -- its mean, its variance, its shape, and how
+    /// its variance scales with rho and with the depth. They do not prove the privacy
+    /// theorem, and no test could: that is a proof about the mechanism, and it is the
+    /// authors', not this library's. What the tests can do, and do, is catch the
+    /// implementation failing to deliver the distribution the proof assumes. A
+    /// mis-scaled mechanism gives a structure that looks like it works and protects
+    /// nobody.
+    /// </para>
+    /// <para>
+    /// <b>What it does not protect against.</b> The guarantee is event-level: one
+    /// record. A user who appears a thousand times is not protected a thousandfold --
+    /// they are protected as one record, a thousand times over, which is much weaker.
+    /// The guarantee also assumes the counters are all a caller ever sees; it says
+    /// nothing about a system that also publishes the exact stream length, or the same
+    /// stream sketched again under a fresh seed.
+    /// </para>
+    /// </remarks>
+    public class PrivateCountMinSketch
+    {
+        private readonly double[][] matrix;
+        private readonly uint width;
+        private readonly uint depth;
+        private readonly double rho;
+        private ulong count;
+
+        private Func<ReadOnlySpan<byte>, ulong> Hash { get; set; }
+
+        /// <summary>
+        /// Builds a sketch of the given shape, seeded with noise for the given privacy
+        /// budget.
+        /// </summary>
+        /// <param name="width">How many counters each row holds.</param>
+        /// <param name="depth">How many rows, and so how many counters an item touches.</param>
+        /// <param name="rho">
+        /// The zero-concentrated differential privacy budget. Smaller is more private
+        /// and less accurate. Use <see cref="BudgetFor"/> to pick one from the epsilon
+        /// and delta a policy is written in terms of.
+        /// </param>
+        /// <param name="seed">
+        /// The seed for the noise. Supplying one makes a sketch reproducible, which is
+        /// what the tests need -- and what a deployment must not do, since anyone who
+        /// knows the seed can subtract the noise back off.
+        /// </param>
+        /// <param name="hash">The hash function to use, or null for the default.</param>
+        public PrivateCountMinSketch(
+            uint width, uint depth, double rho,
+            ulong? seed = null,
+            Func<ReadOnlySpan<byte>, ulong>? hash = null)
+        {
+            if (width == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(width),
+                    "A sketch with no counters in a row divides by zero.");
+            }
+            if (depth == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(depth),
+                    "A sketch with no rows reports every item as seen infinitely often.");
+            }
+            if (double.IsNaN(rho) || rho <= 0 || double.IsInfinity(rho))
+            {
+                throw new ArgumentOutOfRangeException(nameof(rho),
+                    $"The privacy budget is {rho}. It has to be a positive number: at " +
+                    "nought the noise would be infinite and at infinity there would be " +
+                    "none, and neither is a sketch.");
+            }
+
+            this.width = width;
+            this.depth = depth;
+            this.rho = rho;
+            this.Hash = hash ?? Defaults.GetDefaultHashFunction();
+
+            // The l2-sensitivity of a Count-Min Sketch is the square root of twice its
+            // depth, because two neighbouring streams differ in one record, and that
+            // record moves one counter per row in each of them. The Gaussian mechanism
+            // at that sensitivity wants a variance of sensitivity squared over twice
+            // the budget, which is depth over the budget.
+            var deviation = Math.Sqrt(depth / rho);
+
+            var random = seed.HasValue
+                ? new SeededRandom(seed.Value)
+                : SeededRandom.Unpredictable();
+
+            this.matrix = new double[depth][];
+            for (var i = 0; i < depth; i++)
+            {
+                this.matrix[i] = new double[width];
+                for (var j = 0; j < width; j++)
+                {
+                    this.matrix[i][j] = deviation * StandardNormal(ref random);
+                }
+            }
+        }
+
+        /// <summary>How many counters each row holds.</summary>
+        public uint Width => this.width;
+
+        /// <summary>How many rows the sketch keeps.</summary>
+        public uint Depth => this.depth;
+
+        /// <summary>The zero-concentrated privacy budget the noise was drawn for.</summary>
+        public double Rho => this.rho;
+
+        /// <summary>
+        /// The standard deviation of the noise on each counter.
+        /// </summary>
+        public double NoiseDeviation => Math.Sqrt(this.depth / this.rho);
+
+        /// <summary>How many items have been added.</summary>
+        public ulong TotalCount() => this.count;
+
+        /// <summary>
+        /// The counters themselves, for tests that check the noise is what it claims.
+        /// </summary>
+        internal double[][] Counters => this.matrix;
+
+        /// <summary>
+        /// The epsilon of the (epsilon, delta)-differential privacy that a given
+        /// zero-concentrated budget provides.
+        /// </summary>
+        /// <remarks>
+        /// A rho-zCDP mechanism is also (rho + 2 sqrt(rho ln(1/delta)), delta)-DP. Most
+        /// policies are written in epsilon and delta, and this is the bridge to them.
+        /// </remarks>
+        /// <param name="rho">The zero-concentrated budget.</param>
+        /// <param name="delta">The delta to convert at.</param>
+        public static double EpsilonFor(double rho, double delta)
+        {
+            if (double.IsNaN(rho) || rho <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(rho),
+                    "The budget has to be a positive number.");
+            }
+            if (double.IsNaN(delta) || delta <= 0 || delta >= 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(delta),
+                    "Delta is a probability short of certainty, so it lies strictly " +
+                    "between nought and one.");
+            }
+
+            return rho + (2 * Math.Sqrt(rho * Math.Log(1 / delta)));
+        }
+
+        /// <summary>
+        /// The zero-concentrated budget that delivers a given epsilon and delta.
+        /// </summary>
+        /// <remarks>
+        /// The inverse of <see cref="EpsilonFor"/>, solved as a quadratic in the square
+        /// root of the budget. Policies are written in epsilon and delta; the mechanism
+        /// wants rho.
+        /// </remarks>
+        /// <param name="epsilon">The epsilon the policy asks for.</param>
+        /// <param name="delta">The delta the policy asks for.</param>
+        public static double BudgetFor(double epsilon, double delta)
+        {
+            if (double.IsNaN(epsilon) || epsilon <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(epsilon),
+                    "Epsilon has to be a positive number.");
+            }
+            if (double.IsNaN(delta) || delta <= 0 || delta >= 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(delta),
+                    "Delta is a probability short of certainty, so it lies strictly " +
+                    "between nought and one.");
+            }
+
+            // epsilon = rho + 2 sqrt(rho L) with L = ln(1/delta). Writing r for the
+            // square root of rho gives r^2 + 2r sqrt(L) - epsilon = 0.
+            var l = Math.Log(1 / delta);
+            var root = -Math.Sqrt(l) + Math.Sqrt(l + epsilon);
+            return root * root;
+        }
+
+        /// <summary>
+        /// Adds an item to the sketch.
+        /// </summary>
+        /// <param name="data">The item.</param>
+        public PrivateCountMinSketch Add(byte[] data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            return this.Add(data.AsSpan());
+        }
+
+        /// <inheritdoc cref="Add(byte[])"/>
+        public PrivateCountMinSketch Add(ReadOnlySpan<byte> data)
+        {
+            var kernel = Utils.HashKernel(data, this.Hash);
+
+            for (uint i = 0; i < this.depth; i++)
+            {
+                this.matrix[i][ColumnOf(kernel, i)]++;
+            }
+
+            this.count++;
+            return this;
+        }
+
+        /// <summary>
+        /// The estimated number of times an item was added.
+        /// </summary>
+        /// <remarks>
+        /// The smallest of the counters the item touches, as in a plain Count-Min
+        /// Sketch. Two things change once the counters carry noise. The estimate is no
+        /// longer an upper bound -- it can fall below the truth, and for an item that
+        /// was never added it can fall below nought -- and taking the minimum of several
+        /// noisy counters pulls it downwards, because the minimum of several draws is
+        /// below their average.
+        /// <para>
+        /// Nothing is clamped here. Clamping would be free of privacy cost, since
+        /// anything computed from a private result stays private, but it would hide the
+        /// noise from a caller who needs to see it to know what they are holding. Clamp
+        /// at the point of use if a negative frequency is meaningless there.
+        /// </para>
+        /// </remarks>
+        /// <param name="data">The item to estimate.</param>
+        public double Count(byte[] data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            return this.Count(data.AsSpan());
+        }
+
+        /// <inheritdoc cref="Count(byte[])"/>
+        public double Count(ReadOnlySpan<byte> data)
+        {
+            var kernel = Utils.HashKernel(data, this.Hash);
+            var smallest = double.MaxValue;
+
+            for (uint i = 0; i < this.depth; i++)
+            {
+                smallest = Math.Min(smallest, this.matrix[i][ColumnOf(kernel, i)]);
+            }
+
+            return smallest;
+        }
+
+        private uint ColumnOf(in HashKernelReturnValue kernel, uint row) =>
+            (uint)((kernel.LowerBaseHash + (kernel.UpperBaseHash * row)) % this.width);
+
+        /// <summary>
+        /// One draw from the standard normal distribution.
+        /// </summary>
+        /// <remarks>
+        /// The polar form of the Box-Muller transform. It is exact rather than
+        /// approximate -- no sum of uniforms standing in for a bell -- which matters
+        /// because the privacy argument is about this distribution and not about
+        /// something shaped roughly like it.
+        /// </remarks>
+        private static double StandardNormal(ref SeededRandom random)
+        {
+            double x, y, squared;
+
+            do
+            {
+                x = (2 * random.NextDouble()) - 1;
+                y = (2 * random.NextDouble()) - 1;
+                squared = (x * x) + (y * y);
+            }
+            while (squared >= 1 || squared == 0);
+
+            return x * Math.Sqrt(-2 * Math.Log(squared) / squared);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ eleven structures the Go library does not have.
   [`InvertibleBloomLookupTable`](#invertiblebloomlookuptable)
 - [Frequency](#frequency) —
   [`CountMinSketch`](#countminsketch) · [`SublimeCountMinSketch`](#sublimecountminsketch) ·
-  [`CountSketch`](#countsketch) · [`TopK`](#topk) · [`HeavyKeeper`](#heavykeeper)
+  [`CountSketch`](#countsketch) · [`TopK`](#topk) · [`HeavyKeeper`](#heavykeeper) ·
+  [`DpswSketch`](#dpswsketch)
 - [Similarity](#similarity) —
   [`SetSketch`](#setsketch) · [`MinHash`](#minhash) · [`SimHash`](#simhash) ·
   [`MinHashIndex` and `SimHashIndex`](#minhashindex-and-simhashindex)
@@ -86,6 +87,7 @@ eleven structures the Go library does not have.
 | How many distinct things, **and** how alike are two sets? | `SetSketch` | [Similarity](#similarity) |
 | What are the most common things? | `TopK` | [Frequency](#frequency) |
 | …and accuracy matters more than mergeability | `HeavyKeeper` | [Frequency](#frequency) |
+| …over a sliding window, without exposing anyone | `DpswSketch` | [Frequency](#frequency) |
 | How alike are these two **sets**? | `MinHash` | [Similarity](#similarity) |
 | Are these two **documents** near-duplicates? | `SimHash` | [Similarity](#similarity) |
 | …across a corpus, without comparing every pair | `MinHashIndex`, `SimHashIndex` | [Similarity](#similarity) |
@@ -1170,6 +1172,62 @@ Described by Gong, Yang et al. in
 [HeavyKeeper: An Accurate Algorithm for Finding Top-k Elephant Flows](https://www.usenix.org/conference/atc18/presentation/gong).
 
 ---
+
+### `DpswSketch`
+
+<sup>[↑ Contents](#contents)</sup>
+
+How often something happened in the recent past, without revealing whether any one
+record was there.
+
+This is the first structure here whose contract is a **privacy guarantee** rather than an
+error rate, and it is worth being precise about what that means. Counters do not start at
+nought: each begins at a draw from a normal distribution, which is the Gaussian mechanism
+at the sketch's sensitivity. The result satisfies event-level zero-concentrated
+differential privacy — an observer holding the whole structure cannot tell whether any
+single record was in the stream.
+
+```C#
+// A budget in the epsilon and delta most policies are written in.
+double rho = PrivateCountMinSketch.BudgetFor(epsilon: 1.0, delta: 1e-6);
+
+var recent = new DpswSketch(window: 100_000, rho: rho);
+recent.Add(record);
+
+double howOften = recent.Count(record);          // over the last 100,000 records
+var heavy = recent.HeavyHitters(candidates, 0.01);
+```
+
+**What is guaranteed, and by whom.** The privacy claim is the paper's theorem. This
+library does not prove it and no test here pretends to. What the tests do is hold the
+implementation to the distribution the theorem assumes — the noise's centre, spread and
+shape, how its spread moves with the budget and the depth, and that no item is ever
+charged more than the whole budget. That is the checkable part, and it is the part that
+fails silently: a mechanism at half the required noise is exactly as accurate, exactly as
+fast, and protects nobody.
+
+**Read these limits before using it.**
+
+- The guarantee is **event-level**: one record. Someone who appears a thousand times is
+  protected as one record a thousand times over, which is much weaker.
+- Estimates are **two-sided**. Unlike a plain `CountMinSketch`, this can read below the
+  truth, and an item that never appeared can read below nought.
+- It is **not small**. A private window cannot forget by overwriting a counter, because a
+  counter that could be overwritten is one whose history could be inferred — so it keeps
+  many sketches and drops whole ones. A window of 4,000 settles around 4 MB.
+- **Never supply a seed** outside tests. Anyone who knows it can subtract the noise back
+  off.
+
+**Reach for it when** you must publish or retain recent-frequency statistics over data
+about people, and a policy names an epsilon.
+
+**Look elsewhere if** nobody is asking for a privacy guarantee. It costs accuracy,
+memory and speed against `CountMinSketch`, and every one of those costs buys only the
+guarantee.
+
+Described by Wang, Wang and Chen in
+[DPSW-Sketch: A Differentially Private Sketch Framework for Frequency Estimation over
+Sliding Windows](https://doi.org/10.1145/3637528.3671694), KDD 2024.
 
 ## Similarity
 

--- a/TestProbabilisticDataStructures/TestDpswSketch.cs
+++ b/TestProbabilisticDataStructures/TestDpswSketch.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Tests for DPSW-Sketch (Wang, Wang and Chen, KDD 2024).
+    /// </summary>
+    /// <remarks>
+    /// The privacy guarantee is the authors' theorem and nothing here proves it. What
+    /// these tests hold is the structural condition the theorem rests on -- that the
+    /// budgets spent on any one item come to no more than the whole -- along with the
+    /// window behaviour and the accuracy, which are ordinary claims measurable in the
+    /// ordinary way. The noise itself is held to its distribution in
+    /// <see cref="TestPrivateCountMinSketch"/>.
+    /// </remarks>
+    [TestClass]
+    public class TestDpswSketch
+    {
+        private static byte[] Key(int i) => Encoding.UTF8.GetBytes("k" + i);
+
+        /// <summary>
+        /// No item is ever covered by sketches whose budgets add up to more than the
+        /// budget for the whole structure.
+        /// </summary>
+        /// <remarks>
+        /// This is the assertion that makes the privacy claim mean anything, and it is
+        /// the one thing about the privacy that a test can check. Every sketch covering
+        /// an item spends budget on that item, and zero-concentrated privacy composes
+        /// by adding, so if the sketches covering some position summed past the budget,
+        /// the structure would be less private than it says by exactly that factor --
+        /// invisibly, since every estimate would look the same.
+        /// <para>
+        /// The split is a geometric series arranged to sum exactly: the whole-substream
+        /// sketch takes 2a - a^2 and each checkpoint pair takes a^(j-2)(1-a)^3/2, and
+        /// those come to one. Reading the exponent as (1-a)^(3/2) instead -- which the
+        /// paper's typesetting invites -- sums to about twice the budget, which is half
+        /// the noise the mechanism needs.
+        /// </para>
+        /// </remarks>
+        [TestMethod]
+        public void TestNoItemIsChargedMoreThanTheWholeBudget()
+        {
+            foreach (var (window, alpha, beta) in new[]
+            {
+                (10_000L, 0.5, 0.5),
+                (10_000L, 0.75, 0.5),
+                (1_000L, 0.5, 0.6),
+                (100_000L, 0.5, 0.7),
+                (100_000L, 0.4, 0.6),
+            })
+            {
+                const double Budget = 1.0;
+                var sketch = new DpswSketch(window, Budget, alpha, beta, 64, 3, seed: 1);
+
+                for (var position = 1; position <= sketch.SubstreamSize; position++)
+                {
+                    var spent = sketch.BudgetSpentAt(position);
+
+                    Assert.IsTrue(spent <= Budget + 1e-9,
+                        $"At window {window}, alpha {alpha} and beta {beta}, position " +
+                        $"{position} of a substream is covered by sketches whose " +
+                        $"budgets come to {spent:F6} against a budget of {Budget}. " +
+                        "The structure is less private than it claims by that factor.");
+                }
+
+                // And the budget is actually being spent rather than hoarded: a split
+                // that gave everything away to one sketch would also pass the bound.
+                var best = 0.0;
+                for (var position = 1; position <= sketch.SubstreamSize; position++)
+                {
+                    best = Math.Max(best, sketch.BudgetSpentAt(position));
+                }
+                Assert.IsTrue(best > Budget * 0.8,
+                    $"The most any position is charged is {best:F6} of a budget of " +
+                    $"{Budget}, so most of the budget is going unused and the sketches " +
+                    "are noisier than they need to be.");
+            }
+        }
+
+        /// <summary>
+        /// With the noise turned down, the window itself is accurate.
+        /// </summary>
+        /// <remarks>
+        /// This separates the two things that can make an estimate wrong. A sliding
+        /// window built from fixed checkpoints can only approximate where the window
+        /// starts, and a Count-Min Sketch collides; both are here whatever the privacy
+        /// budget. Setting the budget absurdly high leaves those two alone and takes
+        /// the noise away, and what is left is under one percent -- so every larger
+        /// error seen at a real budget is the noise and not the window.
+        /// </remarks>
+        [TestMethod]
+        public void TestWithoutNoiseTheWindowItselfIsAccurate()
+        {
+            const long Window = 5_000;
+
+            foreach (var beta in new[] { 0.5, 0.7 })
+            {
+                var sketch = new DpswSketch(Window, 1e6, 0.5, beta, 512, 5, seed: 4);
+
+                for (var i = 1; i <= 20_000; i++)
+                {
+                    sketch.Add(i % 4 == 0 ? Key(1) : Key(1_000 + (i % 400)));
+                }
+
+                var truth = Window / 4.0;
+                var estimate = sketch.Count(Key(1));
+
+                Assert.AreEqual(truth, estimate, truth * 0.05,
+                    $"With the noise turned down, a window of {Window} estimated " +
+                    $"{estimate:F1} against a truth of {truth}. That gap is the window " +
+                    "approximation and the collisions, and it should be small.");
+            }
+        }
+
+        /// <summary>
+        /// Items that have left the window stop being counted.
+        /// </summary>
+        /// <remarks>
+        /// The whole point of a sliding window. The estimate for an item seen only long
+        /// ago should come back near nought -- and it may well come back below nought,
+        /// since the answer is a sum of noisy sketches with nothing real in them.
+        /// </remarks>
+        [TestMethod]
+        public void TestItemsThatLeftTheWindowAreForgotten()
+        {
+            const long Window = 5_000;
+            var sketch = new DpswSketch(Window, 5.0, 0.5, 0.7, 512, 5, seed: 6);
+
+            for (var i = 0; i < 3_000; i++)
+            {
+                sketch.Add(Key(42));
+            }
+            var whileInside = sketch.Count(Key(42));
+            Assert.IsTrue(whileInside > 2_000,
+                $"While inside the window the item read {whileInside:F1} of 3,000.");
+
+            for (var i = 0; i < 20_000; i++)
+            {
+                sketch.Add(Key(9_000 + i));
+            }
+
+            var afterwards = sketch.Count(Key(42));
+            Assert.IsTrue(Math.Abs(afterwards) < Window * 0.1,
+                $"An item last seen 20,000 items ago still reads {afterwards:F1} in a " +
+                $"window of {Window}.");
+        }
+
+        /// <summary>
+        /// Items inside the window are counted.
+        /// </summary>
+        [TestMethod]
+        public void TestItemsInsideTheWindowAreCounted()
+        {
+            const long Window = 5_000;
+            var sketch = new DpswSketch(Window, 5.0, 0.5, 0.7, 512, 5, seed: 8);
+
+            for (var i = 0; i < 20_000; i++)
+            {
+                sketch.Add(Key(9_000 + i));
+            }
+            for (var i = 0; i < 1_000; i++)
+            {
+                sketch.Add(Key(42));
+            }
+
+            var estimate = sketch.Count(Key(42));
+            Assert.AreEqual(1_000.0, estimate, 400,
+                $"A thousand recent additions read {estimate:F1}.");
+        }
+
+        /// <summary>
+        /// Tightening the guarantee costs accuracy.
+        /// </summary>
+        /// <remarks>
+        /// If it did not, the noise would not be reaching the answers.
+        /// </remarks>
+        [TestMethod]
+        public void TestTighterPrivacyCostsAccuracy()
+        {
+            const long Window = 5_000;
+            var errors = new List<double>();
+
+            foreach (var rho in new[] { 100.0, 5.0, 0.5 })
+            {
+                var sketch = new DpswSketch(Window, rho, 0.5, 0.7, 512, 5, seed: 4);
+                for (var i = 1; i <= 20_000; i++)
+                {
+                    sketch.Add(i % 4 == 0 ? Key(1) : Key(1_000 + (i % 400)));
+                }
+
+                errors.Add(Math.Abs(sketch.Count(Key(1)) - (Window / 4.0)));
+            }
+
+            Assert.IsTrue(errors[2] > errors[0],
+                $"A budget of 0.5 was out by {errors[2]:F1} and one of 100 by " +
+                $"{errors[0]:F1}. Privacy is meant to cost accuracy.");
+        }
+
+        /// <summary>
+        /// Heavy hitters come back and light items do not.
+        /// </summary>
+        [TestMethod]
+        public void TestHeavyHittersAreFound()
+        {
+            const long Window = 4_000;
+            var sketch = new DpswSketch(Window, 20.0, 0.5, 0.7, 512, 5, seed: 12);
+
+            // One item takes a third of the stream, another a fifth, the rest are rare.
+            for (var i = 1; i <= 20_000; i++)
+            {
+                if (i % 3 == 0)
+                {
+                    sketch.Add(Key(1));
+                }
+                else if (i % 5 == 0)
+                {
+                    sketch.Add(Key(2));
+                }
+                else
+                {
+                    sketch.Add(Key(1_000 + (i % 500)));
+                }
+            }
+
+            var candidates = new List<byte[]> { Key(1), Key(2) };
+            for (var i = 0; i < 100; i++)
+            {
+                candidates.Add(Key(1_000 + i));
+            }
+
+            var heavy = sketch.HeavyHitters(candidates, 0.15);
+
+            var wanted = Encoding.UTF8.GetString(Key(1));
+            var found = new List<string>();
+            foreach (var item in heavy)
+            {
+                found.Add(Encoding.UTF8.GetString(item));
+            }
+
+            CollectionAssert.Contains(found, wanted,
+                "The item taking a third of the window was not found.");
+            Assert.IsTrue(heavy.Count < 10,
+                $"{heavy.Count} items were called heavy at a threshold of fifteen " +
+                "percent, and at most a couple can be.");
+        }
+
+        /// <summary>
+        /// The structure reports the memory it is using, and it is a lot.
+        /// </summary>
+        /// <remarks>
+        /// Worth an assertion because the cost is easy to underestimate: a private
+        /// sliding window keeps hundreds of sketches, since it cannot forget by
+        /// overwriting a counter without leaking what that counter used to hold.
+        /// </remarks>
+        [TestMethod]
+        public void TestTheMemoryIsReportedAndSubstantial()
+        {
+            var sketch = new DpswSketch(5_000, 5.0, 0.5, 0.7, 512, 5, seed: 4);
+            for (var i = 0; i < 20_000; i++)
+            {
+                sketch.Add(Key(i % 400));
+            }
+
+            Assert.AreEqual(
+                (long)sketch.SketchesHeld * 512 * 5 * sizeof(double),
+                sketch.SizeInBytes);
+            Assert.IsTrue(sketch.SketchesHeld > 100,
+                $"Only {sketch.SketchesHeld} sketches are being kept, which is fewer " +
+                "than a window of this size needs.");
+        }
+
+        /// <summary>
+        /// A checkpoint factor that would leave a sketch drowning in its own noise is
+        /// refused when the structure is built.
+        /// </summary>
+        /// <remarks>
+        /// The budget for the j-th checkpoint falls as the factor to the power of j
+        /// while the range it covers falls only as one minus the factor, so a small
+        /// factor leaves the last checkpoints with almost nothing. At 0.25 on a window
+        /// of four thousand the leanest sketch gets about a sixty-billionth of the
+        /// budget, giving it a noise deviation of half a million against a window of
+        /// four thousand; queries that land on it come back wrong by thousands, and
+        /// only sometimes, which is harder to notice than being always wrong.
+        /// </remarks>
+        [TestMethod]
+        public void TestACheckpointFactorThatDrownsInNoiseIsRefused()
+        {
+            foreach (var alpha in new[] { 0.1, 0.2, 0.25 })
+            {
+                Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                    () => new DpswSketch(4_000, 20.0, alpha, 0.7, 512, 5),
+                    $"A checkpoint factor of {alpha} should be refused on this window.");
+            }
+
+            // And the ones that work are not refused.
+            foreach (var alpha in new[] { 0.4, 0.5, 0.75 })
+            {
+                _ = new DpswSketch(4_000, 20.0, alpha, 0.7, 512, 5);
+            }
+        }
+
+        /// <summary>
+        /// The parameters are checked.
+        /// </summary>
+        [TestMethod]
+        public void TestBadParametersAreRefused()
+        {
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new DpswSketch(0, 1.0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new DpswSketch(100, 0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new DpswSketch(100, double.NaN));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new DpswSketch(100, 1.0, 0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new DpswSketch(100, 1.0, 1.0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new DpswSketch(100, 1.0, 0.25, 0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new DpswSketch(100, 1.0, 0.25, 1.0));
+
+            var sketch = new DpswSketch(100, 1.0);
+            Assert.ThrowsExactly<ArgumentNullException>(() => sketch.Add((byte[])null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => sketch.Count((byte[])null!));
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => sketch.HeavyHitters(null!, 0.1));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => sketch.HeavyHitters(new List<byte[]>(), 0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => sketch.HeavyHitters(new List<byte[]>(), 1.5));
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestDpswSketch.cs
+++ b/TestProbabilisticDataStructures/TestDpswSketch.cs
@@ -304,6 +304,89 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// Memory stops growing once the window is full.
+        /// </summary>
+        /// <remarks>
+        /// A sliding window that never lets go is not a sliding window. The structure
+        /// forgets by dropping whole substreams once every item in them has left the
+        /// window, and nothing else reclaims anything -- a query that simply ignored
+        /// expired substreams would give every right answer while growing without
+        /// bound, which is the failure this catches.
+        /// </remarks>
+        [TestMethod]
+        public void TestMemoryStopsGrowingOnceTheWindowIsFull()
+        {
+            var sketch = new DpswSketch(4_000, 20.0, 0.5, 0.7, 512, 5, seed: 1);
+
+            var settled = 0;
+            for (var i = 1; i <= 100_000; i++)
+            {
+                sketch.Add(Key(i % 500));
+
+                if (i == 25_000)
+                {
+                    settled = sketch.SketchesHeld;
+                }
+                else if (i > 25_000 && i % 25_000 == 0)
+                {
+                    Assert.IsTrue(sketch.SketchesHeld <= settled * 1.2,
+                        $"After {i} items the structure keeps {sketch.SketchesHeld} " +
+                        $"sketches where it kept {settled} at 25,000. A window that " +
+                        "keeps growing is not forgetting.");
+                }
+            }
+
+            Assert.IsTrue(sketch.SizeInBytes < 16L * 1024 * 1024,
+                $"A window of 4,000 settled at {sketch.SizeInBytes / 1024 / 1024} MB.");
+        }
+
+        /// <summary>
+        /// The substream still being filled is read from its widest sketch, not its
+        /// narrowest.
+        /// </summary>
+        /// <remarks>
+        /// A range that has not finished holds exactly the items that have arrived, so
+        /// it can be read now; the paper's query rule passes it over in favour of a
+        /// short checkpoint sketch holding a small share of the budget. Reading the
+        /// widest one instead is correct, costs no privacy, and is much quieter.
+        /// Measured over 351 query points, the mean error is -30 rather than -51 and
+        /// the fifth percentile -60 rather than -77. The bound below is inside what the
+        /// narrower reading achieves, so it fails if that behaviour comes back.
+        /// </remarks>
+        [TestMethod]
+        public void TestTheFillingSubstreamIsReadFromItsWidestSketch()
+        {
+            var errors = new List<double>();
+
+            for (ulong seed = 1; seed <= 3; seed++)
+            {
+                var sketch = new DpswSketch(4_000, 20.0, 0.5, 0.7, 512, 5, seed);
+
+                for (var i = 1; i <= 24_000; i++)
+                {
+                    sketch.Add(i % 3 == 0 ? Key(1) : Key(1_000 + (i % 500)));
+
+                    if (i > 8_000 && i % 137 == 0)
+                    {
+                        errors.Add(sketch.Count(Key(1)) - (4_000 / 3.0));
+                    }
+                }
+            }
+
+            var mean = 0.0;
+            foreach (var error in errors)
+            {
+                mean += error;
+            }
+            mean /= errors.Count;
+
+            Assert.IsTrue(mean > -40,
+                $"The mean error over {errors.Count} query points is {mean:F1}. " +
+                "Reading the filling substream from a narrow checkpoint sketch instead " +
+                "of its widest gives about -51.");
+        }
+
+        /// <summary>
         /// The parameters are checked.
         /// </summary>
         [TestMethod]

--- a/TestProbabilisticDataStructures/TestPrivateCountMinSketch.cs
+++ b/TestProbabilisticDataStructures/TestPrivateCountMinSketch.cs
@@ -1,0 +1,461 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Tests for the private Count-Min Sketch behind DPSW-Sketch (Wang, Wang and Chen,
+    /// KDD 2024).
+    /// </summary>
+    /// <remarks>
+    /// This is the first structure in this library whose contract is a privacy
+    /// guarantee, and it changes what the tests are for. Everywhere else, a claim is an
+    /// error rate and a test measures it. Here the claim is that an observer cannot
+    /// tell whether any one record was in the stream, and that is a theorem about the
+    /// mechanism -- the authors' theorem, resting on the noise having a particular
+    /// distribution at a particular scale.
+    /// <para>
+    /// No test here proves that theorem, and none is written as though it did. What
+    /// these tests do is hold the implementation to the distribution the theorem
+    /// assumes: its centre, its spread, its shape, and how its spread moves with the
+    /// budget and the depth. That is the part that can be checked, and it is the part
+    /// that can silently be wrong -- a mechanism at half the required noise looks
+    /// exactly like a working one and protects nobody.
+    /// </para>
+    /// <para>
+    /// Everything is seeded, so every figure quoted is the figure this suite will keep
+    /// getting rather than one that happened once.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class TestPrivateCountMinSketch
+    {
+        private static byte[] Key(int i) => Encoding.UTF8.GetBytes("k" + i);
+
+        private static double[] NoiseOf(PrivateCountMinSketch sketch) =>
+            sketch.Counters.SelectMany(row => row).ToArray();
+
+        private static (double Mean, double Variance) MomentsOf(double[] values)
+        {
+            var mean = values.Average();
+            var variance = values.Sum(v => (v - mean) * (v - mean)) / (values.Length - 1);
+            return (mean, variance);
+        }
+
+        /// <summary>
+        /// The noise has the variance the Gaussian mechanism requires.
+        /// </summary>
+        /// <remarks>
+        /// This is the single most important assertion in this file. The privacy
+        /// argument is the Gaussian mechanism at the l2-sensitivity of a Count-Min
+        /// Sketch, which is the square root of twice the depth; the mechanism then
+        /// wants a variance of the sensitivity squared over twice the budget, which is
+        /// the depth over the budget. Get this wrong by a factor and the sketch is
+        /// exactly as accurate as it should be, exactly as fast, and not private.
+        /// <para>
+        /// Measured at ratios of 0.998, 0.998, 0.993 and 0.988 to the required
+        /// variance across the four shapes below.
+        /// </para>
+        /// </remarks>
+        [TestMethod]
+        public void TestTheNoiseHasTheVarianceTheMechanismRequires()
+        {
+            foreach (var (width, depth, rho) in new[]
+            {
+                (2000u, 5u, 1.0),
+                (2000u, 5u, 0.1),
+                (2000u, 10u, 1.0),
+                (5000u, 3u, 0.5),
+            })
+            {
+                var sketch = new PrivateCountMinSketch(width, depth, rho, seed: 7);
+                var (_, variance) = MomentsOf(NoiseOf(sketch));
+
+                var required = depth / rho;
+
+                Assert.AreEqual(required, variance, required * 0.05,
+                    $"At depth {depth} and a budget of {rho} the noise must have a " +
+                    $"variance of {required}, and it has {variance:F4}. A mechanism at " +
+                    "the wrong scale is not the mechanism the privacy proof is about.");
+
+                Assert.AreEqual(Math.Sqrt(required), sketch.NoiseDeviation, 1e-12,
+                    "The sketch reports a deviation it did not draw from.");
+            }
+        }
+
+        /// <summary>
+        /// The noise is centred on nothing.
+        /// </summary>
+        /// <remarks>
+        /// Noise with a mean is a constant offset an observer can subtract, and it
+        /// biases every estimate in the same direction. The bound is three standard
+        /// errors of the mean, which is where a correct implementation sits and a
+        /// shifted one does not.
+        /// </remarks>
+        [TestMethod]
+        public void TestTheNoiseIsCentredOnNothing()
+        {
+            foreach (var seed in new ulong[] { 1, 2, 3, 4, 5 })
+            {
+                var sketch = new PrivateCountMinSketch(2000, 5, 1.0, seed);
+                var noise = NoiseOf(sketch);
+                var (mean, variance) = MomentsOf(noise);
+
+                var standardError = Math.Sqrt(variance / noise.Length);
+
+                Assert.IsTrue(Math.Abs(mean) < 3 * standardError,
+                    $"The noise from seed {seed} averages {mean:F4}, which is more " +
+                    $"than three standard errors ({3 * standardError:F4}) from nought.");
+            }
+        }
+
+        /// <summary>
+        /// The noise is shaped like a Gaussian, not merely spread like one.
+        /// </summary>
+        /// <remarks>
+        /// The variance test above would pass just as happily on uniform noise of the
+        /// right width, or on a sum of a few uniforms, and neither is what the privacy
+        /// proof is about -- the Gaussian mechanism's guarantee comes from the tails of
+        /// a Gaussian. Skewness and kurtosis separate them: a Gaussian has a skewness
+        /// of nought and a kurtosis of three, where a uniform distribution has a
+        /// kurtosis of 1.8 and a Laplace of six.
+        /// <para>
+        /// Measured at a skewness of -0.014 and a kurtosis of 2.97.
+        /// </para>
+        /// </remarks>
+        [TestMethod]
+        public void TestTheNoiseIsShapedLikeAGaussian()
+        {
+            var sketch = new PrivateCountMinSketch(4000, 10, 1.0, seed: 21);
+            var noise = NoiseOf(sketch);
+            var (mean, variance) = MomentsOf(noise);
+            var deviation = Math.Sqrt(variance);
+
+            var skewness = noise.Sum(v => Math.Pow((v - mean) / deviation, 3))
+                / noise.Length;
+            var kurtosis = noise.Sum(v => Math.Pow((v - mean) / deviation, 4))
+                / noise.Length;
+
+            Assert.IsTrue(Math.Abs(skewness) < 0.1,
+                $"The noise has a skewness of {skewness:F4}; a Gaussian has none.");
+            Assert.IsTrue(Math.Abs(kurtosis - 3) < 0.2,
+                $"The noise has a kurtosis of {kurtosis:F4}, where a Gaussian has 3, a " +
+                "uniform distribution 1.8 and a Laplace 6.");
+
+            // And the tails are where a Gaussian's guarantee lives, so check them
+            // rather than trusting two moments: about two thirds within one deviation,
+            // 95% within two, 99.7% within three.
+            foreach (var (multiple, share) in new[] { (1.0, 0.6827), (2.0, 0.9545), (3.0, 0.9973) })
+            {
+                var within = noise.Count(v => Math.Abs(v - mean) < multiple * deviation)
+                    / (double)noise.Length;
+
+                Assert.AreEqual(share, within, 0.01,
+                    $"{within:P2} of the noise lies within {multiple} deviations where " +
+                    $"a Gaussian puts {share:P2}.");
+            }
+        }
+
+        /// <summary>
+        /// The noise grows as the budget shrinks, in the proportion the mechanism sets.
+        /// </summary>
+        /// <remarks>
+        /// The variance is the depth over the budget, so tenfold less budget is tenfold
+        /// more variance. A mechanism that took the budget into account in the wrong
+        /// direction, or not at all, would still pass a test written at a single
+        /// budget.
+        /// </remarks>
+        [TestMethod]
+        public void TestTheNoiseScalesWithTheBudgetAndTheDepth()
+        {
+            var baseline = MomentsOf(NoiseOf(
+                new PrivateCountMinSketch(4000, 5, 1.0, seed: 13))).Variance;
+
+            var tenthBudget = MomentsOf(NoiseOf(
+                new PrivateCountMinSketch(4000, 5, 0.1, seed: 13))).Variance;
+            Assert.AreEqual(10.0, tenthBudget / baseline, 0.05,
+                "A tenth of the budget should be ten times the variance.");
+
+            var doubleDepth = MomentsOf(NoiseOf(
+                new PrivateCountMinSketch(4000, 10, 1.0, seed: 13))).Variance;
+            Assert.AreEqual(2.0, doubleDepth / baseline, 0.1,
+                "Twice the depth is twice the sensitivity squared, so twice the " +
+                "variance.");
+
+            // The width has nothing to do with it: more counters is not more privacy.
+            var wider = MomentsOf(NoiseOf(
+                new PrivateCountMinSketch(16000, 5, 1.0, seed: 13))).Variance;
+            Assert.AreEqual(1.0, wider / baseline, 0.05,
+                "Widening a sketch should not change the noise on each counter.");
+        }
+
+        /// <summary>
+        /// Every counter gets its own draw.
+        /// </summary>
+        /// <remarks>
+        /// One draw shared across a row, or across the sketch, would be far easier to
+        /// subtract back off and would not be the mechanism at all. Neighbouring
+        /// counters should also be uncorrelated, which a generator reused in step
+        /// across rows would not be.
+        /// </remarks>
+        [TestMethod]
+        public void TestEveryCounterGetsItsOwnDraw()
+        {
+            var sketch = new PrivateCountMinSketch(2000, 5, 1.0, seed: 31);
+
+            Assert.AreEqual(NoiseOf(sketch).Length, NoiseOf(sketch).Distinct().Count(),
+                "Two counters share a value, so they did not get their own draws.");
+
+            // Correlation between the first two rows, which a generator running in step
+            // would make one.
+            var first = sketch.Counters[0];
+            var second = sketch.Counters[1];
+            var meanFirst = first.Average();
+            var meanSecond = second.Average();
+
+            var covariance = 0.0;
+            for (var i = 0; i < first.Length; i++)
+            {
+                covariance += (first[i] - meanFirst) * (second[i] - meanSecond);
+            }
+            covariance /= first.Length;
+
+            var correlation = covariance
+                / (Math.Sqrt(MomentsOf(first).Variance) * Math.Sqrt(MomentsOf(second).Variance));
+
+            Assert.IsTrue(Math.Abs(correlation) < 0.05,
+                $"The first two rows of noise correlate at {correlation:F4}.");
+        }
+
+        /// <summary>
+        /// The noise is drawn once, when the sketch is built, and never again.
+        /// </summary>
+        /// <remarks>
+        /// This is a privacy property rather than a performance one, and it is the
+        /// easiest to get wrong by writing the obvious thing. Noise drawn afresh on each
+        /// query can be averaged away by asking the same question enough times, and a
+        /// guarantee that dissolves under repetition is no guarantee. Asking twice must
+        /// give the same answer, exactly.
+        /// </remarks>
+        [TestMethod]
+        public void TestTheNoiseIsDrawnOnceAndNotPerQuery()
+        {
+            var sketch = new PrivateCountMinSketch(1000, 5, 1.0, seed: 5);
+            for (var i = 0; i < 1_000; i++)
+            {
+                sketch.Add(Key(i % 100));
+            }
+
+            var first = sketch.Count(Key(7));
+            for (var i = 0; i < 100; i++)
+            {
+                Assert.AreEqual(first, sketch.Count(Key(7)),
+                    "Asking the same question twice gave two answers, so the noise is " +
+                    "being drawn per query and can be averaged away.");
+            }
+
+            // The same goes for an item that was never added.
+            var absent = sketch.Count(Key(999_999));
+            Assert.AreEqual(absent, sketch.Count(Key(999_999)));
+        }
+
+        /// <summary>
+        /// Two sketches of the same data differ, and the same seed reproduces one.
+        /// </summary>
+        [TestMethod]
+        public void TestTheSeedDecidesTheNoiseAndNothingElseDoes()
+        {
+            var one = new PrivateCountMinSketch(500, 4, 1.0, seed: 100);
+            var same = new PrivateCountMinSketch(500, 4, 1.0, seed: 100);
+            var other = new PrivateCountMinSketch(500, 4, 1.0, seed: 101);
+
+            CollectionAssert.AreEqual(NoiseOf(one), NoiseOf(same),
+                "The same seed should give the same noise.");
+            CollectionAssert.AreNotEqual(NoiseOf(one), NoiseOf(other),
+                "Two seeds should give different noise; a sketch whose noise does not " +
+                "depend on its seed is a sketch everyone can subtract.");
+
+            for (var i = 0; i < 100; i++)
+            {
+                one.Add(Key(i));
+                same.Add(Key(i));
+            }
+
+            Assert.AreEqual(one.Count(Key(3)), same.Count(Key(3)));
+        }
+
+        /// <summary>
+        /// Converting between the two ways of writing a privacy budget round-trips.
+        /// </summary>
+        /// <remarks>
+        /// Policies are written in epsilon and delta; the mechanism wants rho. Getting
+        /// the conversion wrong in the safe direction wastes accuracy and in the unsafe
+        /// direction quietly breaks the promise, so it is worth pinning in both
+        /// directions.
+        /// </remarks>
+        [TestMethod]
+        public void TestTheTwoWaysOfWritingABudgetAgree()
+        {
+            foreach (var (epsilon, delta) in new[]
+            {
+                (1.0, 1e-6), (0.1, 1e-6), (3.0, 1e-9), (0.5, 1e-5),
+            })
+            {
+                var rho = PrivateCountMinSketch.BudgetFor(epsilon, delta);
+                var back = PrivateCountMinSketch.EpsilonFor(rho, delta);
+
+                Assert.AreEqual(epsilon, back, epsilon * 1e-9,
+                    $"A budget for epsilon {epsilon} converts back to {back}.");
+                Assert.IsTrue(rho > 0 && rho < epsilon,
+                    $"A zero-concentrated budget of {rho} for an epsilon of {epsilon} " +
+                    "is not in the range the conversion can produce.");
+            }
+
+            // A tighter epsilon is a smaller budget.
+            Assert.IsTrue(
+                PrivateCountMinSketch.BudgetFor(0.1, 1e-6)
+                    < PrivateCountMinSketch.BudgetFor(1.0, 1e-6));
+        }
+
+        /// <summary>
+        /// Estimates are usable, and get less so as the guarantee tightens.
+        /// </summary>
+        /// <remarks>
+        /// The point of the structure is that it answers the question at all. Measured
+        /// over a skewed stream of a hundred thousand items: a mean absolute error of
+        /// 2.9 at a budget of 10, 4.1 at 1, and 7.5 at 0.1. Most of the error at the
+        /// loose end is ordinary Count-Min collision rather than noise, which is why
+        /// the figures rise more slowly than the noise does.
+        /// </remarks>
+        [TestMethod]
+        public void TestEstimatesAreUsableAndDegradeAsPrivacyTightens()
+        {
+            var errors = new List<double>();
+
+            foreach (var rho in new[] { 10.0, 1.0, 0.1 })
+            {
+                var sketch = new PrivateCountMinSketch(2000, 5, rho, seed: 3);
+                var truth = new Dictionary<int, int>();
+                var random = new Random(1);
+
+                for (var i = 0; i < 100_000; i++)
+                {
+                    var key = (int)(2000 * Math.Pow(random.NextDouble(), 3));
+                    sketch.Add(Key(key));
+                    truth.TryGetValue(key, out var seen);
+                    truth[key] = seen + 1;
+                }
+
+                var total = 0.0;
+                foreach (var (key, count) in truth)
+                {
+                    total += Math.Abs(sketch.Count(Key(key)) - count);
+                }
+                errors.Add(total / truth.Count);
+            }
+
+            Assert.IsTrue(errors[0] < 5,
+                $"At a loose budget the mean error was {errors[0]:F2}, which is worse " +
+                "than the collisions alone should cost.");
+            Assert.IsTrue(errors[2] > errors[0],
+                $"A tighter budget of 0.1 gave a mean error of {errors[2]:F2} against " +
+                $"{errors[0]:F2} at 10. Privacy is supposed to cost accuracy; if it " +
+                "does not, the noise is not reaching the estimates.");
+            Assert.IsTrue(errors[2] < 50,
+                $"At the tightest budget the mean error was {errors[2]:F2}, which is " +
+                "too far off to be useful.");
+        }
+
+        /// <summary>
+        /// An item never added can be reported below nought, and that is not a fault.
+        /// </summary>
+        /// <remarks>
+        /// A plain Count-Min Sketch never undercounts. This one does, because the
+        /// counters start below nought as often as above it, and taking the smallest of
+        /// several pulls the answer further down still. Callers have to know: the
+        /// one-sided guarantee people rely on from Count-Min is gone, and it is the
+        /// price of the noise rather than a defect in it.
+        /// </remarks>
+        [TestMethod]
+        public void TestAnItemNeverAddedCanReadBelowNothing()
+        {
+            var sketch = new PrivateCountMinSketch(2000, 5, 1.0, seed: 11);
+
+            var readings = new List<double>();
+            for (var i = 0; i < 2_000; i++)
+            {
+                readings.Add(sketch.Count(Key(500_000 + i)));
+            }
+
+            Assert.IsTrue(readings.Any(r => r < 0),
+                "No absent item read below nought, which a noisy minimum should do " +
+                "most of the time.");
+            Assert.IsTrue(readings.Average() < 0,
+                $"Absent items averaged {readings.Average():F2}. Taking the smallest of " +
+                "several noisy counters should pull the answer below nought on average.");
+        }
+
+        /// <summary>
+        /// The parameters are checked.
+        /// </summary>
+        [TestMethod]
+        public void TestBadParametersAreRefused()
+        {
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new PrivateCountMinSketch(0, 5, 1.0));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => new PrivateCountMinSketch(100, 0, 1.0));
+
+            foreach (var rho in new[] { 0.0, -1.0, double.NaN, double.PositiveInfinity })
+            {
+                Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                    () => new PrivateCountMinSketch(100, 5, rho),
+                    $"A budget of {rho} should be refused.");
+            }
+
+            foreach (var delta in new[] { 0.0, 1.0, -0.5, double.NaN })
+            {
+                Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                    () => PrivateCountMinSketch.EpsilonFor(1.0, delta));
+                Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                    () => PrivateCountMinSketch.BudgetFor(1.0, delta));
+            }
+
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => PrivateCountMinSketch.EpsilonFor(0, 1e-6));
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => PrivateCountMinSketch.BudgetFor(0, 1e-6));
+
+            var sketch = new PrivateCountMinSketch(100, 5, 1.0);
+            Assert.ThrowsExactly<ArgumentNullException>(() => sketch.Add((byte[])null!));
+            Assert.ThrowsExactly<ArgumentNullException>(() => sketch.Count((byte[])null!));
+        }
+
+        /// <summary>
+        /// A sketch built without a seed still gets noise, and different noise each time.
+        /// </summary>
+        /// <remarks>
+        /// The seed exists for these tests. A deployment must not supply one, because
+        /// anyone who knows it can subtract the noise back off and recover the counters
+        /// exactly -- so the unseeded path is the one that matters and it has to work.
+        /// </remarks>
+        [TestMethod]
+        public void TestAnUnseededSketchGetsItsOwnNoise()
+        {
+            var one = NoiseOf(new PrivateCountMinSketch(500, 4, 1.0));
+            var other = NoiseOf(new PrivateCountMinSketch(500, 4, 1.0));
+
+            CollectionAssert.AreNotEqual(one, other,
+                "Two unseeded sketches drew the same noise, so the noise is not " +
+                "unpredictable and can be subtracted off.");
+
+            var (_, variance) = MomentsOf(one);
+            Assert.AreEqual(4.0, variance, 4.0 * 0.15,
+                "An unseeded sketch drew noise of the wrong scale.");
+        }
+    }
+}


### PR DESCRIPTION
Closes #104.

Frequency estimation over a sliding window that is differentially private. Two classes: `PrivateCountMinSketch`, a Count-Min Sketch whose counters are seeded with Gaussian noise, and `DpswSketch`, the sliding-window framework built from them.

## What is different about this one

Every other structure in this library makes a claim that a test can measure: an error rate, a false positive rate, a space bound. This one's central claim is that an observer holding the whole structure cannot tell whether any single record was in the stream — and that is a theorem about the mechanism, the authors', resting on the noise having a particular distribution at a particular scale.

**Nothing here proves that theorem and nothing is written as though it did.** What the tests do is hold the implementation to the distribution the theorem assumes, because that is the part that can be checked and the part that fails silently. A mechanism at half the required noise is exactly as accurate, exactly as fast, and protects nobody.

Concretely, on the noise:

- variance of depth over budget, to within 5% across four shapes
- mean within three standard errors of nought, across five seeds
- skewness under 0.1, kurtosis within 0.2 of a Gaussian's three
- tail masses within a point of a Gaussian's at one, two and three deviations — which is what separates it from uniform noise of the same width
- variance scaling tenfold with a tenth of the budget, twofold with twice the depth, and not at all with the width
- every counter drawn separately, adjacent rows uncorrelated
- the same question answered identically however often it is asked, so repetition cannot average the noise away

And on the framework, the one structural condition the privacy argument needs: no item is ever covered by sketches whose budgets sum to more than the whole budget.

## The reading that would have broken it

The budget split is a geometric series: the whole-substream sketch takes `2a - a²` and each checkpoint pair takes `a^(j-2)(1-a)³/2`. Those sum to exactly one:

```
(2a - a²) + 2·(1-a)³/2·1/(1-a) = (2a - a²) + (1-a)² = 1
```

The paper's typesetting can equally be read as `(1-a)^(3/2)`, and I read it that way first. That series sums to about **twice** the budget — meaning half the noise the mechanism requires, and a structure that is not private at the rate it claims. Nothing about its accuracy, speed or output would look wrong.

What caught it was computing the sum and finding it was not one. There is now a test that no item is charged more than the whole budget, and it kills that mutation.

## Two findings that changed the defaults

**All the error is noise, not the window.** Turning the budget up to 10⁶ leaves the estimate within 1% of the truth, so the smooth-histogram approximation and the sketch collisions are not where the error lives. A query sums one noisy answer per substream, so fewer and longer substreams help twice: raising the substream factor from 0.5 to 0.7 moved the estimate from 1125 to 1211 against a truth of 1250, and the memory from 43 MB to 12 MB.

**Small checkpoint factors are dangerous, not merely inaccurate.** The budget for the j-th checkpoint falls as `a^j` while the range it covers falls only as `(1-a)^j`. Those decay at different rates, so the last checkpoints end up with almost nothing. At 0.25 on a window of four thousand the leanest sketch gets a sixty-billionth of the budget and carries noise with a standard deviation of half a million. Over 351 query points the median error was −46 and the **fifth percentile −6150**: nearly always fine, occasionally catastrophic, which is the hardest kind of wrong to notice.

The default is now 0.5, where the error ran between −77 and −37, and any configuration whose leanest sketch would carry noise exceeding the window is refused at construction with an explanation.

## One deliberate deviation from the paper

Algorithm 3 restricts the substream still being filled to ranges that have already ended, which leaves it reading a short checkpoint sketch holding a small share of the budget. A range that has not ended yet holds exactly the items that have arrived — exactly the ones the window wants — so reading the whole-substream sketch instead is correct, and it holds the largest share of the budget of any sketch there.

It costs no privacy: choosing which already-noised sketch to read is post-processing, which zCDP is immune to. And it only moves further inside the paper's bound, which is an upper bound. Measured over 351 query points, the mean error went from −51 to −30 and the fifth percentile from −77 to −60. There is a test pinned inside what the narrower reading achieves, so it fails if that behaviour returns.

## Testing

23 tests across the two classes. Full suite green on a clean `-warnaserror` build. Fifteen mutations, all killed — including noise at half scale, uniform noise instead of Gaussian, one draw shared across a row, the budget exponent misread, expiry disabled, and the noise guard defeated.

## Not included

**Persistence.** Every other structure here writes to a stream, and this one deliberately does not yet. Writing the counters is safe — they are already private — but the seed must never be written, and a format that makes it easy to round-trip a private structure is a format that makes it easy to round-trip it wrongly. That deserves its own design pass rather than being appended to this one. Happy to file it.
