### PR TITLE
Anchor every structure outside its own reading, where a source exists

### DIFF
--- a/ProbabilisticDataStructures/BinaryFuseFilter.cs
+++ b/ProbabilisticDataStructures/BinaryFuseFilter.cs
@@ -89,6 +89,15 @@ namespace ProbabilisticDataStructures
         /// </summary>
         internal int AttemptsUsed { get; private set; }
 
+        /// <summary>The chosen segment length, for the geometry tests.</summary>
+        internal uint SegmentLengthChosen => this.segmentLength;
+
+        /// <summary>How many logical segments the array spans, for the geometry tests.</summary>
+        internal uint SegmentCountChosen => this.segmentCount;
+
+        /// <summary>How many fingerprint slots the array holds, for the geometry tests.</summary>
+        internal uint ArrayLengthChosen => this.arrayLength;
+
         /// <summary>Bytes per fingerprint, which the width fixes at one or two.</summary>
         private int Stride => (int)this.width / 8;
 

--- a/ProbabilisticDataStructures/HyperLogLog.cs
+++ b/ProbabilisticDataStructures/HyperLogLog.cs
@@ -78,6 +78,12 @@ namespace ProbabilisticDataStructures
         /// Number of registers
         /// </summary>
         internal uint M { get; set; }
+
+        /// <summary>
+        /// The raw registers, so tests can put the estimator into a crafted state
+        /// and hold Count() to the paper's printed formulas.
+        /// </summary>
+        internal byte[] RegisterState => this.Registers;
         /// <summary>
         /// Number of bits to calculate register
         /// </summary>

--- a/ProbabilisticDataStructures/HyperLogLogPlus.cs
+++ b/ProbabilisticDataStructures/HyperLogLogPlus.cs
@@ -89,6 +89,12 @@ namespace ProbabilisticDataStructures
         internal bool IsSparse => this.sparse is not null;
 
         /// <summary>
+        /// The dense registers, so tests can put the estimator into a crafted state
+        /// and hold Count() to Ertl's printed formulas. Null while sparse.
+        /// </summary>
+        internal byte[]? DenseRegisterState => this.registers;
+
+        /// <summary>
         /// Creates an estimator with the given precision.
         /// </summary>
         /// <param name="precision">

--- a/ProbabilisticDataStructures/InvertibleBloomLookupTable.cs
+++ b/ProbabilisticDataStructures/InvertibleBloomLookupTable.cs
@@ -39,12 +39,16 @@ namespace ProbabilisticDataStructures
         private const int HashCount = 4;
 
         /// <summary>
-        /// Cells per expected difference. Below roughly 1.22 the peeling threshold for
-        /// four hashes, decoding starts to fail; 1.5 leaves room.
+        /// Cells per expected difference. Complete listing needs more than c4 = 1.295
+        /// cells per entry -- the 2-core threshold for four hashes, Table 1 of the
+        /// paper (1.222 is the three-hash figure); 1.5 leaves room.
         /// </summary>
-        private const double CellsPerDifference = 1.5;
+        internal const double CellsPerDifference = 1.5;
 
         private uint cells;
+
+        /// <summary>How many cells the table was provisioned with, for tests.</summary>
+        internal uint CellCount => this.cells;
         private int keySize;
         private long[] counts = null!;
         private byte[] keySums = null!;

--- a/ProbabilisticDataStructures/PartitionedBloomFilter.cs
+++ b/ProbabilisticDataStructures/PartitionedBloomFilter.cs
@@ -59,6 +59,12 @@ namespace ProbabilisticDataStructures
         /// </summary>
         private uint count { get; set; }
 
+        /// <summary>How many bits the filter holds across every partition, for tests.</summary>
+        internal uint BitCount => this.M;
+
+        /// <summary>How many hash functions (and partitions) the filter uses, for tests.</summary>
+        internal uint PartitionCount => this.k;
+
         /// <summary>
         /// Creates a new partitioned Bloom filter optimized to store n items with a
         /// specified target false-positive rate.

--- a/ProbabilisticDataStructures/ThetaSketch.cs
+++ b/ProbabilisticDataStructures/ThetaSketch.cs
@@ -49,6 +49,26 @@ namespace ProbabilisticDataStructures
 
         internal Func<ReadOnlySpan<byte>, ulong> Hash { get; set; } = null!;
 
+        /// <summary>Theta itself, so tests can pin it to the order statistic.</summary>
+        internal ulong ThetaValue
+        {
+            get
+            {
+                this.EnsureCompact();
+                return this.theta;
+            }
+        }
+
+        /// <summary>The values held, compacted, so tests can pin what a trim kept.</summary>
+        internal ulong[] ValuesHeld
+        {
+            get
+            {
+                this.EnsureCompact();
+                return this.values.AsSpan(0, this.held).ToArray();
+            }
+        }
+
         /// <summary>
         /// Creates a sketch retaining the given number of hash values.
         /// </summary>

--- a/ProbabilisticDataStructures/TupleSketch.cs
+++ b/ProbabilisticDataStructures/TupleSketch.cs
@@ -91,6 +91,16 @@ namespace ProbabilisticDataStructures
         /// The keys the sketch is holding, so that tests can check a summary still sits
         /// beside the key it belongs to.
         /// </summary>
+        /// <summary>Theta itself, so tests can pin it to the order statistic.</summary>
+        internal ulong ThetaValue
+        {
+            get
+            {
+                this.EnsureCompact();
+                return this.theta;
+            }
+        }
+
         internal ulong[] KeysHeld
         {
             get

--- a/TESTING.md
+++ b/TESTING.md
@@ -122,6 +122,57 @@ empirical test in the suite; only the formula assertions caught them. Measuring 
 outcome cannot see a quietly-degraded structure. Comparing the size against the
 closed form can.
 
+### Anchor outside your own reading
+
+Every test above shares an author with the code it checks. Round trips, merge
+identities, model oracles, worked examples derived while implementing -- each is
+an internal anchor: if the paper was misread, the test was written from the same
+misreading, and the two agree with each other instead of with the paper. This is
+not hypothetical. Sublime's counter encoding was caught with digits 1 and 2
+swapped behind a worked-example test derived from the same wrong reading, seven
+of its eight tests passing; the persistence corruption tests for three
+structures died at the checksum while asserting they tested the guards behind
+it; DPSW's budget series summed to twice the budget under a misread exponent
+with every utility test green.
+
+The defence is a second derivation that did not pass through this repository:
+values the paper itself prints, a reference implementation's arithmetic, or --
+weakest but real -- the golden bytes this library wrote in an earlier version,
+which anchor today's reading to yesterday's. The external-anchor tests (the
+sizing rules in `TestStructureGeometry`, the estimator pipelines in
+`TestHyperLogLogInternals`, `TestHyperLogLogPlus` and `TestDDSketch`, the
+order-statistic pins in the theta sketches) restate printed formulas and
+evaluate them at hand-checked points, and each header says which source the
+numbers came from and when it was checked against that source.
+
+Two adjudications from the pass that added these are worth keeping:
+
+- **A self-consistent offset can survive everything but the stored bytes.**
+  Shifting every DDSketch bucket index up by one and the reported midpoint down
+  to match passes 844 of 846 tests -- including the new anchor rows, which see
+  the same right answers. The two that fail are the persistence fixtures.
+  Behavioral equivalence is not format equivalence: the fixtures own the paper's
+  index convention, and regenerating them to green a build is how that ownership
+  would be silently signed away.
+
+- **A term can be real code and still be untestable where you first look.**
+  HLL++'s tau correction rides 2^-(64-p): at precision 12, deleting it entirely
+  survived, twelve orders of magnitude below the harmonic term. The state where
+  tau carries ten percent of the denominator needs precision 18 and 194,000
+  registers parked at value 46. A survivor is not always an equivalent mutant --
+  sometimes it is a test parameterized where the mutation cannot matter.
+
+Where no external source exists, no external anchor is possible, and the honest
+move is to say so rather than dress an internal test as one. KeepsakeBox, the
+Buckets bit-packing, the Bloomier filter's encoding and the inverse Bloom
+filter are this repository's own designs: their golden fixtures pin that the
+format is stable, not that it is right, because there is nothing outside the
+repository for them to be right against. The quotient filter's model oracle
+recomputes every fingerprint independently but was written by the same hand as
+the filter; the stable filter is anchored to its own measured behavior, which
+catches the formula disagreeing with the mechanism but not both agreeing on a
+misreading. These are the structures where a second reader adds the most.
+
 ## Mutation testing
 
 Manual, targeted mutation is part of every test commit (step 3 of the loop). Whole-file

--- a/TestProbabilisticDataStructures/TestDDSketch.cs
+++ b/TestProbabilisticDataStructures/TestDDSketch.cs
@@ -560,5 +560,65 @@ namespace TestProbabilisticDataStructures
                 bytes.AsSpan(bytes.Length - 4), crc.GetCurrentHashAsUInt32());
         }
 
+
+        /// <summary>
+        /// The bucket pipeline held to the paper's printed formulas -- Masson, Rim
+        /// and Lee, "DDSketch" (VLDB 2019), section 2, verified against the paper
+        /// 2026-08-18: gamma = (1+a)/(1-a), a value x lands in bucket
+        /// i = ceil(log_gamma(x)) covering (gamma^(i-1), gamma^i], and the bucket
+        /// answers 2*gamma^i/(gamma+1). At a = 0.5 every one of those is exact in
+        /// floating point (gamma is exactly 3), so the expected answers are literals
+        /// and the assertions are equality.
+        /// <para>
+        /// No behavioral test can pin this: the mapping and its inverse share any
+        /// offset, so a sketch that buckets by floor, or shifts every index by one
+        /// and reports the bucket below, still answers within its accuracy bound --
+        /// self-consistently wrong the same way on both sides. Only evaluating the
+        /// printed formulas at hand-checked points notices. The rows at 8, 9 and
+        /// 9.0001 straddle the gamma^2 = 9 boundary: the interval is right-closed,
+        /// so 9 answers with bucket 2 and 9.0001 with bucket 3, and a mapping that
+        /// flips ceil to floor moves 10 from 13.5 to 4.5 while leaving 9 alone.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        [DataRow(0.5, 0.5)]
+        [DataRow(2.0, 1.5)]
+        [DataRow(8.0, 4.5)]
+        [DataRow(9.0, 4.5)]
+        [DataRow(9.0001, 13.5)]
+        [DataRow(10.0, 13.5)]
+        [DataRow(27.0, 13.5)]
+        [DataRow(100.0, 121.5)]
+        [DataRow(-10.0, -13.5)]
+        public void TestBucketsAnswerThePapersMidpoint(double value, double expected)
+        {
+            var sketch = new DDSketch(0.5);
+            sketch.Add(value);
+
+            Assert.AreEqual(expected, sketch.Quantile(0.5),
+                $"a lone {value} lives in bucket ceil(log3(|{value}|)) and every " +
+                $"quantile of it must answer the bucket's 2*3^i/4 = {expected}, " +
+                "mirrored for negatives, exactly.");
+        }
+
+        /// <summary>
+        /// The quantile walk in bucket order, at the same hand-checked points: 2, 10
+        /// and 100 land in buckets 1, 3 and 5, so the median must be bucket 3's
+        /// 13.5 -- not an interpolation, not a neighbor. A walk that misorders
+        /// buckets or miscounts ranks lands on 1.5 or 121.5, both far outside any
+        /// tolerance this could have hidden behind.
+        /// </summary>
+        [TestMethod]
+        public void TestTheQuantileWalkAnswersTheMiddleBucket()
+        {
+            var sketch = new DDSketch(0.5);
+            sketch.Add(2);
+            sketch.Add(10);
+            sketch.Add(100);
+
+            Assert.AreEqual(13.5, sketch.Quantile(0.5),
+                "the median of one value each in buckets 1, 3 and 5 must be bucket " +
+                "3's midpoint.");
+        }
     }
 }

--- a/TestProbabilisticDataStructures/TestHyperLogLogInternals.cs
+++ b/TestProbabilisticDataStructures/TestHyperLogLogInternals.cs
@@ -6,7 +6,8 @@ using ProbabilisticDataStructures;
 namespace TestProbabilisticDataStructures
 {
     /// <summary>
-    /// The derivations HyperLogLog depends on, rather than its estimate.
+    /// The derivations HyperLogLog depends on, and the estimator pipeline held
+    /// to the paper's printed constants on crafted register states.
     /// </summary>
     [TestClass]
     public class TestHyperLogLogInternals
@@ -112,6 +113,159 @@ namespace TestProbabilisticDataStructures
                     $"target {target:P0}: estimated {estimate:N0} against {distinct:N0}, " +
                     $"error {error:P2}");
             }
+        }
+
+        /// <summary>
+        /// Computes the estimate the paper promises for a register state: the raw
+        /// estimator alpha_m * m^2 / sum(2^-M_j) with the printed constants (0.673,
+        /// 0.697, 0.709, then 0.7213/(1 + 1.079/m)), linear counting m*ln(m/V) when
+        /// the raw estimate is at most 5m/2 and V registers are zero, and
+        /// -2^32*ln(1 - E/2^32) past 2^32/30. Restated from Figure 3 of Flajolet,
+        /// Fusy, Gandouet and Meunier (2007), not read back from the implementation
+        /// -- that is the entire point. The constants come out of the paper's
+        /// integral for the bias of the raw estimator; no behavioral test can tell
+        /// 0.673 from 0.697, because both sit inside the estimator's own spread for
+        /// any one stream. The alpha substitution is exactly the mutation the spread
+        /// tests in TestSetHash caught only in the mean, only at one m.
+        /// </summary>
+        private static double PaperEstimate(byte[] registers)
+        {
+            var m = (double)registers.Length;
+            var alpha = registers.Length switch
+            {
+                16 => 0.673,
+                32 => 0.697,
+                64 => 0.709,
+                _ => 0.7213 / (1.0 + (1.079 / m)),
+            };
+
+            var sum = 0.0;
+            var zeros = 0;
+            foreach (var r in registers)
+            {
+                sum += Math.Pow(2.0, -r);
+                if (r == 0)
+                {
+                    zeros++;
+                }
+            }
+
+            var estimate = alpha * m * m / sum;
+            if (estimate <= 5.0 / 2.0 * m)
+            {
+                if (zeros > 0)
+                {
+                    estimate = m * Math.Log(m / zeros);
+                }
+            }
+            else if (estimate > Math.Pow(2, 32) / 30.0)
+            {
+                estimate = -Math.Pow(2, 32) * Math.Log(1 - (estimate / Math.Pow(2, 32)));
+            }
+
+            return estimate;
+        }
+
+        /// <summary>
+        /// The raw-estimator path, at every register count with its own printed
+        /// alpha. All registers are set to the same value, which keeps the harmonic
+        /// sum exact in floating point (m identical powers of two), so the expected
+        /// count is the formula's value to the digit and the assertion is equality,
+        /// not tolerance. Every row sits above 5m/2 and below 2^32/30, so no
+        /// correction engages and alpha is the only thing that can move the answer:
+        /// swapping 0.673 for 0.697 moves the m = 16 row by 6, and dropping the
+        /// 1.079 from the general formula moves the m = 128 row.
+        /// </summary>
+        [TestMethod]
+        [DataRow(16u, (byte)4)]
+        [DataRow(32u, (byte)4)]
+        [DataRow(64u, (byte)4)]
+        [DataRow(128u, (byte)4)]
+        public void TestRawEstimateIsThePapersFormula(uint m, byte fill)
+        {
+            var hll = new HyperLogLog(m);
+            Array.Fill(hll.RegisterState, fill);
+
+            var expected = PaperEstimate(hll.RegisterState);
+            Assert.IsGreaterThan(5.0 / 2.0 * m, expected,
+                $"m={m}: the crafted state must land on the raw path, above 5m/2, " +
+                "or this row pins a correction instead of alpha.");
+
+            Assert.AreEqual((ulong)expected, hll.Count(),
+                $"m={m}: all registers at {fill} must estimate " +
+                $"alpha_m * m * 2^{fill} with the paper's alpha.");
+        }
+
+        /// <summary>
+        /// The two sides of the 5m/2 threshold, with zero registers present so the
+        /// small-range branch has something to do. At m = 16, fifteen registers of 2
+        /// put the raw estimate at 36.3, inside the threshold of 40, and linear
+        /// counting answers 16*ln(16) = 44 -- the correction *raises* the estimate,
+        /// so a dropped branch is a changed answer, not a near miss. Fifteen
+        /// registers of 3 put the raw estimate at 59.9, outside the threshold, and
+        /// the same zero register must now be ignored. Together the rows pin the
+        /// threshold from both sides; a threshold moved to 5m/3 = 26.7 strands the
+        /// first row on the wrong branch.
+        /// </summary>
+        [TestMethod]
+        [DataRow((byte)2, 44UL)]
+        [DataRow((byte)3, 59UL)]
+        public void TestLinearCountingEngagesExactlyAtTheThreshold(byte fill, ulong expected)
+        {
+            var hll = new HyperLogLog(16);
+            Array.Fill(hll.RegisterState, fill);
+            hll.RegisterState[7] = 0;
+
+            Assert.AreEqual((ulong)PaperEstimate(hll.RegisterState), hll.Count(),
+                $"fill={fill}: the paper pipeline and the implementation must agree.");
+            Assert.AreEqual(expected, hll.Count(),
+                $"fill={fill}: the pipeline evaluated by hand gives {expected}.");
+        }
+
+        /// <summary>
+        /// The all-zeros state is the strongest linear-counting case: the raw
+        /// estimator sees a harmonic sum of m and answers alpha*m, but the paper
+        /// answers m*ln(m/m) = 0, and an empty estimator that reports ten items
+        /// would be reporting the estimator's own bias as data.
+        /// </summary>
+        [TestMethod]
+        public void TestAnEmptyEstimatorCountsZero()
+        {
+            Assert.AreEqual(0UL, new HyperLogLog(16).Count(),
+                "an estimator that has seen nothing must say zero, which only the " +
+                "small-range correction can make it say.");
+        }
+
+        /// <summary>
+        /// The large-range path: all sixteen registers at 27 put the raw estimate at
+        /// 1.445e9, a third of the 32-bit hash space, where the paper corrects for
+        /// hash collisions with -2^32*ln(1 - E/2^32) and the answer grows to
+        /// 1.76e9. Nothing in a realistic stream reaches this state cheaply -- which
+        /// is why the branch was previously covered by no exact assertion and a
+        /// deleted correction would have shown up only past a billion distinct
+        /// items, in production, as a 20% undercount.
+        /// <para>
+        /// The fill = 24 row sits at 1.8e8, just past the 1.43e8 threshold; a
+        /// threshold moved from 2^32/30 toward 2^32/3 leaves the fill = 27 row
+        /// corrected but strands this one on the raw path.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        [DataRow((byte)27)]
+        [DataRow((byte)24)]
+        public void TestLargeRangeCorrectionIsThePapersFormula(byte fill)
+        {
+            var hll = new HyperLogLog(16);
+            Array.Fill(hll.RegisterState, fill);
+
+            var expected = PaperEstimate(hll.RegisterState);
+            Assert.IsGreaterThan(Math.Pow(2, 32) / 30.0, expected,
+                $"fill={fill}: the crafted state must land past the 2^32/30 " +
+                "threshold, or this pins the raw path twice.");
+
+            Assert.AreEqual((ulong)expected, hll.Count(),
+                $"fill={fill}: this deep into the hash space, the estimate must be " +
+                "the paper's collision correction, not the raw formula.");
         }
     }
 }

--- a/TestProbabilisticDataStructures/TestHyperLogLogPlus.cs
+++ b/TestProbabilisticDataStructures/TestHyperLogLogPlus.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.IO;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
 
@@ -474,6 +475,204 @@ namespace TestProbabilisticDataStructures
             crc.Append(bytes.AsSpan(4, bytes.Length - 8));
             BinaryPrimitives.WriteUInt32LittleEndian(
                 bytes.AsSpan(bytes.Length - 4), crc.GetCurrentHashAsUInt32());
+        }
+
+        /// <summary>
+        /// Ertl's sigma function, restated from equation 33 of "New cardinality
+        /// estimation algorithms for HyperLogLog sketches" (2017), verified against
+        /// the paper 2026-08-18: sigma(x) = x + sum over k of x^(2^k) * 2^(k-1),
+        /// diverging at x = 1. This is the zero-register correction that replaces
+        /// linear counting in the dense estimator.
+        /// </summary>
+        private static double ErtlSigma(double x)
+        {
+            if (x == 1.0)
+            {
+                return double.PositiveInfinity;
+            }
+
+            double z = x, y = 1.0, previous;
+            do
+            {
+                x *= x;
+                previous = z;
+                z += x * y;
+                y += y;
+            }
+            while (previous != z);
+            return z;
+        }
+
+        /// <summary>
+        /// Ertl's tau function in the numerically stable form of equation 37:
+        /// tau(x) = (1 - x - sum over k of (1 - x^(2^-k))^2 * 2^-k) / 3. This is the
+        /// saturated-register correction that replaces the classic large-range
+        /// correction.
+        /// </summary>
+        private static double ErtlTau(double x)
+        {
+            if (x == 0.0 || x == 1.0)
+            {
+                return 0.0;
+            }
+
+            double y = 1.0, z = 1 - x, previous;
+            do
+            {
+                x = Math.Sqrt(x);
+                previous = z;
+                y *= 0.5;
+                z -= Math.Pow(1 - x, 2) * y;
+            }
+            while (previous != z);
+            return z / 3.0;
+        }
+
+        /// <summary>
+        /// The full estimator of Ertl's equation 32, from the register histogram:
+        /// alpha_inf * m^2 / (m*sigma(C0/m) + sum C_k 2^-k + m*tau(1 - C_(q+1)/m) * 2^-q),
+        /// with alpha_inf = 1/(2 ln 2). Summed here in the opposite order from the
+        /// implementation's Horner fold, deliberately: agreement then says the fold
+        /// computes the printed series, not merely something self-consistent.
+        /// </summary>
+        private static double ErtlEstimate(byte[] registers, int q)
+        {
+            var m = (double)registers.Length;
+            var counts = new int[q + 2];
+            foreach (var r in registers)
+            {
+                counts[r]++;
+            }
+
+            var denominator = m * ErtlTau(1 - (counts[q + 1] / m)) * Math.Pow(2, -q);
+            for (var k = q; k >= 1; k--)
+            {
+                denominator += counts[k] * Math.Pow(2, -k);
+            }
+            denominator += m * ErtlSigma(counts[0] / m);
+
+            return 1.0 / (2.0 * Math.Log(2)) * registers.Length * registers.Length / denominator;
+        }
+
+        /// <summary>
+        /// An estimator forced dense: 9,000 distinct items cannot fit the sparse
+        /// form's budget at precision 12, so the registers exist and can be crafted.
+        /// </summary>
+        private static HyperLogLogPlus DenseEstimator()
+        {
+            var hll = new HyperLogLogPlus(12);
+            for (int i = 0; i < 9000; i++)
+            {
+                hll.Add(Encoding.ASCII.GetBytes($"dense-{i}"));
+            }
+            Assert.IsFalse(hll.IsSparse,
+                "9,000 distinct items must force the dense form, or nothing below " +
+                "tests dense at all.");
+            return hll;
+        }
+
+        /// <summary>
+        /// The dense estimator against Ertl's printed pipeline on four crafted
+        /// register states: a mixed state that exercises only the harmonic series, a
+        /// half-zeros state where sigma carries the answer, a state with saturated
+        /// registers present (whose tau contribution at q = 52 sits twelve orders
+        /// below the harmonic term -- the state where tau actually carries weight
+        /// needs precision 18 and lives in the next test), and the empty state,
+        /// which must answer exactly zero because sigma(1) diverges.
+        /// <para>
+        /// No behavioral test can check this estimator against anything but itself:
+        /// its whole claim is to be less biased than the raw formula, and bias this
+        /// small only shows against the closed form. The alpha_inf constant is
+        /// 1/(2 ln 2) = 0.7213475...; the truncated 0.7213 an older HLL formula uses
+        /// moves the mixed row by one count in fifteen thousand, and only exact
+        /// agreement with the restated series notices.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestDenseEstimateIsErtlsPrintedFormula()
+        {
+            var hll = DenseEstimator();
+            var registers = hll.DenseRegisterState!;
+            var q = 64 - 12;
+
+            for (int i = 0; i < registers.Length; i++)
+            {
+                registers[i] = (byte)(1 + (i % 7));
+            }
+            Assert.AreEqual((ulong)Math.Round(ErtlEstimate(registers, q)), hll.Count(),
+                "mixed registers: the estimate must be equation 32 to the digit.");
+
+            for (int i = 0; i < registers.Length; i++)
+            {
+                registers[i] = (byte)(i % 2 == 0 ? 0 : 3);
+            }
+            var zeros = ErtlEstimate(registers, q);
+            Assert.IsGreaterThan(0, Array.IndexOf(registers, (byte)0) + 1,
+                "the sigma row must actually contain zero registers.");
+            Assert.AreEqual((ulong)Math.Round(zeros), hll.Count(),
+                "half-zero registers: sigma must carry the estimate, per equation 33.");
+
+            for (int i = 0; i < registers.Length; i++)
+            {
+                registers[i] = (byte)(i % 8 == 0 ? q + 1 : 2);
+            }
+            Assert.IsGreaterThan(0, Array.IndexOf(registers, (byte)(q + 1)) + 1,
+                "the saturation row must actually contain saturated registers.");
+            Assert.AreEqual((ulong)Math.Round(ErtlEstimate(registers, q)), hll.Count(),
+                "saturated registers present: the estimate must still be equation 32.");
+
+            Array.Clear(registers);
+            Assert.AreEqual(0UL, hll.Count(),
+                "all-zero registers: sigma(1) diverges and the estimate must be " +
+                "exactly zero, not merely small.");
+        }
+
+        /// <summary>
+        /// The state where tau genuinely carries the estimate. At precision 12 the
+        /// tau term is scaled by 2^-52 and contributes twelve orders of magnitude
+        /// below the harmonic term -- dropping it entirely is invisible to Count()
+        /// there, a fact the first mutation run against these anchors demonstrated.
+        /// At precision 18 (q = 46), 194,000 registers at value 46 and the remaining
+        /// 68,144 saturated at 47 put tau at 10% of the denominator with the
+        /// estimate at 1.62e19, still inside ulong: dropping the tau term moves the
+        /// answer to 1.80e19, and feeding tau the count at q instead of q+1 moves it
+        /// comparably. The tolerance is 4,096 counts -- two ulps of a double at that
+        /// magnitude, against a mutation displacement of 1.8e18.
+        /// </summary>
+        [TestMethod]
+        public void TestTauCarriesTheEstimateWhenRegistersSaturate()
+        {
+            var hll = new HyperLogLogPlus(18);
+            for (int i = 0; i < 40000; i++)
+            {
+                hll.Add(Encoding.ASCII.GetBytes($"tau-{i}"));
+            }
+            Assert.IsFalse(hll.IsSparse,
+                "40,000 distinct items must force the dense form at precision 18.");
+
+            var registers = hll.DenseRegisterState!;
+            var q = 64 - 18;
+            for (int i = 0; i < registers.Length; i++)
+            {
+                registers[i] = (byte)(i < 194000 ? q : q + 1);
+            }
+
+            var m = (double)registers.Length;
+            var tauTerm = m * ErtlTau(1 - ((m - 194000) / m)) * Math.Pow(2, -q);
+            var harmonic = 194000 * Math.Pow(2, -q);
+            var expected = 1.0 / (2.0 * Math.Log(2)) * m * m / (tauTerm + harmonic);
+
+            Assert.IsGreaterThan(0.05, tauTerm / (tauTerm + harmonic),
+                "tau must carry at least 5% of the denominator, or this row pins " +
+                "the harmonic series a second time and the tau mutations survive.");
+            Assert.IsLessThan((double)ulong.MaxValue, expected,
+                "the crafted estimate must fit a ulong, or saturation hides the " +
+                "comparison entirely.");
+
+            Assert.IsLessThanOrEqualTo(4096.0, Math.Abs(hll.Count() - expected),
+                "with saturated registers dominating, the estimate must be " +
+                "equation 32 with tau evaluated at 1 - C_(q+1)/m, to within two " +
+                "ulps of a double at 1.6e19.");
         }
     }
 }

--- a/TestProbabilisticDataStructures/TestStructureGeometry.cs
+++ b/TestProbabilisticDataStructures/TestStructureGeometry.cs
@@ -243,5 +243,183 @@ namespace TestProbabilisticDataStructures
                 $"n={n} p={fpRate}: packing must actually save something against the " +
                 $"byte-aligned {byteAligned} bytes, or there is nothing to justify it.");
         }
+
+        /// <summary>
+        /// Count-Min width is ceil(e/epsilon) and depth is ceil(ln(1/delta)) -- Theorem
+        /// 1 of Cormode and Muthukrishnan, "An Improved Data Stream Summary: The
+        /// Count-Min Sketch and its Applications" (2005). The e is Euler's constant,
+        /// not a typo for 2: the error bound is proved through Markov's inequality
+        /// with e as the base that makes ln(1/delta) rows suffice. A sketch built with
+        /// 2/epsilon columns is 26% narrower, overcounts proportionally more, and
+        /// passes every behavioral bound in this suite regardless, because the bound
+        /// tests carry the slack the loose inequality forces on them. Only this
+        /// restatement notices.
+        /// <para>
+        /// The last two rows straddle the ceilings: e/0.0271 = 100.3 rounds up to 101
+        /// where e/0.0272 = 99.94 rounds to 100, and ln(1/0.05) = 2.996 stays at
+        /// depth 3 where ln(1/0.049) = 3.016 forces 4. An implementation that floors,
+        /// rounds, or drops the ceiling entirely agrees with ceil on almost every
+        /// input; these are chosen from the inputs on which it cannot.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        [DataRow(0.01, 0.01, 272u, 5u)]
+        [DataRow(0.001, 0.02, 2719u, 4u)]
+        [DataRow(0.1, 0.001, 28u, 7u)]
+        [DataRow(0.0271, 0.05, 101u, 3u)]
+        [DataRow(0.0272, 0.049, 100u, 4u)]
+        public void TestCountMinGeometryMatchesThePaper(
+            double epsilon, double delta, uint expectedWidth, uint expectedDepth)
+        {
+            var cms = new CountMinSketch(epsilon, delta);
+
+            Assert.AreEqual((uint)Math.Ceiling(Math.E / epsilon), cms.Width,
+                $"e={epsilon}: width must be ceil(e/epsilon), with e Euler's constant.");
+            Assert.AreEqual(expectedWidth, cms.Width,
+                $"e={epsilon}: the formula evaluated by hand gives {expectedWidth}.");
+
+            Assert.AreEqual((uint)Math.Ceiling(Math.Log(1 / delta)), cms.Depth,
+                $"d={delta}: depth must be ceil(ln(1/delta)), the natural logarithm.");
+            Assert.AreEqual(expectedDepth, cms.Depth,
+                $"d={delta}: the formula evaluated by hand gives {expectedDepth}.");
+        }
+
+        /// <summary>
+        /// The fuse filter's segment geometry is the reference implementation's
+        /// arithmetic -- binary_fuse_calculate_segment_length and _size_factor in
+        /// FastFilter's binaryfusefilter.h, verified against the source 2026-08-18:
+        /// for arity 3, a segment length of 2^floor(ln(n)/ln(3.33) + 2.25) capped at
+        /// 2^18, and a size factor of max(1.125, 0.875 + 0.25 ln(10^6)/ln(n)). The
+        /// constants are empirical fits from the paper's authors; nothing rederives
+        /// them, so nothing but this restatement would notice 3.33 becoming 3.
+        /// <para>
+        /// n = 3565 is chosen because ln(3565)/ln(3.33) has fractional part 0.80,
+        /// inside the [0.75, 1) band where floor(x + 2.25) and floor(x + 2.0)
+        /// disagree; every rounder n in this list is blind to that edit.
+        /// </para>
+        /// <para>
+        /// n = 1 and n = 4 pin the small-set path, where the segment subtraction
+        /// underflows by design and the clamp turns the wreckage into one segment.
+        /// The restatement reproduces the underflow rather than special-casing it,
+        /// because the reference behaves this way and the implementation documents
+        /// itself as following the reference.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        [DataRow(1u)]
+        [DataRow(4u)]
+        [DataRow(1000u)]
+        [DataRow(3565u)]
+        [DataRow(65536u)]
+        [DataRow(1000000u)]
+        public void TestBinaryFuseGeometryMatchesTheReferenceImplementation(uint n)
+        {
+            var keys = new System.Collections.Generic.List<byte[]>();
+            for (uint i = 0; i < n; i++)
+            {
+                keys.Add(System.Text.Encoding.ASCII.GetBytes($"geometry-{i}"));
+            }
+            var f = BinaryFuseFilter.Build(keys);
+
+            var segmentLength = n == 0
+                ? 4u
+                : Math.Min(262144u, 1u << (int)Math.Floor(Math.Log(n) / Math.Log(3.33) + 2.25));
+            var factor = n <= 1
+                ? 0
+                : Math.Max(1.125, 0.875 + (0.25 * Math.Log(1000000.0) / Math.Log(n)));
+            var capacity = n <= 1 ? 0 : (uint)Math.Round(n * factor);
+
+            uint arrayLength;
+            unchecked
+            {
+                var initialSegments = ((capacity + segmentLength - 1) / segmentLength) - 2;
+                arrayLength = (initialSegments + 2) * segmentLength;
+            }
+            var segmentCount = (arrayLength + segmentLength - 1) / segmentLength;
+            segmentCount = segmentCount <= 2 ? 1u : segmentCount - 2;
+            arrayLength = (segmentCount + 2) * segmentLength;
+
+            Assert.AreEqual(segmentLength, f.SegmentLengthChosen,
+                $"n={n}: segment length must be 2^floor(ln(n)/ln(3.33) + 2.25).");
+            Assert.AreEqual(segmentCount, f.SegmentCountChosen,
+                $"n={n}: segment count must follow the reference derivation.");
+            Assert.AreEqual(arrayLength, f.ArrayLengthChosen,
+                $"n={n}: array length must be (segments + 2) segment lengths.");
+        }
+
+        /// <summary>
+        /// Each filter a scalable Bloom filter adds is built to the rate p0*r^i --
+        /// section 3 of Almeida, Baquero, Preguica and Hutchison, "Scalable Bloom
+        /// Filters" (2007), where the compounded rate telescopes to at most
+        /// p0/(1-r). The series is only observable through the geometry the rate
+        /// buys, so the assertion goes through OptimalK and OptimalM, which the
+        /// tests above hold to their own papers. With p0 = 0.05 and r = 0.8, k
+        /// crosses a ceiling boundary between filters 2 and 3 (log2(1/rate) passes
+        /// 5), so a mutation that stops tightening -- r^i frozen at r, or applied to
+        /// the wrong exponent -- shifts the transition and fails.
+        /// <para>
+        /// The paper also grows each successive filter's capacity geometrically.
+        /// This implementation adds fixed-size filters instead and only tightens the
+        /// rates; the union bound the series exists for cares about the rates alone,
+        /// so that is what this pins.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestScalableFilterRatesFollowTheTighteningSeries()
+        {
+            var s = new ScalableBloomFilter(1000, 0.05, 0.8);
+            for (int i = 0; i < 5000; i++)
+            {
+                s.Add(System.Text.Encoding.ASCII.GetBytes($"series-{i}"));
+            }
+
+            Assert.IsGreaterThanOrEqualTo(4, s.Filters.Count,
+                "5,000 additions against a 1,000-item hint must force at least four " +
+                "filters, or the series below is asserted on air.");
+
+            double compounded = 0;
+            for (int i = 0; i < s.Filters.Count; i++)
+            {
+                var rate = 0.05 * Math.Pow(0.8, i);
+                compounded += rate;
+
+                Assert.AreEqual(Utils.OptimalK(rate), s.Filters[i].PartitionCount,
+                    $"filter {i} must be built with k for the tightened rate 0.05*0.8^{i}.");
+                Assert.AreEqual(Utils.OptimalM(1000, rate), s.Filters[i].BitCount,
+                    $"filter {i} must be sized for the tightened rate 0.05*0.8^{i}.");
+            }
+
+            Assert.IsLessThan(0.05 / (1 - 0.8), compounded,
+                "the compounded rate must stay below p0/(1-r), the geometric series " +
+                "bound the tightening exists to enforce.");
+        }
+
+        /// <summary>
+        /// An invertible Bloom lookup table can only list its contents while it has
+        /// more than c4 = 1.295 cells per entry -- the 2-core threshold for four
+        /// hashes, Table 1 of Goodrich and Mitzenmacher, "Invertible Bloom Lookup
+        /// Tables" (2011). The 1.5 the sizing uses is that threshold plus margin.
+        /// Nothing else fails fast if the margin is edited away: listing degrades
+        /// probabilistically, at scale, in someone else's diff.
+        /// </summary>
+        [TestMethod]
+        public void TestIbltProvisioningClearsThePeelingThreshold()
+        {
+            Assert.IsGreaterThanOrEqualTo(1.295, InvertibleBloomLookupTable.CellsPerDifference,
+                "cells per difference must clear the four-hash 2-core threshold " +
+                "c4 = 1.295, below which listEntries stops succeeding with high " +
+                "probability.");
+
+            foreach (var d in new uint[] { 3, 50, 1000 })
+            {
+                var t = new InvertibleBloomLookupTable(d, 8);
+                Assert.AreEqual((uint)Math.Ceiling(d * 1.5), t.CellCount,
+                    $"d={d}: the table must provision ceil(1.5d) cells.");
+            }
+
+            Assert.AreEqual(4u, new InvertibleBloomLookupTable(2, 8).CellCount,
+                "two differences ask for three cells, but four hashes need four " +
+                "distinct cells to land in, so the hash count is the floor.");
+        }
     }
 }

--- a/TestProbabilisticDataStructures/TestThetaSketch.cs
+++ b/TestProbabilisticDataStructures/TestThetaSketch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
@@ -502,5 +503,53 @@ namespace TestProbabilisticDataStructures
             Assert.IsLessThan(1024ul, new ThetaSketch(K).SizeInBytes());
         }
 
+
+        /// <summary>
+        /// Theta after a trim must be exactly the (k+1)-th smallest distinct hash of
+        /// the stream, and the survivors exactly the k below it. This is the
+        /// unbiased KMV estimator -- DataSketches' "better estimator" (K-1)/V(K),
+        /// Beyer et al. 2007 -- written with K = k+1: retain k values strictly below
+        /// the (k+1)-th order statistic and estimate k divided by that statistic's
+        /// fraction of the hash space.
+        /// <para>
+        /// The characterization tests cannot see this: "the values held are exactly
+        /// the input hashes below theta" is just as true of a sketch that sets theta
+        /// to the k-th smallest and keeps k-1 -- self-consistent, biased by one part
+        /// in k, and invisible to every behavioral test at any realistic k. The
+        /// order statistic has to be computed by something that is not the trim
+        /// code, which is what the independent sort below is.
+        /// </para>
+        /// </summary>
+        [TestMethod]
+        public void TestThetaIsTheKPlusFirstSmallestHash()
+        {
+            const uint k = 32;
+            var sketch = new ThetaSketch(k);
+
+            var hashes = new ulong[2 * k];
+            for (var i = 0; i < 2 * k; i++)
+            {
+                var key = System.Text.Encoding.ASCII.GetBytes($"order-statistic-{i}");
+                hashes[i] = sketch.Hash(key);
+                sketch.Add(key);
+            }
+
+            var sorted = hashes.Distinct().OrderBy(h => h).ToArray();
+            Assert.HasCount((int)(2 * k), sorted,
+                "the 64 keys must hash distinctly, or the stream never reaches the " +
+                "trim and theta is asserted on air.");
+
+            Assert.AreEqual(sorted[k], sketch.ThetaValue,
+                "theta must be the (k+1)-th smallest hash the stream produced -- " +
+                "the k-th leaves a sample the stated rate was never applied to.");
+            CollectionAssert.AreEqual(sorted.Take((int)k).ToArray(), sketch.ValuesHeld,
+                "the survivors must be exactly the k hashes below theta, in order.");
+
+            var expected = (ulong)Math.Round(
+                k / (sorted[k] / 18446744073709551616.0));
+            Assert.AreEqual(expected, sketch.Count(),
+                "the estimate must be k over theta's fraction of the hash space, " +
+                "the unbiased (K-1)/V(K) form.");
+        }
     }
 }

--- a/TestProbabilisticDataStructures/TestTupleSketch.cs
+++ b/TestProbabilisticDataStructures/TestTupleSketch.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ProbabilisticDataStructures;
@@ -573,6 +574,51 @@ namespace TestProbabilisticDataStructures
 
             Assert.AreEqual(0UL, read.Count());
             Assert.AreEqual(0.0, read.Total());
+        }
+
+        /// <summary>
+        /// The same order-statistic pin TestThetaSketch carries, because TupleSketch
+        /// trims with its own copy of the rule: theta becomes the (k+1)-th smallest
+        /// distinct hash, the k keys below it survive, and each keeps the summary
+        /// that was folded for it. The pairing matters as much as the rule -- a trim
+        /// that sorts keys without carrying summaries, or off by one slot, leaves
+        /// every surviving key wearing a neighbor's value, which no theta-side test
+        /// can notice.
+        /// </summary>
+        [TestMethod]
+        public void TestThetaIsTheKPlusFirstSmallestHashAndSummariesFollow()
+        {
+            const uint k = 32;
+            var sketch = new TupleSketch(k);
+
+            var hashes = new ulong[2 * k];
+            var values = new System.Collections.Generic.Dictionary<ulong, double>();
+            for (var i = 0; i < 2 * k; i++)
+            {
+                var key = System.Text.Encoding.ASCII.GetBytes($"order-statistic-{i}");
+                hashes[i] = sketch.Hash(key);
+                values[hashes[i]] = 10.0 * i;
+                sketch.Add(key, 10.0 * i);
+            }
+
+            var sorted = hashes.Distinct().OrderBy(h => h).ToArray();
+            Assert.HasCount((int)(2 * k), sorted,
+                "the 64 keys must hash distinctly, or the stream never reaches the " +
+                "trim and theta is asserted on air.");
+
+            Assert.AreEqual(sorted[k], sketch.ThetaValue,
+                "theta must be the (k+1)-th smallest hash the stream produced.");
+            CollectionAssert.AreEqual(sorted.Take((int)k).ToArray(), sketch.KeysHeld,
+                "the survivors must be exactly the k hashes below theta, in order.");
+
+            var keys = sketch.KeysHeld;
+            var summaries = sketch.SummariesHeld;
+            for (var i = 0; i < keys.Length; i++)
+            {
+                Assert.AreEqual(values[keys[i]], summaries[i],
+                    $"survivor {i} must keep the summary folded for its own key, " +
+                    "not a neighbor's.");
+            }
         }
     }
 }


### PR DESCRIPTION
The audit pass behind this: every test in the suite shares an author with the code it checks, and the recent structures each shipped a defect that internal tests could not see — swapped digits behind a worked example derived from the same misreading, corruption tests refused by the CRC, a budget series summing to 2ρ. This pass classifies every structure by its strongest anchor and adds external ones — expected values computed outside this codebase — where a source exists.

## What was unanchored, now pinned

| Structure | Was | Now pinned to |
|---|---|---|
| CountMinSketch | sizing only in the implementation | ⌈e/ε⌉ × ⌈ln(1/δ)⌉, Cormode–Muthukrishnan; ceiling straddles on both axes |
| BinaryFuseFilter | implementation *is* reference arithmetic, unpinned | FastFilter `binaryfusefilter.h` constants, verified against source; n=3565 discriminates the +2.25 |
| ScalableBloomFilter | series implemented, unpinned | p₀·rⁱ per filter (Almeida §3) through the already-pinned OptimalK/M |
| IBLT | 1.5 cells/diff, threshold misattributed in a comment | c₄ = 1.295 (Goodrich–Mitzenmacher Table 1); comment fixed — 1.22 is the three-hash figure |
| HyperLogLog | α table only in the implementation | full Figure-3 pipeline: printed α per m, linear counting straddling 5m/2, large-range straddling 2³²/30 |
| HyperLogLogPlus | dense estimator (Ertl σ/τ) unpinned | Eq. 32 recomputed from the histogram, σ/τ transcribed from Eqs. 33/37, opposite summation order |
| DDSketch | behavioral only (self-consistent layer invisible) | γ=(1+α)/(1−α), i=⌈log_γ x⌉, (γ^(i−1), γ^i], 2γⁱ/(γ+1) at exact γ=3 points |
| ThetaSketch / TupleSketch | θ order statistic unpinned | θ = (k+1)-th smallest (unbiased KMV, (K−1)/V(K)); Tuple also pins key↔summary pairing through the trim |

Every constant pinned was verified against its source this session (papers via ar5iv, FastFilter header, DataSketches KMV tutorial), not recalled.

## The two adjudications worth reading

- **DDSketch joint offset** (index+1, report−1): survives **844 of 846** tests, including the new anchor rows. The two that fail are the persistence fixtures. The golden bytes own the paper's index convention; the writeup in TESTING.md says why regenerating them would sign that ownership away.
- **HLL++ tau**: deleting the saturation correction *survived* at precision 12 — it rides 2^−52 there, twelve orders below the harmonic term. The killable state needs precision 18, 194k registers at value 46, tau at 10% of the denominator, estimate 1.62e19 still inside `ulong`. Survivor ≠ equivalent mutant; sometimes the test is parameterized where the mutation cannot matter.

## Mutation tables

All in the commit messages. 22 mutations run, 20 killed outright, 2 (the tau pair) killed after the precision-18 test was added for them. Every kill was watched, not assumed.

## The honest residue (in TESTING.md)

KeepsakeBox, Buckets packing, Bloomier encoding, inverse Bloom: repo-original, no external source exists — fixtures pin stability, not correctness. Quotient filter's model oracle is independent arithmetic by the same hand. Stable filter is anchored to its own measured behavior. These are where a second reader adds the most.

Source changes are internal test accessors only (the `SetSketch.RegisterValues` pattern) plus the IBLT comment correction. No behavior changes; 848 tests, clean `-warnaserror` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9
