### PR TITLE
Make the mutation harness refuse a dirty tree

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,10 @@ worth two minutes of your time before you write the tests rather than after.
   to fail proves nothing. Twice in this repository a test that *named* a constant
   turned out to be unable to detect that constant changing.
 - **Break the implementation on purpose** to prove the new test catches it, then put it
-  back, and record what you broke in the commit message. Commit *before* you start
-  breaking things — the obvious way to undo a deliberate break also discards everything
-  else uncommitted.
+  back, and record what you broke in the commit message. `scripts/mutate.sh` does the
+  mechanics; see TESTING.md. Commit *before* you start breaking things — the obvious way
+  to undo a deliberate break also discards everything else uncommitted, which is why the
+  script refuses to run on a dirty tree rather than trusting anyone to remember.
 - **Say what survived.** If you tried a mutation and the suite did not catch it, that
   belongs in the commit message too, along with why you decided it was acceptable. A
   documented survivor is worth more than a tidy story.

--- a/TESTING.md
+++ b/TESTING.md
@@ -199,8 +199,34 @@ rebuilds a segment, so work is only ever measured on expansion-free spans.
 
 ## Mutation testing
 
-Manual, targeted mutation is part of every test commit (step 3 of the loop). Whole-file
-sweeps use Stryker.NET. The config carries the settings; the scope belongs on the
+Manual, targeted mutation is part of every test commit (step 3 of the loop).
+`scripts/mutate.sh` carries the mechanics; a run is a scratch script naming the edits,
+which belong next to the commit they verify:
+
+```bash
+source scripts/mutate.sh
+mutation_target ProbabilisticDataStructures
+
+MUTATION_FILTER='FullyQualifiedName~TestHyperLogLogInternals' \
+run_mutation "alpha 0.673 -> 0.697" \
+    ProbabilisticDataStructures/HyperLogLog.cs \
+    'return 0.673;' 'return 0.697;'
+
+mutation_done
+```
+
+It restores the target between edits, refuses a pattern that does not name exactly one
+place, distinguishes a mutation the tests killed from one that would not compile, and
+checks the tree still builds at the end.
+
+**It refuses to start on a dirty target.** The restore is `git checkout -- <dir>`, which
+discards every uncommitted change in that directory and not only the deliberate break.
+That rule was learned three times before it was enforced: twice by losing a nearly
+finished change to its own verification step, and once by losing a fix, re-running the
+harness, and reporting a mutation table measured against the tree without it. Commit
+first — the commit is what the table is describing anyway.
+
+Whole-file sweeps use Stryker.NET. The config carries the settings; the scope belongs on the
 command line, per run:
 
 ```

--- a/scripts/mutate.sh
+++ b/scripts/mutate.sh
@@ -1,0 +1,154 @@
+# Helpers for step 3 of the loop in TESTING.md: break the implementation on
+# purpose, watch the tests fail, put it back.
+#
+# Sourced rather than run, because a mutation run is a handful of one-off edits
+# whose text belongs next to the commit it is verifying:
+#
+#     source scripts/mutate.sh
+#     mutation_target ProbabilisticDataStructures
+#
+#     run_mutation "alpha 0.673 -> 0.697" \
+#         ProbabilisticDataStructures/HyperLogLog.cs \
+#         'return 0.673;' 'return 0.697;'
+#
+#     mutation_done
+#
+# Each run restores the target directory, applies one edit, builds, runs the
+# tests, and prints the verdict. Set MUTATION_FILTER to scope the test run:
+#
+#     MUTATION_FILTER='FullyQualifiedName~TestHyperLogLog' source scripts/mutate.sh
+#
+# The restore is `git checkout -- <dir>`, which discards *every* uncommitted
+# change in that directory and not only the deliberate break. That is why
+# mutation_target refuses to start on a dirty tree. The rule it enforces was
+# learned three times: twice by losing a nearly finished change to its own
+# verification step, and once by losing a fix and then reporting a mutation
+# result measured against the tree without it.
+
+MUTATION_DIR=""
+MUTATION_FILTER="${MUTATION_FILTER:-}"
+MUTATION_CONFIG="${MUTATION_CONFIG:-Release}"
+MUTATION_KILLED=0
+MUTATION_SURVIVED=0
+
+mutation_target() {
+    MUTATION_DIR="$1"
+
+    if [ ! -d "$MUTATION_DIR" ]; then
+        echo "mutate: no such directory: $MUTATION_DIR" >&2
+        return 1
+    fi
+
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        echo "mutate: not a git repository, so nothing could restore the break" >&2
+        return 1
+    fi
+
+    # The guard. Staged or unstaged changes under the target are exactly what
+    # the restore would throw away.
+    if ! git diff --quiet -- "$MUTATION_DIR" \
+        || ! git diff --cached --quiet -- "$MUTATION_DIR"; then
+        echo "mutate: refusing to run -- '$MUTATION_DIR' has uncommitted changes." >&2
+        echo >&2
+        git status --short -- "$MUTATION_DIR" >&2
+        echo >&2
+        echo "  Restoring a mutation discards everything uncommitted in that" >&2
+        echo "  directory, not only the deliberate break. Commit the work first;" >&2
+        echo "  the commit is what you are verifying anyway." >&2
+        return 1
+    fi
+
+    # Untracked files survive the restore, so they are not in danger -- but they
+    # usually mean a change is half made, and a mutation table measured now
+    # describes a tree nobody will have again.
+    local untracked
+    untracked="$(git ls-files --others --exclude-standard -- "$MUTATION_DIR")"
+    if [ -n "$untracked" ]; then
+        echo "mutate: note -- untracked files under '$MUTATION_DIR':" >&2
+        echo "$untracked" | sed 's/^/    /' >&2
+        echo "  These survive the restore, but the table will describe a tree" >&2
+        echo "  that is not the commit under test." >&2
+    fi
+
+    trap 'mutation_restore' EXIT INT TERM
+    MUTATION_KILLED=0
+    MUTATION_SURVIVED=0
+    echo "mutate: target '$MUTATION_DIR', clean. Config $MUTATION_CONFIG."
+}
+
+mutation_restore() {
+    if [ -n "$MUTATION_DIR" ]; then
+        git checkout -- "$MUTATION_DIR" 2>/dev/null
+    fi
+}
+
+run_mutation() {
+    local name="$1" file="$2" old="$3" new="$4"
+
+    if [ -z "$MUTATION_DIR" ]; then
+        echo "mutate: call mutation_target before run_mutation" >&2
+        return 1
+    fi
+
+    mutation_restore
+
+    if ! MUTATION_FILE="$file" MUTATION_OLD="$old" MUTATION_NEW="$new" python3 -c '
+import os, sys
+path = os.environ["MUTATION_FILE"]
+old, new = os.environ["MUTATION_OLD"], os.environ["MUTATION_NEW"]
+try:
+    src = open(path, encoding="utf-8").read()
+except OSError as e:
+    sys.exit(f"cannot read {path}: {e}")
+found = src.count(old)
+if found != 1:
+    sys.exit(f"pattern appears {found} times, and a mutation must name one place")
+open(path, "w", encoding="utf-8").write(src.replace(old, new))
+'; then
+        printf '  %-38s PATTERN ERROR\n' "$name"
+        return 1
+    fi
+
+    # A mutation that will not compile is caught, but say so rather than
+    # counting it beside one the tests actually noticed.
+    if ! dotnet build -c "$MUTATION_CONFIG" > /dev/null 2>&1; then
+        printf '  %-38s caught (build failed)\n' "$name"
+        MUTATION_KILLED=$((MUTATION_KILLED + 1))
+        return 0
+    fi
+
+    local output
+    if [ -n "$MUTATION_FILTER" ]; then
+        output="$(dotnet test -c "$MUTATION_CONFIG" --no-build --filter "$MUTATION_FILTER" 2>&1 | tail -1)"
+    else
+        output="$(dotnet test -c "$MUTATION_CONFIG" --no-build 2>&1 | tail -1)"
+    fi
+
+    local counts
+    counts="$(echo "$output" | sed -n 's/.*Failed: *\([0-9]*\), Passed: *\([0-9]*\).*/\1 of \1+\2/p')"
+    if echo "$output" | grep -q "^Failed!"; then
+        printf '  %-38s killed   %s\n' "$name" \
+            "$(echo "$output" | sed -n 's/.*Failed: *\([0-9]*\),.*/(\1 tests)/p')"
+        MUTATION_KILLED=$((MUTATION_KILLED + 1))
+    else
+        printf '  %-38s SURVIVED %s\n' "$name" \
+            "$(echo "$output" | sed -n 's/.*Total: *\([0-9]*\).*/(all \1 passed)/p')"
+        MUTATION_SURVIVED=$((MUTATION_SURVIVED + 1))
+    fi
+}
+
+mutation_done() {
+    mutation_restore
+    trap - EXIT INT TERM
+
+    if ! dotnet build -c "$MUTATION_CONFIG" > /dev/null 2>&1; then
+        echo "mutate: the tree does NOT build after restoring -- check it by hand" >&2
+        return 1
+    fi
+
+    echo "mutate: $MUTATION_KILLED killed, $MUTATION_SURVIVED survived; tree restored and building."
+    if [ "$MUTATION_SURVIVED" -gt 0 ]; then
+        echo "mutate: survivors are leads, not verdicts. Hand-apply each before believing it."
+    fi
+    MUTATION_DIR=""
+}


### PR DESCRIPTION
The manual mutation loop — step 3 of the loop in TESTING.md — has been hand-rolled per commit for as long as it has existed. That's why the rule it depends on lived only in prose and in whoever remembered it.

It restores with `git checkout -- <dir>`, which discards **every** uncommitted change in that directory, not only the deliberate break. That has now cost work three times: twice a nearly finished change, and once — in the SetSketch2 speed work — a fix that was then reported as verified by a mutation table measured against the tree *without* it.

## What this adds

`scripts/mutate.sh`, the harness those scratch scripts kept reimplementing, with the guard built in:

```bash
source scripts/mutate.sh
mutation_target ProbabilisticDataStructures

MUTATION_FILTER='FullyQualifiedName~TestHyperLogLogInternals' \
run_mutation "alpha 0.673 -> 0.697" \
    ProbabilisticDataStructures/HyperLogLog.cs \
    'return 0.673;' 'return 0.697;'

mutation_done
```

**It refuses to start when the target has staged or unstaged changes** — prints what they are, says why, and leaves them alone. Untracked files are *noted* rather than refused: the restore can't destroy them, but they mean the table would describe a tree that isn't the commit under test.

It also settles the things the ad-hoc versions each got slightly differently: restores between edits, refuses a pattern that doesn't name exactly one place (rather than silently editing several or none), separates a mutation the tests killed from one that wouldn't compile, and checks the tree still builds when the run ends.

## Verified, not assumed

A guard that never fires is the same defect as a test that never fails, so all five paths were exercised:

| Case | Result |
| --- | --- |
| Dirty target | refused, exit 1, **edit left untouched** |
| Clean target | proceeds, exit 0 |
| Known killer | reported killed (4 tests) — matches the table this suite recorded for it by hand |
| Known survivor | reported survived — the Count-Min half-width mutation under the coarse-corner filter, whose survival is documented and owned by the geometry pin |
| Bad pattern | reported as an error, not skipped |

Using a known survivor as well as a known killer matters: a harness that reported everything as killed would look perfect and be useless.

TESTING.md and CONTRIBUTING.md point at it. No library or test changes; 904 tests, clean `-warnaserror` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH2NRDbhF5bwAsTAP7znb9
