### PR TITLE
Derive the every-structure sweeps from a roster that can refuse you

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -229,6 +229,44 @@ The tell is that the hook's body duplicates an expression rather than delegating
 adding one, check the production path calls it — a mutation applied to the *loop* and
 not the hook is the cheapest way to find out.
 
+### A sweep named "every X" must derive its roster
+
+A test that sweeps the whole library is only as complete as its list, and a list typed
+out by hand is written by whoever last remembered to extend it. It agrees with itself
+perfectly: it is named "every structure" and it means "every structure someone thought
+of". Nothing fails when the next one is added.
+
+Six sweeps here made that claim and none of them was true. The empty round trip reached
+26 of 33 structures, the corruption sweep and the read-as-another sweep 30, and the
+three hash sweeps 12 of 25, 11 of 20 and 11 of 20. The gaps tracked the release: the
+structures 6.2.0 added were the ones absent, and `BloomFilter` itself had fallen out of
+the empty sweep at some earlier point without anyone noticing.
+
+The sharpest instance was the read-as-another sweep, which ends by asserting that no two
+structures share a persistence id — computed across its own roster. Three structures were
+missing from that roster, so a duplicate id handed to any of them would have passed the
+test written to catch exactly that. A completeness check downstream of an incomplete list
+is not a check.
+
+The fix is to derive the roster from something a new structure cannot omit itself from.
+`StructureId` is that for persistence: a structure that is not in it cannot be persisted
+at all. For the hash sweeps there is no enum, so the roster comes from the library's
+public surface by reflection — the types declaring `SetHash`, and the types with a
+constructor or static factory taking a hash — filtered to those that persist, which is
+what keeps the hash plumbing out. A structure that cannot be swept is exempted *with its
+reason*, and the exemption is checked in turn: one naming a structure the sweep does
+cover has gone stale and fails as loudly as a gap.
+
+The proof that this works is not that the sweeps pass. It is that adding a member to
+`StructureId` fails all four persistence sweeps by name, and dropping the persistable
+filter from the reflected roster fails the constructor sweep on the hash plumbing it
+was there to exclude.
+
+Filling the six sweeps found no defects in the library — every structure did honour a
+constructor hash, did refuse to replace one once occupied, and did catch corruption
+anywhere in its payload. That is the point worth keeping: the sweeps were not wrong
+about the structures they reached, they were silent about the ones they did not.
+
 ### Bound the work, not the wall clock
 
 The quotient-style filters walk their metadata in while-true loops whose

--- a/TestProbabilisticDataStructures/StructureRoster.cs
+++ b/TestProbabilisticDataStructures/StructureRoster.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Checks that a test named for every structure reaches every structure.
+    /// </summary>
+    /// <remarks>
+    /// Several tests in this project sweep the whole library: every structure round
+    /// trips while empty, every structure refuses a hash it was not written with,
+    /// every structure that can be handed a hash keeps the one it was given. Each was
+    /// a list written by hand, and a hand-written list of structures agrees with
+    /// itself -- it is named "every structure" and means "every structure whoever last
+    /// edited it remembered".
+    /// <para>
+    /// That is not hypothetical. When this was first written, all six such sweeps were
+    /// short, and the gaps tracked the release: the structures added most recently
+    /// were the ones missing. One of them ended by asserting that no two structures
+    /// share a persistence id -- across a roster three structures short of the full
+    /// set, so a duplicate given to any of those three would have passed the test
+    /// written to catch precisely that.
+    /// </para>
+    /// <para>
+    /// The rosters here are derived rather than typed out: from <see cref="StructureId"/>,
+    /// which a structure cannot leave itself off of because one that is not in it
+    /// cannot be persisted at all, and from the library's own public surface. A new
+    /// structure fails these until it is either covered or exempted with a reason.
+    /// </para>
+    /// </remarks>
+    internal static class StructureRoster
+    {
+        private static readonly Assembly Library = typeof(BloomFilter).Assembly;
+
+        private static readonly Type HashFunction = typeof(Func<ReadOnlySpan<byte>, ulong>);
+
+        /// <summary>
+        /// Every public structure exposing SetHash, which is the surface the
+        /// "hash cannot be replaced once it holds something" rule applies to.
+        /// </summary>
+        internal static IReadOnlyList<Type> WithSetHash { get; } =
+            Library.GetTypes()
+                .Where(t => t.IsPublic && !t.IsAbstract && IsAStructure(t))
+                .Where(t => t.GetMethod("SetHash", new[] { HashFunction }) is not null)
+                .OrderBy(t => t.Name, StringComparer.Ordinal)
+                .ToArray();
+
+        /// <summary>
+        /// Every public structure that can be handed a hash as it is built, whether
+        /// through a constructor or a static factory. This is a wider set than
+        /// <see cref="WithSetHash"/>: for several structures, construction is the only
+        /// place a hash can be installed at all.
+        /// </summary>
+        internal static IReadOnlyList<Type> TakingAHashWhenBuilt { get; } =
+            Library.GetTypes()
+                .Where(t => t.IsPublic && !t.IsAbstract && IsAStructure(t))
+                .Where(t =>
+                    t.GetConstructors().Any(TakesAHash)
+                    || Library.GetTypes()
+                        .SelectMany(f => f.GetMethods(BindingFlags.Public | BindingFlags.Static))
+                        // ReadFrom takes a hash too, but restoring a structure is not
+                        // building one: it is the caller handing back the hash the
+                        // payload says was in use. Only builders count here.
+                        .Any(m => m.Name != "ReadFrom" && m.ReturnType == t && TakesAHash(m)))
+                .OrderBy(t => t.Name, StringComparer.Ordinal)
+                .ToArray();
+
+        // What counts as a structure here: the library also holds hash plumbing whose
+        // factories take a hash function, and those are not things anyone sweeps.
+        // Being persistable is the line, and it is the same line StructureId draws.
+        private static bool IsAStructure(Type type) =>
+            type.GetInterfaces().Any(i =>
+                i.IsGenericType
+                && i.GetGenericTypeDefinition() == typeof(IBinaryPersistable<>));
+
+        private static bool TakesAHash(MethodBase method) =>
+            method.GetParameters().Any(p => p.ParameterType == HashFunction);
+
+        /// <summary>
+        /// Asserts a sweep reached every structure the persistence format knows about.
+        /// </summary>
+        /// <param name="sweep">Named in the failure, since several sweeps share this.</param>
+        /// <param name="covered">The structures the sweep exercised.</param>
+        /// <param name="exempt">
+        /// Structures the sweep cannot apply to, each with its reason. An exemption is
+        /// a claim about the structure rather than a way to quieten this, so it is
+        /// checked in turn: one naming a structure the sweep does cover has gone stale
+        /// and fails as loudly as a gap.
+        /// </param>
+        internal static void AssertCoversEveryStructure(
+            string sweep,
+            IEnumerable<StructureId> covered,
+            params (StructureId Id, string Why)[] exempt)
+        {
+            AssertCovers(
+                sweep,
+                Enum.GetValues<StructureId>().Select(id => id.ToString()),
+                covered.Select(id => id.ToString()),
+                exempt.Select(e => (e.Id.ToString(), e.Why)));
+        }
+
+        /// <summary>
+        /// Asserts a sweep reached every type in one of the rosters above.
+        /// </summary>
+        internal static void AssertCoversEveryType(
+            string sweep,
+            IReadOnlyList<Type> roster,
+            IEnumerable<Type> covered,
+            params (Type Type, string Why)[] exempt)
+        {
+            AssertCovers(
+                sweep,
+                roster.Select(t => t.Name),
+                covered.Select(t => t.Name),
+                exempt.Select(e => (e.Type.Name, e.Why)));
+        }
+
+        private static void AssertCovers(
+            string sweep,
+            IEnumerable<string> roster,
+            IEnumerable<string> covered,
+            IEnumerable<(string Name, string Why)> exempt)
+        {
+            var seen = covered.ToHashSet(StringComparer.Ordinal);
+            var excuses = exempt.ToArray();
+            var excused = excuses.Select(e => e.Name).ToHashSet(StringComparer.Ordinal);
+
+            Assert.AreEqual(excuses.Length, excused.Count,
+                $"the {sweep} sweep exempts the same structure twice");
+
+            foreach (var (name, why) in excuses)
+            {
+                Assert.IsFalse(string.IsNullOrWhiteSpace(why),
+                    $"the {sweep} sweep exempts {name} without saying why");
+                Assert.IsFalse(seen.Contains(name),
+                    $"the {sweep} sweep exempts {name} and then covers it anyway; " +
+                    "the reason given is out of date");
+            }
+
+            var known = roster.ToArray();
+
+            var unknown = seen.Concat(excused)
+                .Where(name => !known.Contains(name, StringComparer.Ordinal))
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.IsEmpty(unknown,
+                $"the {sweep} sweep names " + string.Join(", ", unknown) +
+                ", which is not in the roster it is checked against. Either the name " +
+                "is wrong or the roster is derived from the wrong thing.");
+
+            var missing = known
+                .Where(name => !seen.Contains(name) && !excused.Contains(name))
+                .ToArray();
+
+            Assert.IsEmpty(missing,
+                $"the {sweep} sweep is named for every structure but does not reach " +
+                string.Join(", ", missing) +
+                ". Cover it, or exempt it here with the reason it cannot apply.");
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestHashConfiguration.cs
+++ b/TestProbabilisticDataStructures/TestHashConfiguration.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -35,23 +36,62 @@ namespace TestProbabilisticDataStructures
         private const int Custom = 0;
         private const int Default = 1;
 
+        /// <summary>
+        /// A hash handed to a structure as it is built is the one it holds, and the one
+        /// its payload names. For several structures here, construction is the only
+        /// place a hash can be installed at all: they expose no SetHash.
+        /// </summary>
         [TestMethod]
         public void TestEveryStructureUsesAHashGivenToItsConstructor()
         {
-            Assert.AreEqual(Custom, RecordedHashId(new BloomFilter(100, 0.01, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new BloomFilter64(100, 0.01, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new CountingBloomFilter(100, 4, 0.01, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new DeletableBloomFilter(100, 10, 0.01, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new PartitionedBloomFilter(100, 0.01, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new StableBloomFilter(100, 2, 0.01, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new InverseBloomFilter(64, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new CuckooBloomFilter(100, 0.01, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new CountMinSketch(0.01, 0.01, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new HyperLogLog(64, Alternate).ToByteArray()));
+            var built = new (Type Type, Func<byte[]> Payload)[]
+            {
+                (typeof(BloomFilter), () => new BloomFilter(100, 0.01, Alternate).ToByteArray()),
+                (typeof(BloomFilter64), () => new BloomFilter64(100, 0.01, Alternate).ToByteArray()),
+                (typeof(CountingBloomFilter), () => new CountingBloomFilter(100, 4, 0.01, Alternate).ToByteArray()),
+                (typeof(DeletableBloomFilter), () => new DeletableBloomFilter(100, 10, 0.01, Alternate).ToByteArray()),
+                (typeof(PartitionedBloomFilter), () => new PartitionedBloomFilter(100, 0.01, Alternate).ToByteArray()),
+                (typeof(StableBloomFilter), () => new StableBloomFilter(100, 2, 0.01, Alternate).ToByteArray()),
+                (typeof(InverseBloomFilter), () => new InverseBloomFilter(64, Alternate).ToByteArray()),
+                (typeof(CuckooBloomFilter), () => new CuckooBloomFilter(100, 0.01, Alternate).ToByteArray()),
+                (typeof(CountMinSketch), () => new CountMinSketch(0.01, 0.01, Alternate).ToByteArray()),
+                (typeof(HyperLogLog), () => new HyperLogLog(64, Alternate).ToByteArray()),
+                (typeof(CountSketch), () => new CountSketch(0.05, 0.01, Alternate).ToByteArray()),
+                (typeof(HyperLogLogPlus), () => new HyperLogLogPlus(14, Alternate).ToByteArray()),
+                (typeof(QuotientFilter), () => new QuotientFilter(100, 0.01, Alternate).ToByteArray()),
+                (typeof(UltraLogLog), () => new UltraLogLog(10, Alternate).ToByteArray()),
+                (typeof(InfiniFilter), () => new InfiniFilter(64, 8, Alternate).ToByteArray()),
+                (typeof(SetSketch), () => new SetSketch(8, Alternate).ToByteArray()),
+                (typeof(SublimeCountMinSketch), () => new SublimeCountMinSketch(
+                    0.5, 0.5, ValeCounterArray.DefaultCountersPerChunk, Alternate).ToByteArray()),
+                (typeof(HeavyKeeper), () => new HeavyKeeper(10, 64, seed: 1, hash: Alternate).ToByteArray()),
+                (typeof(PrivateCountMinSketch),
+                    () => new PrivateCountMinSketch(8, 2, 0.5, seed: 1, hash: Alternate).ToByteArray()),
+                (typeof(DpswSketch), () => new DpswSketch(
+                    window: 16, rho: 4.0, alpha: 0.6, width: 4, depth: 2,
+                    seed: 3, hash: Alternate).ToByteArray()),
+                (typeof(BinaryFuseFilter), () => BinaryFuseFilter.Build(
+                    new[] { Key("a"), Key("b"), Key("c") }, BinaryFuseWidth.Eight, Alternate).ToByteArray()),
+                (typeof(BloomierFilter), () => BloomierFilter.Build(
+                    new[] { new KeyValuePair<byte[], ulong>(Key("a"), 1UL) }, 8, Alternate).ToByteArray()),
+                (typeof(InvertibleBloomLookupTable),
+                    () => new InvertibleBloomLookupTable(10, 8, Alternate).ToByteArray()),
 
-            // The composites have to pass it down to what they hold.
-            Assert.AreEqual(Custom, RecordedHashId(new ScalableBloomFilter(50, 0.01, 0.8, Alternate).ToByteArray()));
-            Assert.AreEqual(Custom, RecordedHashId(new TopK(0.01, 0.01, 5, Alternate).ToByteArray()));
+                // The composites have to pass it down to what they hold.
+                (typeof(ScalableBloomFilter), () => new ScalableBloomFilter(50, 0.01, 0.8, Alternate).ToByteArray()),
+                (typeof(TopK), () => new TopK(0.01, 0.01, 5, Alternate).ToByteArray()),
+            };
+
+            foreach (var (type, payload) in built)
+            {
+                Assert.AreEqual(Custom, RecordedHashId(payload()),
+                    $"a {type.Name} built with a hash of its own recorded the default instead");
+            }
+
+            StructureRoster.AssertCoversEveryType(
+                "constructor hash",
+                StructureRoster.TakingAHashWhenBuilt,
+                built.Select(b => b.Type));
         }
 
         [TestMethod]
@@ -111,32 +151,61 @@ namespace TestProbabilisticDataStructures
             Assert.AreEqual(500u, bloom.Count());
         }
 
+        /// <summary>
+        /// Once a structure holds anything, its hash is settled: everything already in
+        /// it was placed by the old one, and replacing it moves none of it.
+        /// </summary>
         [TestMethod]
-        public void TestEveryStructureRefusesToReplaceThHashOnceItHoldsSomething()
+        public void TestEveryStructureRefusesToReplaceTheHashOnceItHoldsSomething()
         {
-            var bloom = new BloomFilter(100, 0.01); bloom.Add(Key("a"));
-            var bloom64 = new BloomFilter64(100, 0.01); bloom64.Add(Key("a"));
-            var counting = new CountingBloomFilter(100, 4, 0.01); counting.Add(Key("a"));
-            var deletable = new DeletableBloomFilter(100, 10, 0.01); deletable.Add(Key("a"));
-            var partitioned = new PartitionedBloomFilter(100, 0.01); partitioned.Add(Key("a"));
-            var stable = new StableBloomFilter(100, 2, 0.01); stable.Add(Key("a"));
-            var inverse = new InverseBloomFilter(64); inverse.Add(Key("a"));
-            var cuckoo = new CuckooBloomFilter(100, 0.01); cuckoo.Add(Key("a"));
-            var sketch = new CountMinSketch(0.01, 0.01); sketch.Add(Key("a"));
-            var hll = new HyperLogLog(64); hll.Add(Key("a"));
-            var scalable = new ScalableBloomFilter(50, 0.01, 0.8); scalable.Add(Key("a"));
+            var occupied = new (Type Type, Action Replace)[]
+            {
+                Holding(new BloomFilter(100, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new BloomFilter64(100, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new CountingBloomFilter(100, 4, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new DeletableBloomFilter(100, 10, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new PartitionedBloomFilter(100, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new StableBloomFilter(100, 2, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new InverseBloomFilter(64), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new CuckooBloomFilter(100, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new CountMinSketch(0.01, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new HyperLogLog(64), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new ScalableBloomFilter(50, 0.01, 0.8), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new CountSketch(0.05, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new HyperLogLogPlus(14), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new QuotientFilter(100, 0.01), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new ThetaSketch(64), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new UltraLogLog(10), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new InfiniFilter(64, 8), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new SetSketch(8), f => f.Add(Key("a")), f => f.SetHash(Alternate)),
+                Holding(new TupleSketch(16), f => f.Add(Key("a"), 1.0), f => f.SetHash(Alternate)),
+                Holding(
+                    new SublimeCountMinSketch(0.5, 0.5, ValeCounterArray.DefaultCountersPerChunk),
+                    f => f.Add(Key("a")),
+                    f => f.SetHash(Alternate)),
+            };
 
-            Assert.ThrowsExactly<InvalidOperationException>(() => bloom.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => bloom64.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => counting.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => deletable.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => partitioned.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => stable.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => inverse.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => cuckoo.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => sketch.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => hll.SetHash(Alternate));
-            Assert.ThrowsExactly<InvalidOperationException>(() => scalable.SetHash(Alternate));
+            foreach (var (type, replace) in occupied)
+            {
+                Assert.ThrowsExactly<InvalidOperationException>(replace,
+                    $"a {type.Name} holding something allowed its hash to be replaced");
+            }
+
+            StructureRoster.AssertCoversEveryType(
+                "replacing the hash",
+                StructureRoster.WithSetHash,
+                occupied.Select(o => o.Type));
+        }
+
+        /// <summary>
+        /// Builds a structure, puts something in it, and hands back the attempt to
+        /// replace its hash afterwards, paired with the type so a failure names it.
+        /// </summary>
+        private static (Type Type, Action Replace) Holding<T>(
+            T structure, Action<T> fill, Action<T> replace)
+        {
+            fill(structure);
+            return (typeof(T), () => replace(structure));
         }
 
         /// <summary>

--- a/TestProbabilisticDataStructures/TestPersistenceAllStructures.cs
+++ b/TestProbabilisticDataStructures/TestPersistenceAllStructures.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -43,6 +43,60 @@ namespace TestProbabilisticDataStructures
                 Assert.AreEqual(original(Key(word)), restored(Key(word)),
                     $"{name} disagreed about {word} after being restored");
             }
+        }
+
+        /// <summary>
+        /// Asserts a sweep touched every structure the format knows about.
+        /// </summary>
+        /// <remarks>
+        /// Every roster in this file is written by hand, and a hand-written roster
+        /// agrees with itself: it is named "every structure" and means "every structure
+        /// whoever last edited it remembered". That is not a hypothetical -- when this
+        /// check was first written, all four sweeps below were missing the structures
+        /// added most recently, and one of them was asserting that no two structures
+        /// share an id across a roster three structures short of the full set.
+        /// <para>
+        /// <see cref="StructureId"/> is the roster a structure cannot leave itself off
+        /// of, because a structure that is not in it cannot be persisted at all. A new
+        /// structure therefore fails this until it is either covered or exempted.
+        /// </para>
+        /// </remarks>
+        /// <param name="sweep">Named in the failure, since four sweeps share this.</param>
+        /// <param name="covered">The structures the sweep exercised.</param>
+        /// <param name="exempt">
+        /// Structures the sweep cannot apply to, each with its reason. An exemption is
+        /// a claim about the structure rather than a way to quieten this, so it is
+        /// checked in turn: one naming a structure the sweep does cover has gone stale
+        /// and fails just as loudly as a gap.
+        /// </param>
+        private static void AssertSweepCoversEveryStructure(
+            string sweep,
+            IEnumerable<StructureId> covered,
+            params (StructureId Id, string Why)[] exempt)
+        {
+            var seen = covered.ToHashSet();
+            var excused = exempt.Select(e => e.Id).ToHashSet();
+
+            Assert.AreEqual(exempt.Length, excused.Count,
+                $"the {sweep} sweep exempts a structure twice");
+
+            foreach (var (id, why) in exempt)
+            {
+                Assert.IsFalse(string.IsNullOrWhiteSpace(why),
+                    $"the {sweep} sweep exempts {id} without saying why");
+                Assert.IsFalse(seen.Contains(id),
+                    $"the {sweep} sweep exempts {id} and then covers it anyway; " +
+                    "the reason given is out of date");
+            }
+
+            var missing = Enum.GetValues<StructureId>()
+                .Where(id => !seen.Contains(id) && !excused.Contains(id))
+                .ToArray();
+
+            Assert.IsEmpty(missing,
+                $"the {sweep} sweep is named for every structure but does not reach " +
+                string.Join(", ", missing) +
+                ". Cover it, or exempt it here with the reason it cannot apply.");
         }
 
         [TestMethod]
@@ -485,46 +539,119 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void TestEveryStructureRoundTripsWhileEmpty()
         {
-            Assert.AreEqual(0ul, RoundTrip(new BloomFilter64(1000, 0.01)).Count());
-            Assert.AreEqual(0u, RoundTrip(new CountingBloomFilter(1000, 4, 0.01)).Count());
-            Assert.AreEqual(0u, RoundTrip(new DeletableBloomFilter(1000, 10, 0.01)).Count());
-            Assert.AreEqual(0u, RoundTrip(new PartitionedBloomFilter(1000, 0.01)).Count());
-            Assert.AreEqual(0u, RoundTrip(new CuckooBloomFilter(1000, 0.01)).Count());
-            Assert.AreEqual(0ul, RoundTrip(new HyperLogLog(1024)).Count());
+            var checks = new (StructureId Id, Action Check)[]
+            {
+                (StructureId.BloomFilter,
+                    () => Assert.AreEqual(0u, RoundTrip(new BloomFilter(1000, 0.01)).Count())),
+                (StructureId.BloomFilter64,
+                    () => Assert.AreEqual(0ul, RoundTrip(new BloomFilter64(1000, 0.01)).Count())),
+                (StructureId.CountingBloomFilter,
+                    () => Assert.AreEqual(0u, RoundTrip(new CountingBloomFilter(1000, 4, 0.01)).Count())),
+                (StructureId.DeletableBloomFilter,
+                    () => Assert.AreEqual(0u, RoundTrip(new DeletableBloomFilter(1000, 10, 0.01)).Count())),
+                (StructureId.PartitionedBloomFilter,
+                    () => Assert.AreEqual(0u, RoundTrip(new PartitionedBloomFilter(1000, 0.01)).Count())),
+                (StructureId.CuckooBloomFilter,
+                    () => Assert.AreEqual(0u, RoundTrip(new CuckooBloomFilter(1000, 0.01)).Count())),
+                (StructureId.HyperLogLog,
+                    () => Assert.AreEqual(0ul, RoundTrip(new HyperLogLog(1024)).Count())),
 
-            Assert.IsFalse(RoundTrip(new StableBloomFilter(1000, 2, 0.01)).Test(Key("x")));
-            Assert.IsFalse(RoundTrip(new InverseBloomFilter(500)).Test(Key("x")));
-            Assert.IsFalse(RoundTrip(new ScalableBloomFilter(100, 0.01, 0.8)).Test(Key("x")));
-            Assert.HasCount(0, RoundTrip(new TopK(0.001, 0.01, 10)).Elements());
-            Assert.HasCount(0, RoundTrip(new HeavyKeeper(10, 64, seed: 1)).Elements());
-            Assert.AreEqual(0u, RoundTrip(new VarOpt(10, seed: 1)).SampleCount);
-            Assert.AreEqual(0ul, RoundTrip(new UltraLogLog(10)).Count());
-            Assert.AreEqual(0ul, RoundTrip(Grafite.Build(Array.Empty<ulong>(), 0.01, 16)).Count());
-            Assert.IsFalse(RoundTrip(new InfiniFilter(64, 8)).Test(Key("x")));
-            Assert.IsFalse(RoundTrip(new MementoFilter(256, 8)).Test(7));
+                (StructureId.StableBloomFilter,
+                    () => Assert.IsFalse(RoundTrip(new StableBloomFilter(1000, 2, 0.01)).Test(Key("x")))),
+                (StructureId.InverseBloomFilter,
+                    () => Assert.IsFalse(RoundTrip(new InverseBloomFilter(500)).Test(Key("x")))),
+                (StructureId.ScalableBloomFilter,
+                    () => Assert.IsFalse(RoundTrip(new ScalableBloomFilter(100, 0.01, 0.8)).Test(Key("x")))),
+                (StructureId.TopK,
+                    () => Assert.HasCount(0, RoundTrip(new TopK(0.001, 0.01, 10)).Elements())),
+                (StructureId.HeavyKeeper,
+                    () => Assert.HasCount(0, RoundTrip(new HeavyKeeper(10, 64, seed: 1)).Elements())),
+                (StructureId.VarOpt,
+                    () => Assert.AreEqual(0u, RoundTrip(new VarOpt(10, seed: 1)).SampleCount)),
+                (StructureId.UltraLogLog,
+                    () => Assert.AreEqual(0ul, RoundTrip(new UltraLogLog(10)).Count())),
+                (StructureId.Grafite,
+                    () => Assert.AreEqual(0ul, RoundTrip(Grafite.Build(Array.Empty<ulong>(), 0.01, 16)).Count())),
+                (StructureId.InfiniFilter,
+                    () => Assert.IsFalse(RoundTrip(new InfiniFilter(64, 8)).Test(Key("x")))),
+                (StructureId.MementoFilter,
+                    () => Assert.IsFalse(RoundTrip(new MementoFilter(256, 8)).Test(7))),
 
-            Assert.AreEqual(0ul, RoundTrip(new CountMinSketch(0.01, 0.01)).TotalCount());
-            Assert.AreEqual(0u, RoundTrip(BinaryFuseFilter.Build(Array.Empty<byte[]>())).Count());
-            Assert.AreEqual(0ul, RoundTrip(new DDSketch(0.01)).Count());
-            Assert.AreEqual(0ul, RoundTrip(new HyperLogLogPlus(14)).Count());
-            Assert.AreEqual(0u, RoundTrip(new QuotientFilter(1000, 0.01)).Count());
-            Assert.AreEqual(0ul, RoundTrip(new ThetaSketch(4096)).Count());
-            Assert.AreEqual(0L, RoundTrip(new CountSketch(0.05, 0.01)).Count(Key("x")));
-            Assert.AreEqual(0u, RoundTrip(BloomierFilter.Build(
-                Array.Empty<System.Collections.Generic.KeyValuePair<byte[], ulong>>(), 8)).Count());
+                (StructureId.CountMinSketch,
+                    () => Assert.AreEqual(0ul, RoundTrip(new CountMinSketch(0.01, 0.01)).TotalCount())),
+                (StructureId.BinaryFuseFilter,
+                    () => Assert.AreEqual(0u, RoundTrip(BinaryFuseFilter.Build(Array.Empty<byte[]>())).Count())),
+                (StructureId.DDSketch,
+                    () => Assert.AreEqual(0ul, RoundTrip(new DDSketch(0.01)).Count())),
+                (StructureId.HyperLogLogPlus,
+                    () => Assert.AreEqual(0ul, RoundTrip(new HyperLogLogPlus(14)).Count())),
+                (StructureId.QuotientFilter,
+                    () => Assert.AreEqual(0u, RoundTrip(new QuotientFilter(1000, 0.01)).Count())),
+                (StructureId.ThetaSketch,
+                    () => Assert.AreEqual(0ul, RoundTrip(new ThetaSketch(4096)).Count())),
+                (StructureId.CountSketch,
+                    () => Assert.AreEqual(0L, RoundTrip(new CountSketch(0.05, 0.01)).Count(Key("x")))),
+                (StructureId.BloomierFilter,
+                    () => Assert.AreEqual(0u, RoundTrip(BloomierFilter.Build(
+                        Array.Empty<KeyValuePair<byte[], ulong>>(), 8)).Count())),
 
-            var emptyTable = RoundTrip(new InvertibleBloomLookupTable(10, 8));
-            Assert.AreEqual(15u, emptyTable.Cells());
-            Assert.AreEqual(8, emptyTable.KeySize());
-            Assert.IsTrue(emptyTable.TryDecode(out var nothing, out _));
-            Assert.HasCount(0, nothing);
+                (StructureId.SetSketch,
+                    () => Assert.AreEqual(0.0, RoundTrip(new SetSketch(8)).Cardinality())),
+                (StructureId.TupleSketch,
+                    () => Assert.AreEqual(0ul, RoundTrip(new TupleSketch(16)).Count())),
+                (StructureId.SublimeCountMinSketch,
+                    () => Assert.AreEqual(0ul, RoundTrip(EmptySublime()).TotalCount())),
 
-            // A signature of an empty bag is the one case here that is not all zeroes:
-            // every position holds the identity ulong.MaxValue, which a restore that
-            // defaulted the array instead of reading it would turn into 0.
-            var empty = RoundTrip(MinHash.Signature(Array.Empty<string>(), 8));
-            Assert.AreEqual(1f, MinHash.Similarity(empty, MinHash.Signature(Array.Empty<string>(), 8)));
+                // The two private structures hold noise rather than counts, so an empty
+                // one does not answer zero to a query. What has to survive the round
+                // trip is the true tally underneath, which no noise is added to.
+                (StructureId.PrivateCountMinSketch,
+                    () => Assert.AreEqual(0ul,
+                        RoundTrip(new PrivateCountMinSketch(8, 2, 0.5, seed: 1)).TotalCount())),
+                (StructureId.DpswSketch,
+                    () => Assert.AreEqual(0L, RoundTrip(EmptyDpsw()).Position)),
+
+                (StructureId.InvertibleBloomLookupTable, () =>
+                {
+                    var emptyTable = RoundTrip(new InvertibleBloomLookupTable(10, 8));
+                    Assert.AreEqual(15u, emptyTable.Cells());
+                    Assert.AreEqual(8, emptyTable.KeySize());
+                    Assert.IsTrue(emptyTable.TryDecode(out var nothing, out _));
+                    Assert.HasCount(0, nothing);
+                }),
+
+                // A signature of an empty bag is the one case here that is not all
+                // zeroes: every position holds the identity ulong.MaxValue, which a
+                // restore that defaulted the array instead of reading it would turn
+                // into 0.
+                (StructureId.MinHashSignature, () =>
+                {
+                    var empty = RoundTrip(MinHash.Signature(Array.Empty<string>(), 8));
+                    Assert.AreEqual(1f, MinHash.Similarity(empty, MinHash.Signature(Array.Empty<string>(), 8)));
+                }),
+
+                (StructureId.SimHashSignature, () =>
+                {
+                    var empty = RoundTrip(SimHash.Signature(Array.Empty<string>()));
+                    Assert.AreEqual(0, SimHash.HammingDistance(empty, SimHash.Signature(Array.Empty<string>())));
+                }),
+            };
+
+            foreach (var (id, check) in checks)
+            {
+                check();
+            }
+
+            AssertSweepCoversEveryStructure("empty round trip", checks.Select(c => c.Id));
         }
+
+        // The starting width is a chunk of counters divided by the size factor, so
+        // handing it a whole chunk asks for the smallest sketch the paper allows.
+        private static SublimeCountMinSketch EmptySublime() =>
+            new SublimeCountMinSketch(0.5, 0.5, ValeCounterArray.DefaultCountersPerChunk);
+
+        private static DpswSketch EmptyDpsw() =>
+            new DpswSketch(window: 16, rho: 4.0, alpha: 0.6, width: 4, depth: 2, seed: 3);
 
         /// <summary>
         /// Every structure names the hash it was written with, and refuses to substitute
@@ -554,7 +681,7 @@ namespace TestProbabilisticDataStructures
             var iblt = new InvertibleBloomLookupTable(10, 8, custom);
             iblt.Add(new byte[8]);
             var bloomier = BloomierFilter.Build(
-                Present.Select(w => new System.Collections.Generic.KeyValuePair<byte[], ulong>(Key(w), 1UL)),
+                Present.Select(w => new KeyValuePair<byte[], ulong>(Key(w), 1UL)),
                 8, custom);
             var theta = new ThetaSketch(4096); theta.SetHash(custom);
             foreach (var w in Present) theta.Add(Key(w));
@@ -563,34 +690,92 @@ namespace TestProbabilisticDataStructures
             var hllPlus = new HyperLogLogPlus(14); hllPlus.SetHash(custom);
             foreach (var w in Present) hllPlus.Add(Key(w));
 
-            AssertRefusesThenAccepts(bloomier.ToByteArray(), b => Persistence.FromByteArray<BloomierFilter>(b), b => Persistence.FromByteArray<BloomierFilter>(b, custom));
-            AssertRefusesThenAccepts(iblt.ToByteArray(), b => Persistence.FromByteArray<InvertibleBloomLookupTable>(b), b => Persistence.FromByteArray<InvertibleBloomLookupTable>(b, custom));
-            AssertRefusesThenAccepts(countSketch.ToByteArray(), b => Persistence.FromByteArray<CountSketch>(b), b => Persistence.FromByteArray<CountSketch>(b, custom));
-            AssertRefusesThenAccepts(theta.ToByteArray(), b => Persistence.FromByteArray<ThetaSketch>(b), b => Persistence.FromByteArray<ThetaSketch>(b, custom));
-            AssertRefusesThenAccepts(quotient.ToByteArray(), b => Persistence.FromByteArray<QuotientFilter>(b), b => Persistence.FromByteArray<QuotientFilter>(b, custom));
-            AssertRefusesThenAccepts(hllPlus.ToByteArray(), b => Persistence.FromByteArray<HyperLogLogPlus>(b), b => Persistence.FromByteArray<HyperLogLogPlus>(b, custom));
-            AssertRefusesThenAccepts(fuse.ToByteArray(), b => Persistence.FromByteArray<BinaryFuseFilter>(b), b => Persistence.FromByteArray<BinaryFuseFilter>(b, custom));
-            AssertRefusesThenAccepts(bloom.ToByteArray(), b => Persistence.FromByteArray<BloomFilter>(b), b => Persistence.FromByteArray<BloomFilter>(b, custom));
-            AssertRefusesThenAccepts(sketch.ToByteArray(), b => Persistence.FromByteArray<CountMinSketch>(b), b => Persistence.FromByteArray<CountMinSketch>(b, custom));
-            AssertRefusesThenAccepts(bloom64.ToByteArray(), b => Persistence.FromByteArray<BloomFilter64>(b), b => Persistence.FromByteArray<BloomFilter64>(b, custom));
-            AssertRefusesThenAccepts(counting.ToByteArray(), b => Persistence.FromByteArray<CountingBloomFilter>(b), b => Persistence.FromByteArray<CountingBloomFilter>(b, custom));
-            AssertRefusesThenAccepts(deletable.ToByteArray(), b => Persistence.FromByteArray<DeletableBloomFilter>(b), b => Persistence.FromByteArray<DeletableBloomFilter>(b, custom));
-            AssertRefusesThenAccepts(partitioned.ToByteArray(), b => Persistence.FromByteArray<PartitionedBloomFilter>(b), b => Persistence.FromByteArray<PartitionedBloomFilter>(b, custom));
-            AssertRefusesThenAccepts(stable.ToByteArray(), b => Persistence.FromByteArray<StableBloomFilter>(b), b => Persistence.FromByteArray<StableBloomFilter>(b, custom));
-            AssertRefusesThenAccepts(inverse.ToByteArray(), b => Persistence.FromByteArray<InverseBloomFilter>(b), b => Persistence.FromByteArray<InverseBloomFilter>(b, custom));
-            AssertRefusesThenAccepts(cuckoo.ToByteArray(), b => Persistence.FromByteArray<CuckooBloomFilter>(b), b => Persistence.FromByteArray<CuckooBloomFilter>(b, custom));
-            AssertRefusesThenAccepts(hll.ToByteArray(), b => Persistence.FromByteArray<HyperLogLog>(b), b => Persistence.FromByteArray<HyperLogLog>(b, custom));
+            // These take their hash at construction rather than through SetHash, which
+            // for several of them is the only way to install one at all.
+            var topK = new TopK(0.001, 0.01, 10, custom); topK.Add(Key("a"));
+            var keeper = new HeavyKeeper(10, 64, seed: 1, hash: custom); keeper.Add(Key("a"));
+            var ultra = new UltraLogLog(10, custom); ultra.Add(Key("a"));
+            var infini = new InfiniFilter(64, 8, custom); infini.Add(Key("a"));
+            var sublime = new SublimeCountMinSketch(
+                0.5, 0.5, ValeCounterArray.DefaultCountersPerChunk, custom);
+            sublime.Add(Key("a"));
+            var setSketch = new SetSketch(8, custom); setSketch.Add(Key("a"));
+            var tuple = new TupleSketch(16); tuple.SetHash(custom); tuple.Add(Key("a"), 1.0);
+            var priv = new PrivateCountMinSketch(8, 2, 0.5, seed: 1, hash: custom);
+            priv.Add(Key("a"));
+            var dpsw = new DpswSketch(
+                window: 16, rho: 4.0, alpha: 0.6, width: 4, depth: 2, seed: 3, hash: custom);
+            dpsw.Add(Key("a"));
 
-            // The composite one matters most: its contained filters each name the hash
-            // too, so a scalable filter cannot come back half converted.
-            AssertRefusesThenAccepts(scalable.ToByteArray(), b => Persistence.FromByteArray<ScalableBloomFilter>(b), b => Persistence.FromByteArray<ScalableBloomFilter>(b, custom));
+            var covered = new (StructureId Id, byte[] Bytes, Func<byte[], object> Without, Func<byte[], object> With)[]
+            {
+                (StructureId.BloomierFilter, bloomier.ToByteArray(), b => Persistence.FromByteArray<BloomierFilter>(b), b => Persistence.FromByteArray<BloomierFilter>(b, custom)),
+                (StructureId.InvertibleBloomLookupTable, iblt.ToByteArray(), b => Persistence.FromByteArray<InvertibleBloomLookupTable>(b), b => Persistence.FromByteArray<InvertibleBloomLookupTable>(b, custom)),
+                (StructureId.CountSketch, countSketch.ToByteArray(), b => Persistence.FromByteArray<CountSketch>(b), b => Persistence.FromByteArray<CountSketch>(b, custom)),
+                (StructureId.ThetaSketch, theta.ToByteArray(), b => Persistence.FromByteArray<ThetaSketch>(b), b => Persistence.FromByteArray<ThetaSketch>(b, custom)),
+                (StructureId.QuotientFilter, quotient.ToByteArray(), b => Persistence.FromByteArray<QuotientFilter>(b), b => Persistence.FromByteArray<QuotientFilter>(b, custom)),
+                (StructureId.HyperLogLogPlus, hllPlus.ToByteArray(), b => Persistence.FromByteArray<HyperLogLogPlus>(b), b => Persistence.FromByteArray<HyperLogLogPlus>(b, custom)),
+                (StructureId.BinaryFuseFilter, fuse.ToByteArray(), b => Persistence.FromByteArray<BinaryFuseFilter>(b), b => Persistence.FromByteArray<BinaryFuseFilter>(b, custom)),
+                (StructureId.BloomFilter, bloom.ToByteArray(), b => Persistence.FromByteArray<BloomFilter>(b), b => Persistence.FromByteArray<BloomFilter>(b, custom)),
+                (StructureId.CountMinSketch, sketch.ToByteArray(), b => Persistence.FromByteArray<CountMinSketch>(b), b => Persistence.FromByteArray<CountMinSketch>(b, custom)),
+                (StructureId.BloomFilter64, bloom64.ToByteArray(), b => Persistence.FromByteArray<BloomFilter64>(b), b => Persistence.FromByteArray<BloomFilter64>(b, custom)),
+                (StructureId.CountingBloomFilter, counting.ToByteArray(), b => Persistence.FromByteArray<CountingBloomFilter>(b), b => Persistence.FromByteArray<CountingBloomFilter>(b, custom)),
+                (StructureId.DeletableBloomFilter, deletable.ToByteArray(), b => Persistence.FromByteArray<DeletableBloomFilter>(b), b => Persistence.FromByteArray<DeletableBloomFilter>(b, custom)),
+                (StructureId.PartitionedBloomFilter, partitioned.ToByteArray(), b => Persistence.FromByteArray<PartitionedBloomFilter>(b), b => Persistence.FromByteArray<PartitionedBloomFilter>(b, custom)),
+                (StructureId.StableBloomFilter, stable.ToByteArray(), b => Persistence.FromByteArray<StableBloomFilter>(b), b => Persistence.FromByteArray<StableBloomFilter>(b, custom)),
+                (StructureId.InverseBloomFilter, inverse.ToByteArray(), b => Persistence.FromByteArray<InverseBloomFilter>(b), b => Persistence.FromByteArray<InverseBloomFilter>(b, custom)),
+                (StructureId.CuckooBloomFilter, cuckoo.ToByteArray(), b => Persistence.FromByteArray<CuckooBloomFilter>(b), b => Persistence.FromByteArray<CuckooBloomFilter>(b, custom)),
+                (StructureId.HyperLogLog, hll.ToByteArray(), b => Persistence.FromByteArray<HyperLogLog>(b), b => Persistence.FromByteArray<HyperLogLog>(b, custom)),
+                (StructureId.TopK, topK.ToByteArray(), b => Persistence.FromByteArray<TopK>(b), b => Persistence.FromByteArray<TopK>(b, custom)),
+                (StructureId.HeavyKeeper, keeper.ToByteArray(), b => Persistence.FromByteArray<HeavyKeeper>(b), b => Persistence.FromByteArray<HeavyKeeper>(b, custom)),
+                (StructureId.UltraLogLog, ultra.ToByteArray(), b => Persistence.FromByteArray<UltraLogLog>(b), b => Persistence.FromByteArray<UltraLogLog>(b, custom)),
+                (StructureId.InfiniFilter, infini.ToByteArray(), b => Persistence.FromByteArray<InfiniFilter>(b), b => Persistence.FromByteArray<InfiniFilter>(b, custom)),
+                (StructureId.SublimeCountMinSketch, sublime.ToByteArray(), b => Persistence.FromByteArray<SublimeCountMinSketch>(b), b => Persistence.FromByteArray<SublimeCountMinSketch>(b, custom)),
+                (StructureId.SetSketch, setSketch.ToByteArray(), b => Persistence.FromByteArray<SetSketch>(b), b => Persistence.FromByteArray<SetSketch>(b, custom)),
+                (StructureId.TupleSketch, tuple.ToByteArray(), b => Persistence.FromByteArray<TupleSketch>(b), b => Persistence.FromByteArray<TupleSketch>(b, custom)),
+                (StructureId.PrivateCountMinSketch, priv.ToByteArray(), b => Persistence.FromByteArray<PrivateCountMinSketch>(b), b => Persistence.FromByteArray<PrivateCountMinSketch>(b, custom)),
+                (StructureId.DpswSketch, dpsw.ToByteArray(), b => Persistence.FromByteArray<DpswSketch>(b), b => Persistence.FromByteArray<DpswSketch>(b, custom)),
+
+                // The composite one matters most: its contained filters each name the
+                // hash too, so a scalable filter cannot come back half converted.
+                (StructureId.ScalableBloomFilter, scalable.ToByteArray(), b => Persistence.FromByteArray<ScalableBloomFilter>(b), b => Persistence.FromByteArray<ScalableBloomFilter>(b, custom)),
+            };
+
+            foreach (var (id, bytes, without, with) in covered)
+            {
+                AssertRefusesThenAccepts(id, bytes, without, with);
+            }
+
+            AssertSweepCoversEveryStructure(
+                "custom hash",
+                covered.Select(c => c.Id),
+                (StructureId.DDSketch,
+                    "takes numbers rather than bytes, so it hashes nothing and records " +
+                    "HashId.None; a reader handed a hash for one is refused instead."),
+                (StructureId.MinHashSignature,
+                    "hashes with a fixed family chosen by the signature length; there " +
+                    "is no parameter through which to substitute another."),
+                (StructureId.SimHashSignature,
+                    "same: the hash is fixed by the construction rather than supplied."),
+                (StructureId.VarOpt,
+                    "samples the items themselves rather than hashing them."),
+                (StructureId.Grafite,
+                    "takes ulong keys and derives its positions from them and a seed, " +
+                    "with no hash parameter on Build."),
+                (StructureId.MementoFilter,
+                    "takes ulong keys likewise, with no hash parameter on the constructor."));
         }
 
         private static void AssertRefusesThenAccepts(
-            byte[] bytes, Func<byte[], object> withoutHash, Func<byte[], object> withHash)
+            StructureId id,
+            byte[] bytes,
+            Func<byte[], object> withoutHash,
+            Func<byte[], object> withHash)
         {
-            Assert.ThrowsExactly<InvalidDataException>(() => withoutHash(bytes));
-            Assert.IsNotNull(withHash(bytes));
+            Assert.ThrowsExactly<InvalidDataException>(() => withoutHash(bytes),
+                $"a {id} written under a custom hash was restored without being given one");
+            Assert.IsNotNull(withHash(bytes),
+                $"a {id} written under a custom hash was refused when handed that hash");
         }
 
         /// <summary>
@@ -601,45 +786,48 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void TestEveryStructureRefusesToBeReadAsAnother()
         {
-            var payloads = new (string Name, byte[] Bytes)[]
+            var payloads = new (StructureId Id, byte[] Bytes)[]
             {
-                ("BloomFilter", new BloomFilter(1000, 0.01).ToByteArray()),
-                ("BloomFilter64", new BloomFilter64(1000, 0.01).ToByteArray()),
-                ("CountingBloomFilter", new CountingBloomFilter(1000, 4, 0.01).ToByteArray()),
-                ("DeletableBloomFilter", new DeletableBloomFilter(1000, 10, 0.01).ToByteArray()),
-                ("PartitionedBloomFilter", new PartitionedBloomFilter(1000, 0.01).ToByteArray()),
-                ("ScalableBloomFilter", new ScalableBloomFilter(100, 0.01, 0.8).ToByteArray()),
-                ("StableBloomFilter", new StableBloomFilter(1000, 2, 0.01).ToByteArray()),
-                ("InverseBloomFilter", new InverseBloomFilter(500).ToByteArray()),
-                ("CuckooBloomFilter", new CuckooBloomFilter(1000, 0.01).ToByteArray()),
-                ("CountMinSketch", new CountMinSketch(0.01, 0.01).ToByteArray()),
-                ("HyperLogLog", new HyperLogLog(1024).ToByteArray()),
-                ("TopK", new TopK(0.001, 0.01, 10).ToByteArray()),
-                ("MinHashSignature", MinHash.Signature(new[] { "a" }, 8).ToByteArray()),
-                ("BinaryFuseFilter", BinaryFuseFilter.Build(new[] { Key("a") }).ToByteArray()),
-                ("DDSketch", FilledSketchOfNumbers()),
-                ("HyperLogLogPlus", new HyperLogLogPlus(14).Add(Key("a")).ToByteArray()),
-                ("QuotientFilter", new QuotientFilter(1000, 0.01).Add(Key("a")).ToByteArray()),
-                ("ThetaSketch", new ThetaSketch(4096).Add(Key("a")).ToByteArray()),
-                ("SimHashSignature", SimHash.Signature(new[] { "a" }).ToByteArray()),
-                ("CountSketch", new CountSketch(0.5, 0.5).Add(Key("a")).ToByteArray()),
-                ("InvertibleBloomLookupTable", new InvertibleBloomLookupTable(4, 8).Add(new byte[8]).ToByteArray()),
-                ("BloomierFilter", FilledBloomier()),
-                ("HeavyKeeper", new HeavyKeeper(10, 64, seed: 1).Add(Key("a")).ToByteArray()),
-                ("VarOpt", new VarOpt(10, seed: 1).Add(Key("a")).ToByteArray()),
-                ("UltraLogLog", new UltraLogLog(10).Add(Key("a")).ToByteArray()),
-                ("Grafite", Grafite.Build(new ulong[] { 1, 2, 3 }, 0.01, 16, seed: 1).ToByteArray()),
-                ("InfiniFilter", new InfiniFilter(64, 8).Add(Key("a")).ToByteArray()),
-                ("MementoFilter", new MementoFilter(256, 8).Add(5).ToByteArray()),
-                ("PrivateCountMinSketch",
+                (StructureId.BloomFilter, new BloomFilter(1000, 0.01).ToByteArray()),
+                (StructureId.BloomFilter64, new BloomFilter64(1000, 0.01).ToByteArray()),
+                (StructureId.CountingBloomFilter, new CountingBloomFilter(1000, 4, 0.01).ToByteArray()),
+                (StructureId.DeletableBloomFilter, new DeletableBloomFilter(1000, 10, 0.01).ToByteArray()),
+                (StructureId.PartitionedBloomFilter, new PartitionedBloomFilter(1000, 0.01).ToByteArray()),
+                (StructureId.ScalableBloomFilter, new ScalableBloomFilter(100, 0.01, 0.8).ToByteArray()),
+                (StructureId.StableBloomFilter, new StableBloomFilter(1000, 2, 0.01).ToByteArray()),
+                (StructureId.InverseBloomFilter, new InverseBloomFilter(500).ToByteArray()),
+                (StructureId.CuckooBloomFilter, new CuckooBloomFilter(1000, 0.01).ToByteArray()),
+                (StructureId.CountMinSketch, new CountMinSketch(0.01, 0.01).ToByteArray()),
+                (StructureId.HyperLogLog, new HyperLogLog(1024).ToByteArray()),
+                (StructureId.TopK, new TopK(0.001, 0.01, 10).ToByteArray()),
+                (StructureId.MinHashSignature, MinHash.Signature(new[] { "a" }, 8).ToByteArray()),
+                (StructureId.BinaryFuseFilter, BinaryFuseFilter.Build(new[] { Key("a") }).ToByteArray()),
+                (StructureId.DDSketch, FilledSketchOfNumbers()),
+                (StructureId.HyperLogLogPlus, new HyperLogLogPlus(14).Add(Key("a")).ToByteArray()),
+                (StructureId.QuotientFilter, new QuotientFilter(1000, 0.01).Add(Key("a")).ToByteArray()),
+                (StructureId.ThetaSketch, new ThetaSketch(4096).Add(Key("a")).ToByteArray()),
+                (StructureId.SimHashSignature, SimHash.Signature(new[] { "a" }).ToByteArray()),
+                (StructureId.CountSketch, new CountSketch(0.5, 0.5).Add(Key("a")).ToByteArray()),
+                (StructureId.InvertibleBloomLookupTable, new InvertibleBloomLookupTable(4, 8).Add(new byte[8]).ToByteArray()),
+                (StructureId.BloomierFilter, FilledBloomier()),
+                (StructureId.HeavyKeeper, new HeavyKeeper(10, 64, seed: 1).Add(Key("a")).ToByteArray()),
+                (StructureId.VarOpt, new VarOpt(10, seed: 1).Add(Key("a")).ToByteArray()),
+                (StructureId.UltraLogLog, new UltraLogLog(10).Add(Key("a")).ToByteArray()),
+                (StructureId.Grafite, Grafite.Build(new ulong[] { 1, 2, 3 }, 0.01, 16, seed: 1).ToByteArray()),
+                (StructureId.InfiniFilter, new InfiniFilter(64, 8).Add(Key("a")).ToByteArray()),
+                (StructureId.MementoFilter, new MementoFilter(256, 8).Add(5).ToByteArray()),
+                (StructureId.PrivateCountMinSketch,
                     new PrivateCountMinSketch(16, 2, 0.5, seed: 1).Add(Key("a")).ToByteArray()),
-                ("DpswSketch", FilledDpsw()),
+                (StructureId.DpswSketch, FilledDpsw()),
+                (StructureId.SublimeCountMinSketch, FilledSublime()),
+                (StructureId.SetSketch, FilledSetSketch()),
+                (StructureId.TupleSketch, FilledTuple()),
             };
 
             // Read every payload as a BloomFilter; only its own may succeed.
-            foreach (var (name, bytes) in payloads)
+            foreach (var (id, bytes) in payloads)
             {
-                if (name == "BloomFilter")
+                if (id == StructureId.BloomFilter)
                 {
                     Assert.IsNotNull(Persistence.FromByteArray<BloomFilter>(bytes));
                     continue;
@@ -647,12 +835,15 @@ namespace TestProbabilisticDataStructures
 
                 var ex = Assert.ThrowsExactly<InvalidDataException>(
                     () => Persistence.FromByteArray<BloomFilter>(bytes),
-                    $"a {name} payload was accepted as a BloomFilter");
-                StringAssert.Contains(ex.Message, name);
+                    $"a {id} payload was accepted as a BloomFilter");
+                StringAssert.Contains(ex.Message, id.ToString());
             }
 
+            AssertSweepCoversEveryStructure("read as another", payloads.Select(pl => pl.Id));
+
             // Every payload carries a distinct structure id, or the check above is
-            // weaker than it looks.
+            // weaker than it looks -- and the sweep has to be complete first, or this
+            // is only asserting that the structures someone remembered do not collide.
             var ids = payloads.Select(p => p.Bytes[6] | (p.Bytes[7] << 8)).ToArray();
             Assert.AreEqual(payloads.Length, ids.Distinct().Count(),
                 "two structures share a structure id");
@@ -665,45 +856,49 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void TestCorruptionIsCaughtInEveryStructure()
         {
-            var payloads = new (string Name, Func<byte[], object> Read, byte[] Bytes)[]
+            var payloads = new (StructureId Id, Func<byte[], object> Read, byte[] Bytes)[]
             {
-                ("BloomFilter64", b => Persistence.FromByteArray<BloomFilter64>(b), Filled(new BloomFilter64(200, 0.01))),
-                ("CountingBloomFilter", b => Persistence.FromByteArray<CountingBloomFilter>(b), Filled(new CountingBloomFilter(200, 4, 0.01))),
-                ("DeletableBloomFilter", b => Persistence.FromByteArray<DeletableBloomFilter>(b), Filled(new DeletableBloomFilter(200, 10, 0.01))),
-                ("PartitionedBloomFilter", b => Persistence.FromByteArray<PartitionedBloomFilter>(b), Filled(new PartitionedBloomFilter(200, 0.01))),
-                ("StableBloomFilter", b => Persistence.FromByteArray<StableBloomFilter>(b), Filled(new StableBloomFilter(200, 2, 0.01))),
-                ("InverseBloomFilter", b => Persistence.FromByteArray<InverseBloomFilter>(b), Filled(new InverseBloomFilter(50))),
-                ("CuckooBloomFilter", b => Persistence.FromByteArray<CuckooBloomFilter>(b), FilledCuckoo()),
-                ("HyperLogLog", b => Persistence.FromByteArray<HyperLogLog>(b), FilledHll()),
-                ("ScalableBloomFilter", b => Persistence.FromByteArray<ScalableBloomFilter>(b), Filled(new ScalableBloomFilter(50, 0.01, 0.8))),
-                ("TopK", b => Persistence.FromByteArray<TopK>(b), FilledTopK()),
-                ("BloomFilter", b => Persistence.FromByteArray<BloomFilter>(b), Filled(new BloomFilter(200, 0.01))),
-                ("CountMinSketch", b => Persistence.FromByteArray<CountMinSketch>(b), FilledSketch()),
-                ("MinHashSignature", b => Persistence.FromByteArray<MinHashSignature>(b), FilledSignature()),
-                ("BinaryFuseFilter", b => Persistence.FromByteArray<BinaryFuseFilter>(b), FilledFuse()),
-                ("DDSketch", b => Persistence.FromByteArray<DDSketch>(b), FilledSketchOfNumbers()),
+                (StructureId.BloomFilter64, b => Persistence.FromByteArray<BloomFilter64>(b), Filled(new BloomFilter64(200, 0.01))),
+                (StructureId.CountingBloomFilter, b => Persistence.FromByteArray<CountingBloomFilter>(b), Filled(new CountingBloomFilter(200, 4, 0.01))),
+                (StructureId.DeletableBloomFilter, b => Persistence.FromByteArray<DeletableBloomFilter>(b), Filled(new DeletableBloomFilter(200, 10, 0.01))),
+                (StructureId.PartitionedBloomFilter, b => Persistence.FromByteArray<PartitionedBloomFilter>(b), Filled(new PartitionedBloomFilter(200, 0.01))),
+                (StructureId.StableBloomFilter, b => Persistence.FromByteArray<StableBloomFilter>(b), Filled(new StableBloomFilter(200, 2, 0.01))),
+                (StructureId.InverseBloomFilter, b => Persistence.FromByteArray<InverseBloomFilter>(b), Filled(new InverseBloomFilter(50))),
+                (StructureId.CuckooBloomFilter, b => Persistence.FromByteArray<CuckooBloomFilter>(b), FilledCuckoo()),
+                (StructureId.HyperLogLog, b => Persistence.FromByteArray<HyperLogLog>(b), FilledHll()),
+                (StructureId.ScalableBloomFilter, b => Persistence.FromByteArray<ScalableBloomFilter>(b), Filled(new ScalableBloomFilter(50, 0.01, 0.8))),
+                (StructureId.TopK, b => Persistence.FromByteArray<TopK>(b), FilledTopK()),
+                (StructureId.BloomFilter, b => Persistence.FromByteArray<BloomFilter>(b), Filled(new BloomFilter(200, 0.01))),
+                (StructureId.CountMinSketch, b => Persistence.FromByteArray<CountMinSketch>(b), FilledSketch()),
+                (StructureId.MinHashSignature, b => Persistence.FromByteArray<MinHashSignature>(b), FilledSignature()),
+                (StructureId.BinaryFuseFilter, b => Persistence.FromByteArray<BinaryFuseFilter>(b), FilledFuse()),
+                (StructureId.DDSketch, b => Persistence.FromByteArray<DDSketch>(b), FilledSketchOfNumbers()),
                 // Both representations, which are different layouts behind one id.
-                ("HyperLogLogPlus sparse", b => Persistence.FromByteArray<HyperLogLogPlus>(b), FilledHllPlus(20)),
-                ("HyperLogLogPlus dense", b => Persistence.FromByteArray<HyperLogLogPlus>(b), FilledHllPlus(200)),
-                ("QuotientFilter", b => Persistence.FromByteArray<QuotientFilter>(b), FilledQuotient()),
-                ("ThetaSketch", b => Persistence.FromByteArray<ThetaSketch>(b), FilledTheta()),
-                ("SimHashSignature", b => Persistence.FromByteArray<SimHashSignature>(b),
+                (StructureId.HyperLogLogPlus, b => Persistence.FromByteArray<HyperLogLogPlus>(b), FilledHllPlus(20)),
+                (StructureId.HyperLogLogPlus, b => Persistence.FromByteArray<HyperLogLogPlus>(b), FilledHllPlus(200)),
+                (StructureId.QuotientFilter, b => Persistence.FromByteArray<QuotientFilter>(b), FilledQuotient()),
+                (StructureId.ThetaSketch, b => Persistence.FromByteArray<ThetaSketch>(b), FilledTheta()),
+                (StructureId.SimHashSignature, b => Persistence.FromByteArray<SimHashSignature>(b),
                     SimHash.Signature(new[] { "a", "b", "c", "d" }).ToByteArray()),
-                ("CountSketch", b => Persistence.FromByteArray<CountSketch>(b), FilledCountSketch()),
-                ("InvertibleBloomLookupTable", b => Persistence.FromByteArray<InvertibleBloomLookupTable>(b), FilledIblt()),
-                ("BloomierFilter", b => Persistence.FromByteArray<BloomierFilter>(b), FilledBloomier()),
-                ("HeavyKeeper", b => Persistence.FromByteArray<HeavyKeeper>(b), FilledHeavyKeeper()),
-                ("VarOpt", b => Persistence.FromByteArray<VarOpt>(b), FilledVarOpt()),
-                ("UltraLogLog", b => Persistence.FromByteArray<UltraLogLog>(b), FilledUltraLogLog()),
-                ("Grafite", b => Persistence.FromByteArray<Grafite>(b), FilledGrafite()),
-                ("InfiniFilter", b => Persistence.FromByteArray<InfiniFilter>(b), FilledInfiniFilter()),
-                ("MementoFilter", b => Persistence.FromByteArray<MementoFilter>(b), FilledMementoFilter()),
-                ("PrivateCountMinSketch", b => Persistence.FromByteArray<PrivateCountMinSketch>(b),
+                (StructureId.CountSketch, b => Persistence.FromByteArray<CountSketch>(b), FilledCountSketch()),
+                (StructureId.InvertibleBloomLookupTable, b => Persistence.FromByteArray<InvertibleBloomLookupTable>(b), FilledIblt()),
+                (StructureId.BloomierFilter, b => Persistence.FromByteArray<BloomierFilter>(b), FilledBloomier()),
+                (StructureId.HeavyKeeper, b => Persistence.FromByteArray<HeavyKeeper>(b), FilledHeavyKeeper()),
+                (StructureId.VarOpt, b => Persistence.FromByteArray<VarOpt>(b), FilledVarOpt()),
+                (StructureId.UltraLogLog, b => Persistence.FromByteArray<UltraLogLog>(b), FilledUltraLogLog()),
+                (StructureId.Grafite, b => Persistence.FromByteArray<Grafite>(b), FilledGrafite()),
+                (StructureId.InfiniFilter, b => Persistence.FromByteArray<InfiniFilter>(b), FilledInfiniFilter()),
+                (StructureId.MementoFilter, b => Persistence.FromByteArray<MementoFilter>(b), FilledMementoFilter()),
+                (StructureId.PrivateCountMinSketch, b => Persistence.FromByteArray<PrivateCountMinSketch>(b),
                     FilledPrivateSketch()),
-                ("DpswSketch", b => Persistence.FromByteArray<DpswSketch>(b), FilledDpsw()),
+                (StructureId.DpswSketch, b => Persistence.FromByteArray<DpswSketch>(b), FilledDpsw()),
+                (StructureId.SublimeCountMinSketch, b => Persistence.FromByteArray<SublimeCountMinSketch>(b),
+                    FilledSublime()),
+                (StructureId.SetSketch, b => Persistence.FromByteArray<SetSketch>(b), FilledSetSketch()),
+                (StructureId.TupleSketch, b => Persistence.FromByteArray<TupleSketch>(b), FilledTuple()),
             };
 
-            foreach (var (name, read, clean) in payloads)
+            foreach (var (id, read, clean) in payloads)
             {
                 for (int i = 4; i < clean.Length; i++)
                 {
@@ -711,9 +906,34 @@ namespace TestProbabilisticDataStructures
                     corrupted[i] ^= 0x01;
 
                     Assert.ThrowsExactly<InvalidDataException>(() => read(corrupted),
-                        $"{name}: a flipped bit at offset {i} was not caught");
+                        $"{id}: a flipped bit at offset {i} was not caught");
                 }
             }
+
+            AssertSweepCoversEveryStructure("corruption", payloads.Select(pl => pl.Id));
+        }
+
+        // Small on purpose, as with the other payloads here: the sweep above flips a
+        // bit at every offset of every payload one at a time.
+        private static byte[] FilledSublime()
+        {
+            var sketch = EmptySublime();
+            for (var i = 0; i < 40; i++) sketch.Add(Key($"w{i % 5}"));
+            return sketch.ToByteArray();
+        }
+
+        private static byte[] FilledSetSketch()
+        {
+            var sketch = new SetSketch(8);
+            for (var i = 0; i < 40; i++) sketch.Add(Key($"w{i}"));
+            return sketch.ToByteArray();
+        }
+
+        private static byte[] FilledTuple()
+        {
+            var sketch = new TupleSketch(16);
+            for (var i = 0; i < 40; i++) sketch.Add(Key($"w{i}"), 1.0 + i);
+            return sketch.ToByteArray();
         }
 
         private static byte[] FilledPrivateSketch()

--- a/TestProbabilisticDataStructures/TestPersistenceAllStructures.cs
+++ b/TestProbabilisticDataStructures/TestPersistenceAllStructures.cs
@@ -45,60 +45,6 @@ namespace TestProbabilisticDataStructures
             }
         }
 
-        /// <summary>
-        /// Asserts a sweep touched every structure the format knows about.
-        /// </summary>
-        /// <remarks>
-        /// Every roster in this file is written by hand, and a hand-written roster
-        /// agrees with itself: it is named "every structure" and means "every structure
-        /// whoever last edited it remembered". That is not a hypothetical -- when this
-        /// check was first written, all four sweeps below were missing the structures
-        /// added most recently, and one of them was asserting that no two structures
-        /// share an id across a roster three structures short of the full set.
-        /// <para>
-        /// <see cref="StructureId"/> is the roster a structure cannot leave itself off
-        /// of, because a structure that is not in it cannot be persisted at all. A new
-        /// structure therefore fails this until it is either covered or exempted.
-        /// </para>
-        /// </remarks>
-        /// <param name="sweep">Named in the failure, since four sweeps share this.</param>
-        /// <param name="covered">The structures the sweep exercised.</param>
-        /// <param name="exempt">
-        /// Structures the sweep cannot apply to, each with its reason. An exemption is
-        /// a claim about the structure rather than a way to quieten this, so it is
-        /// checked in turn: one naming a structure the sweep does cover has gone stale
-        /// and fails just as loudly as a gap.
-        /// </param>
-        private static void AssertSweepCoversEveryStructure(
-            string sweep,
-            IEnumerable<StructureId> covered,
-            params (StructureId Id, string Why)[] exempt)
-        {
-            var seen = covered.ToHashSet();
-            var excused = exempt.Select(e => e.Id).ToHashSet();
-
-            Assert.AreEqual(exempt.Length, excused.Count,
-                $"the {sweep} sweep exempts a structure twice");
-
-            foreach (var (id, why) in exempt)
-            {
-                Assert.IsFalse(string.IsNullOrWhiteSpace(why),
-                    $"the {sweep} sweep exempts {id} without saying why");
-                Assert.IsFalse(seen.Contains(id),
-                    $"the {sweep} sweep exempts {id} and then covers it anyway; " +
-                    "the reason given is out of date");
-            }
-
-            var missing = Enum.GetValues<StructureId>()
-                .Where(id => !seen.Contains(id) && !excused.Contains(id))
-                .ToArray();
-
-            Assert.IsEmpty(missing,
-                $"the {sweep} sweep is named for every structure but does not reach " +
-                string.Join(", ", missing) +
-                ". Cover it, or exempt it here with the reason it cannot apply.");
-        }
-
         [TestMethod]
         public void TestBloomFilter64RoundTrips()
         {
@@ -642,7 +588,7 @@ namespace TestProbabilisticDataStructures
                 check();
             }
 
-            AssertSweepCoversEveryStructure("empty round trip", checks.Select(c => c.Id));
+            StructureRoster.AssertCoversEveryStructure("empty round trip", checks.Select(c => c.Id));
         }
 
         // The starting width is a chunk of counters divided by the size factor, so
@@ -746,7 +692,7 @@ namespace TestProbabilisticDataStructures
                 AssertRefusesThenAccepts(id, bytes, without, with);
             }
 
-            AssertSweepCoversEveryStructure(
+            StructureRoster.AssertCoversEveryStructure(
                 "custom hash",
                 covered.Select(c => c.Id),
                 (StructureId.DDSketch,
@@ -839,7 +785,7 @@ namespace TestProbabilisticDataStructures
                 StringAssert.Contains(ex.Message, id.ToString());
             }
 
-            AssertSweepCoversEveryStructure("read as another", payloads.Select(pl => pl.Id));
+            StructureRoster.AssertCoversEveryStructure("read as another", payloads.Select(pl => pl.Id));
 
             // Every payload carries a distinct structure id, or the check above is
             // weaker than it looks -- and the sweep has to be complete first, or this
@@ -910,7 +856,7 @@ namespace TestProbabilisticDataStructures
                 }
             }
 
-            AssertSweepCoversEveryStructure("corruption", payloads.Select(pl => pl.Id));
+            StructureRoster.AssertCoversEveryStructure("corruption", payloads.Select(pl => pl.Id));
         }
 
         // Small on purpose, as with the other payloads here: the sweep above flips a

--- a/TestProbabilisticDataStructures/TestSetHash.cs
+++ b/TestProbabilisticDataStructures/TestSetHash.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO.Hashing;
 using System.Linq;
 using System.Text;
@@ -78,70 +78,81 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
-        /// Every filter exposing SetHash should accept one and keep working. This is a
+        /// Every structure exposing SetHash accepts one and keeps working. This is a
         /// breadth check rather than a deep one: the point is that no implementation
-        /// was missed when the signature changed.
+        /// was missed when the signature changed, so the roster it sweeps is derived
+        /// from the library's own surface rather than typed out here.
         /// </summary>
         [TestMethod]
-        public void TestEveryFilterAcceptsASuppliedHash()
+        public void TestEveryStructureAcceptsASuppliedHash()
         {
             var a = Key("alpha");
 
-            var bloom = new BloomFilter(100, 0.01);
-            bloom.SetHash(AlternateHash);
-            bloom.Add(a);
-            Assert.IsTrue(bloom.Test(a));
+            var covered = new (Type Type, Action Exercise)[]
+            {
+                Accepting(new BloomFilter(100, 0.01), f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(new BloomFilter64(100, 0.01), f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(CountingBloomFilter.NewDefaultCountingBloomFilter(100, 0.01),
+                    f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(new PartitionedBloomFilter(100, 0.01), f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(new DeletableBloomFilter(100, 10, 0.01), f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(StableBloomFilter.NewDefaultStableBloomFilter(100, 0.01),
+                    f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(new InverseBloomFilter(100), f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(new CuckooBloomFilter(100, 0.01), f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(ScalableBloomFilter.NewDefaultScalableBloomFilter(0.01),
+                    f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(new QuotientFilter(100, 0.01), f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
+                Accepting(new InfiniFilter(64, 8), f => { f.Add(a); Assert.IsTrue(f.Test(a)); }),
 
-            var bloom64 = new BloomFilter64(100, 0.01);
-            bloom64.SetHash(AlternateHash);
-            bloom64.Add(a);
-            Assert.IsTrue(bloom64.Test(a));
+                // These have no Test, so exercising the query they do have is the
+                // available check.
+                Accepting(new CountMinSketch(0.001, 0.99),
+                    f => { f.Add(a); Assert.IsGreaterThanOrEqualTo(1UL, f.Count(a)); }),
+                Accepting(HyperLogLog.NewDefaultHyperLogLog(0.01),
+                    f => { f.Add(a); Assert.IsGreaterThan(0UL, f.Count()); }),
+                Accepting(new HyperLogLogPlus(14),
+                    f => { f.Add(a); Assert.IsGreaterThan(0UL, f.Count()); }),
+                Accepting(new CountSketch(0.05, 0.01),
+                    f => { f.Add(a); Assert.IsGreaterThanOrEqualTo(1L, f.Count(a)); }),
+                Accepting(new ThetaSketch(64),
+                    f => { f.Add(a); Assert.IsGreaterThan(0UL, f.Count()); }),
+                Accepting(new UltraLogLog(10),
+                    f => { f.Add(a); Assert.IsGreaterThan(0UL, f.Count()); }),
+                Accepting(new SetSketch(64),
+                    f => { f.Add(a); Assert.IsGreaterThan(0.0, f.Cardinality()); }),
+                Accepting(new TupleSketch(16),
+                    f => { f.Add(a, 1.0); Assert.IsGreaterThan(0UL, f.Count()); }),
+                Accepting(new SublimeCountMinSketch(0.5, 0.5, ValeCounterArray.DefaultCountersPerChunk),
+                    f => { f.Add(a); Assert.IsGreaterThanOrEqualTo(1UL, f.Count(a)); }),
+            };
 
-            var counting = CountingBloomFilter.NewDefaultCountingBloomFilter(100, 0.01);
-            counting.SetHash(AlternateHash);
-            counting.Add(a);
-            Assert.IsTrue(counting.Test(a));
+            foreach (var (_, exercise) in covered)
+            {
+                exercise();
+            }
 
-            var partitioned = new PartitionedBloomFilter(100, 0.01);
-            partitioned.SetHash(AlternateHash);
-            partitioned.Add(a);
-            Assert.IsTrue(partitioned.Test(a));
+            StructureRoster.AssertCoversEveryType(
+                "supplied hash",
+                StructureRoster.WithSetHash,
+                covered.Select(c => c.Type));
+        }
 
-            var deletable = new DeletableBloomFilter(100, 10, 0.01);
-            deletable.SetHash(AlternateHash);
-            deletable.Add(a);
-            Assert.IsTrue(deletable.Test(a));
-
-            var stable = StableBloomFilter.NewDefaultStableBloomFilter(100, 0.01);
-            stable.SetHash(AlternateHash);
-            stable.Add(a);
-            Assert.IsTrue(stable.Test(a));
-
-            var inverse = new InverseBloomFilter(100);
-            inverse.SetHash(AlternateHash);
-            inverse.Add(a);
-            Assert.IsTrue(inverse.Test(a));
-
-            var cuckoo = new CuckooBloomFilter(100, 0.01);
-            cuckoo.SetHash(AlternateHash);
-            cuckoo.Add(a);
-            Assert.IsTrue(cuckoo.Test(a));
-
-            var scalable = ScalableBloomFilter.NewDefaultScalableBloomFilter(0.01);
-            scalable.SetHash(AlternateHash);
-            scalable.Add(a);
-            Assert.IsTrue(scalable.Test(a));
-
-            // These have no Test, so exercising Add is the available check.
-            var cms = new CountMinSketch(0.001, 0.99);
-            cms.SetHash(AlternateHash);
-            cms.Add(a);
-            Assert.IsGreaterThanOrEqualTo(1UL, cms.Count(a));
-
-            var hll = HyperLogLog.NewDefaultHyperLogLog(0.01);
-            hll.SetHash(AlternateHash);
-            hll.Add(a);
-            Assert.IsGreaterThan(0UL, hll.Count());
+        /// <summary>
+        /// Installs the alternate hash on a freshly built structure and hands back the
+        /// check that it still works, paired with the type so a failure names it.
+        /// </summary>
+        /// <remarks>
+        /// SetHash is a shape rather than an interface -- twenty structures declare it
+        /// and none of them share a base that does -- so it is called here through the
+        /// same signature the roster is derived from. That keeps the two in step: a
+        /// type the roster finds is a type this can drive.
+        /// </remarks>
+        private static (Type Type, Action Exercise) Accepting<T>(T structure, Action<T> exercise)
+        {
+            typeof(T).GetMethod("SetHash", new[] { typeof(Func<ReadOnlySpan<byte>, ulong>) })!
+                .Invoke(structure, new object[] { (Func<ReadOnlySpan<byte>, ulong>)AlternateHash });
+            return (typeof(T), () => exercise(structure));
         }
     }
 }


### PR DESCRIPTION
Six tests in this suite are named for every structure in the library. None of them was true.

Each was a list written by hand, which means each was a list of the structures whoever last edited it remembered. They agree with themselves perfectly — named "every structure", meaning "every structure someone thought of" — and nothing failed when the next one was added.

## What was missing

| Sweep | Reached |
|---|---|
| `TestEveryStructureRoundTripsWhileEmpty` | 26 of 33 |
| `TestCorruptionIsCaughtInEveryStructure` | 30 of 33 |
| `TestEveryStructureRefusesToBeReadAsAnother` | 30 of 33 |
| `TestEveryStructureUsesAHashGivenToItsConstructor` | 12 of 25 |
| `TestEveryStructureRefusesToReplaceTheHashOnceItHoldsSomething` | 11 of 20 |
| `TestEveryStructureAcceptsASuppliedHash` | 11 of 20 |

The gaps tracked the release — the structures 6.2.0 added were the ones absent — and `BloomFilter` itself had dropped out of the empty sweep at some earlier point.

The sharpest one is `TestEveryStructureRefusesToBeReadAsAnother`. It ends by asserting that no two structures share a persistence id, computed across its own roster. Three structures were missing from that roster, so a duplicate id given to any of them would have passed the test written to catch precisely that.

## What changed

`StructureRoster` checks each sweep against a roster derived rather than typed out:

- **`StructureId`** for the persistence sweeps — a structure that is not in it cannot be persisted at all.
- **Reflection over the library's public surface** for the hash sweeps, where no enum exists: the types declaring `SetHash` with the hash signature, and the types with a constructor or static factory taking one. Both filtered to structures that persist, which excludes the hash plumbing whose factories also take a hash function. `ReadFrom` is deliberately not a builder — it is the caller handing back the hash the payload says was in use.

A structure that genuinely cannot be swept is exempted **with its reason**, and the exemption is checked in turn: one naming a structure the sweep does cover has gone stale and fails as loudly as a gap. Six structures are exempt from the custom-hash sweep, all because they offer no parameter through which to install one.

## What it caught

Nothing in the library. Every structure that can be handed a hash at construction does record it; every structure exposing `SetHash` does refuse to replace one once occupied; corruption is caught anywhere in every payload. The sweeps were not wrong about the structures they reached — they were silent about the ones they did not.

## Verification

Eight probes, each with the build exit checked so a probe that failed to compile could not be read as a result:

- dropping one structure from each of the six sweeps → killed, named
- an exemption naming a covered structure → killed as stale
- an exemption with a blank reason → killed
- a sweep naming a type outside its roster → killed
- **adding a member to `StructureId`** → fails all four persistence sweeps by name
- **removing the persistable filter from the reflected roster** → fails the constructor sweep on the hash plumbing it exists to exclude

Clean `dotnet build -c Release -warnaserror`, exit 0 unpiped. 904 tests passing, unchanged — the sweeps are the same six methods, reaching 71 more structure-sweep pairs between them.