### PR TITLE
Document the three missing payloads, and hold the spec to the code

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -715,6 +715,60 @@ read another", so a small count costs as much as one memento and a large one sti
 A reader rejects an impossible memento width, a chain of no tables or absurdly many, a
 table with more entries than slots, and a word count disagreeing with the shape claimed.
 
+### `SublimeCountMinSketch` (id 29)
+
+```
+f64     delta, the probability the error bound is exceeded
+f64     the growth exponent
+f64     the size factor
+u32     the number of rows
+u32     the number of counters in a row
+u64     the total count
+u64     the count at which the arrays next double
+u64     the count at which they next fold back
+u32     the number of records of earlier states, oldest first
+u32       the number of counters in one row of that record
+u64         each of its counters, row by row
+u64     each counter of the current arrays, row by row
+```
+
+The counters are written as plain `u64` rather than in the packed form the sketch holds
+them in. Packing depends on two parameters the sketch retunes as it runs, so packed bits
+would only be safely readable by the version that wrote them — and a corrupted payload
+would not look corrupt, it would decode into different counters. Every `u64` is a valid
+count, so nothing in this layout can be misread as something else. The sketch packs them
+again on the way in, at a tuning chosen to suit what it just read.
+
+The records of earlier states are what let the sketch fold back rather than only grow.
+Each stands for one doubling and is half the width of the one after it, so a reader can
+check the whole chain against the current width: a record claiming a width the doublings
+that follow it do not require is refused.
+
+A reader also rejects a delta outside nought to one, a growth exponent outside the same
+range, a size factor that is not positive, a row count of zero or sixty-four or more,
+a width that is not a power of two — the low bits of a hash pick the counter — and more
+than thirty records, which would be more counters than a row may hold.
+
+### `SetSketch` (id 30)
+
+```
+f64     b, the base
+f64     a, the hash rate
+u32     m, the number of registers
+u32     q, the largest value a register may hold
+u8      the construction, at format version 4 only
+u16     each register
+```
+
+The lower bound the insert path keeps is not written. It is an accelerator rather than
+state: any value no register is below will do, and the registers themselves say what it
+should be, so a reader recomputes it rather than trusting a number that could be wrong.
+
+A reader rejects a base at or below one or above two, a rate that is not positive, a
+register count of zero or one that would run to half a gigabyte, a ceiling a two-byte
+register could not hold one more than, and any register above that ceiling — which no
+sketch with these parameters could have written.
+
 ### `SetSketch` variants
 
 A sketch built with the paper's **second** construction writes one extra byte after the
@@ -729,6 +783,28 @@ merely tolerated.
 
 A reader at version 4 or above rejects any variant byte other than the second
 construction's, since the first writes none.
+
+### `TupleSketch` (id 31)
+
+```
+u32     the nominal entry count
+u8      the summary policy
+u64     theta, the sampling threshold
+u32     the number of keys held
+u64     each key, in increasing order
+f64     each key's summary, in the same order
+```
+
+Keys come first and summaries after, rather than interleaved, so that a payload whose
+keys are not in increasing order is detectably not one of these without stepping over a
+value between each pair. The sketch is compacted before it is written, so the keys are
+the distinct retained set rather than whatever order they arrived in.
+
+A reader rejects a nominal entry count this library does not build, a policy byte naming
+a way of folding it does not know, more keys held than twice what the sketch retains,
+keys out of increasing order, a key at or above theta — which the sampling that produced
+the rest would have discarded — and a summary that is not a number, which the sketch
+refuses on the way in and so cannot have written.
 
 ### `PrivateCountMinSketch` (id 32)
 

--- a/ProbabilisticDataStructures/PersistenceFormat.cs
+++ b/ProbabilisticDataStructures/PersistenceFormat.cs
@@ -126,12 +126,17 @@ namespace ProbabilisticDataStructures
         /// </summary>
         /// <remarks>
         /// The version travels in each payload rather than being a property of the
-        /// library, so a structure whose layout changes bumps only its own. Version 2
-        /// exists for the two filters that gained a stored random-generator state in
-        /// 6.0.0; the other eleven still write version 1 and stay readable by 3.x
-        /// onwards. Raising all of them together would have made every payload
-        /// unreadable to older versions to record a change that eleven of them did not
-        /// have.
+        /// library, so a structure whose layout changes bumps only its own and the rest
+        /// go on writing version 1, readable by 3.x onwards. Raising all of them
+        /// together would make every payload unreadable to older libraries in order to
+        /// record a change those payloads did not have.
+        /// <para>
+        /// Which structures write which version is not stated here on purpose. A count
+        /// in a comment is a roster maintained by hand, and this one was wrong for
+        /// several releases before anyone read it closely. The versions that exist are
+        /// the named constants below, and each is used by the structures that reference
+        /// it -- which the compiler keeps true and a comment cannot.
+        /// </para>
         /// </remarks>
         internal const ushort DefaultVersion = 1;
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -262,6 +262,27 @@ The proof that this works is not that the sweeps pass. It is that adding a membe
 filter from the reflected roster fails the constructor sweep on the hash plumbing it
 was there to exclude.
 
+The same treatment applies past the test suite. FORMAT.md is the one artefact here
+written for someone who does not have the library — it exists so a payload can be
+decoded from the bytes alone — and it had drifted the same way, silently, because a
+document has no build to fail. Two structures shipped in 6.2.0 with no section at all
+and a third had a section about its variant byte that never said what the rest of its
+payload holds. It is now embedded in the test assembly and held to `StructureId`: every
+structure has a section, and every section's heading names the id a reader will find in
+the envelope. A section under the wrong id is worse than a missing one, because someone
+decoding by hand gets an answer.
+
+Prose counts belong in the same category. `PersistenceFormat.DefaultVersion` explained
+that two filters write version 2 and "the other eleven" version 1 — true at thirteen
+structures, wrong from the next release onward. A count in a comment is a roster
+maintained by hand, and the fix is to remove the number rather than correct it.
+
+The rosters also disagree with your own audit, which is the point of deriving them. The
+span-equivalence sweep was short by six, and adding those six turned up two more the
+audit had passed over — `BinaryFuseFilter` and `BloomierFilter`, which are built once
+from a whole key set and have no incremental path to compare. They are exempt with that
+reason, and the exemption is checked. The roster found them; reading the file had not.
+
 Filling the six sweeps found no defects in the library — every structure did honour a
 constructor hash, did refuse to replace one once occupied, and did catch corruption
 anywhere in its payload. That is the point worth keeping: the sweeps were not wrong

--- a/TestProbabilisticDataStructures/StructureRoster.cs
+++ b/TestProbabilisticDataStructures/StructureRoster.cs
@@ -50,6 +50,21 @@ namespace TestProbabilisticDataStructures
                 .ToArray();
 
         /// <summary>
+        /// Every public structure offering a span overload. The span and array paths
+        /// have to be the same operation rather than a similar one, and that is a claim
+        /// about all of them: the seam between the two is per structure, so a structure
+        /// left out of the sweep is a seam nobody looked at.
+        /// </summary>
+        internal static IReadOnlyList<Type> WithSpanOverloads { get; } =
+            Library.GetTypes()
+                .Where(t => t.IsPublic && !t.IsAbstract && IsAStructure(t))
+                .Where(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                    .Any(m => m.GetParameters()
+                        .Any(param => param.ParameterType == typeof(ReadOnlySpan<byte>))))
+                .OrderBy(t => t.Name, StringComparer.Ordinal)
+                .ToArray();
+
+        /// <summary>
         /// Every public structure that can be handed a hash as it is built, whether
         /// through a constructor or a static factory. This is a wider set than
         /// <see cref="WithSetHash"/>: for several structures, construction is the only

--- a/TestProbabilisticDataStructures/TestFormatDocumentation.cs
+++ b/TestProbabilisticDataStructures/TestFormatDocumentation.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ProbabilisticDataStructures;
+
+namespace TestProbabilisticDataStructures
+{
+    /// <summary>
+    /// Holds FORMAT.md to the format it describes.
+    /// </summary>
+    /// <remarks>
+    /// The specification is the one artefact here written for someone who does not have
+    /// the library: it exists so a payload can be decoded from the bytes alone. That
+    /// makes a gap in it worse than a gap in a test, and harder to notice, because
+    /// nothing stops compiling and no assertion goes red.
+    /// <para>
+    /// It had drifted. SublimeCountMinSketch and TupleSketch shipped in 6.2.0 with no
+    /// section at all, and SetSketch had a section about its variant byte without ever
+    /// saying what the rest of its payload holds -- so a reader learnt that the sketch
+    /// records which construction built it, and nothing about the registers.
+    /// </para>
+    /// </remarks>
+    [TestClass]
+    public class TestFormatDocumentation
+    {
+        private static readonly Regex PayloadSection =
+            new(@"^### `(?<name>[A-Za-z0-9]+)` \(id (?<id>\d+)\)$", RegexOptions.Multiline);
+
+        private static string Specification()
+        {
+            using var resource = typeof(TestFormatDocumentation).Assembly
+                .GetManifestResourceStream("TestProbabilisticDataStructures.FORMAT.md");
+            Assert.IsNotNull(resource, "FORMAT.md is not embedded in the test assembly");
+            using var reader = new StreamReader(resource);
+            return reader.ReadToEnd();
+        }
+
+        /// <summary>
+        /// Every structure the format can write has a section describing what it writes.
+        /// </summary>
+        [TestMethod]
+        public void TestEveryStructureHasItsPayloadDocumented()
+        {
+            var documented = PayloadSection.Matches(Specification())
+                .Select(m => m.Groups["name"].Value)
+                .ToArray();
+
+            Assert.AreEqual(documented.Length, documented.Distinct().Count(),
+                "FORMAT.md documents the same structure twice");
+
+            StructureRoster.AssertCoversEveryStructure(
+                "payload documentation",
+                documented.Select(Enum.Parse<StructureId>));
+        }
+
+        /// <summary>
+        /// Each section's heading names the id a reader will actually find in the
+        /// envelope. A section under the wrong id sends someone decoding by hand to the
+        /// wrong layout, which is worse than no section: they get an answer.
+        /// </summary>
+        [TestMethod]
+        public void TestEveryDocumentedIdMatchesTheStructureItNames()
+        {
+            foreach (Match section in PayloadSection.Matches(Specification()))
+            {
+                var name = section.Groups["name"].Value;
+                var documented = ushort.Parse(section.Groups["id"].Value);
+
+                Assert.AreEqual(
+                    (ushort)Enum.Parse<StructureId>(name), documented,
+                    $"FORMAT.md documents {name} under id {documented}");
+            }
+        }
+    }
+}

--- a/TestProbabilisticDataStructures/TestFormatDocumentation.cs
+++ b/TestProbabilisticDataStructures/TestFormatDocumentation.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -25,8 +25,12 @@ namespace TestProbabilisticDataStructures
     [TestClass]
     public class TestFormatDocumentation
     {
+        // The trailing \r is matched rather than assumed away: the file is checked out
+        // with CRLF line endings on Windows, and a pattern anchored with $ alone finds
+        // nothing there. That failure is not loud by itself -- a sweep over no sections
+        // passes every per-section assertion it makes -- so PayloadSections guards it.
         private static readonly Regex PayloadSection =
-            new(@"^### `(?<name>[A-Za-z0-9]+)` \(id (?<id>\d+)\)$", RegexOptions.Multiline);
+            new(@"^### `(?<name>[A-Za-z0-9]+)` \(id (?<id>\d+)\)\r?$", RegexOptions.Multiline);
 
         private static string Specification()
         {
@@ -38,12 +42,29 @@ namespace TestProbabilisticDataStructures
         }
 
         /// <summary>
+        /// The payload sections, with the vacuity guard both tests below need: a
+        /// pattern matching nothing turns either of them into a loop over an empty
+        /// collection, which passes.
+        /// </summary>
+        private static MatchCollection PayloadSections()
+        {
+            var sections = PayloadSection.Matches(Specification());
+
+            Assert.IsGreaterThan(0, sections.Count,
+                "no payload sections were found in FORMAT.md at all, so every " +
+                "assertion made about them below is vacuous. The heading pattern and " +
+                "the document have diverged.");
+
+            return sections;
+        }
+
+        /// <summary>
         /// Every structure the format can write has a section describing what it writes.
         /// </summary>
         [TestMethod]
         public void TestEveryStructureHasItsPayloadDocumented()
         {
-            var documented = PayloadSection.Matches(Specification())
+            var documented = PayloadSections()
                 .Select(m => m.Groups["name"].Value)
                 .ToArray();
 
@@ -63,7 +84,7 @@ namespace TestProbabilisticDataStructures
         [TestMethod]
         public void TestEveryDocumentedIdMatchesTheStructureItNames()
         {
-            foreach (Match section in PayloadSection.Matches(Specification()))
+            foreach (Match section in PayloadSections())
             {
                 var name = section.Groups["name"].Value;
                 var documented = ushort.Parse(section.Groups["id"].Value);

--- a/TestProbabilisticDataStructures/TestProbabilisticDataStructures.csproj
+++ b/TestProbabilisticDataStructures/TestProbabilisticDataStructures.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -12,6 +12,10 @@
     <!-- Payloads written by 3.2.0, kept byte-for-byte so that a change to the format
          fails here rather than in a user's stored data. -->
     <EmbeddedResource Include="fixtures\*.bin" LogicalName="TestProbabilisticDataStructures.fixtures.%(Filename)%(Extension)" />
+    <!-- The format specification, embedded so a test can hold it to the code it
+         describes. A spec that has drifted is worse than none: it is read by people
+         decoding a payload without this library. -->
+    <EmbeddedResource Include="..\FORMAT.md" LogicalName="TestProbabilisticDataStructures.FORMAT.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestProbabilisticDataStructures/TestSpanOverloads.cs
+++ b/TestProbabilisticDataStructures/TestSpanOverloads.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -63,7 +63,7 @@ namespace TestProbabilisticDataStructures
         /// Drives a structure twice -- once through arrays, once through slices of a
         /// packed buffer -- and requires the two final states to be identical.
         /// </summary>
-        private static void AssertSpanPathMatches<T>(
+        private static Type AssertSpanPathMatches<T>(
             string name, Func<T> create, Action<T, byte[]> viaArray,
             Action<T, byte[], int, int> viaSpan)
             where T : IBinaryPersistable<T>
@@ -86,76 +86,148 @@ namespace TestProbabilisticDataStructures
                 $"{name}: feeding the same {Items} keys as spans left a different " +
                 "state than feeding them as arrays. The overloads must be the same " +
                 "operation, not merely a similar one.");
+
+            return typeof(T);
+        }
+
+        /// <summary>
+        /// The same, for a structure whose keys are a fixed width. One packed buffer of
+        /// equal-length keys, so the slices differ in provenance and offset but not in
+        /// length -- which is all the table will accept.
+        /// </summary>
+        private static Type AssertFixedWidthSpanPathMatches<T>(
+            string name, int keySize, Func<T> create, Action<T, byte[]> viaArray,
+            Action<T, byte[], int, int> viaSpan)
+            where T : IBinaryPersistable<T>
+        {
+            var buffer = new byte[Items * keySize];
+            for (int i = 0; i < Items; i++)
+            {
+                BitConverter.TryWriteBytes(buffer.AsSpan(i * keySize, keySize), (long)i * 2654435761L);
+            }
+
+            var arrayFed = create();
+            var spanFed = create();
+            for (int i = 0; i < Items; i++)
+            {
+                viaArray(arrayFed, buffer.AsSpan(i * keySize, keySize).ToArray());
+                viaSpan(spanFed, buffer, i * keySize, keySize);
+            }
+
+            CollectionAssert.AreEqual(arrayFed.ToByteArray(), spanFed.ToByteArray(),
+                $"{name}: feeding the same {Items} keys as spans left a different " +
+                "state than feeding them as arrays.");
+
+            return typeof(T);
         }
 
         [TestMethod]
         public void TestSpanAndArrayPathsLeaveIdenticalState()
         {
+            var covered = new[]
+            {
             AssertSpanPathMatches("BloomFilter", () => new BloomFilter(1000, 0.01),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("BloomFilter64", () => new BloomFilter64(1000, 0.01),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("PartitionedBloomFilter",
                 () => new PartitionedBloomFilter(1000, 0.01),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("CountingBloomFilter",
                 () => CountingBloomFilter.NewDefaultCountingBloomFilter(1000, 0.01),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("DeletableBloomFilter",
                 () => new DeletableBloomFilter(1000, 100, 0.01),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("CuckooBloomFilter",
                 () => new CuckooBloomFilter(1000, 0.01, seed: 9),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("QuotientFilter", () => new QuotientFilter(1000, 0.01),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("InverseBloomFilter", () => new InverseBloomFilter(500),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("CountMinSketch", () => new CountMinSketch(0.001, 0.01),
-                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l)));
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("CountSketch", () => new CountSketch(0.01, 0.01),
-                (s, k) => s.Add(k, 3), (s, b, o, l) => s.Add(b.AsSpan(o, l), 3));
+                (s, k) => s.Add(k, 3), (s, b, o, l) => s.Add(b.AsSpan(o, l), 3)),
 
             AssertSpanPathMatches("HyperLogLog", () => new HyperLogLog(1024),
-                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l)));
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("HyperLogLogPlus", () => new HyperLogLogPlus(12),
-                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l)));
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("ThetaSketch", () => new ThetaSketch(256),
-                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l)));
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("TopK", () => new TopK(0.001, 0.01, 20),
-                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l)));
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("HeavyKeeper", () => new HeavyKeeper(20, 512, seed: 3),
-                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l)));
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("VarOpt", () => new VarOpt(20, seed: 3),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("UltraLogLog", () => new UltraLogLog(10),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("InfiniFilter", () => new InfiniFilter(64, 8),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("StableBloomFilter",
                 () => new StableBloomFilter(1000, 4, 0.01, seed: 5),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
 
             AssertSpanPathMatches("ScalableBloomFilter",
                 () => new ScalableBloomFilter(100, 0.01, 0.8),
-                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l)));
+                (f, k) => f.Add(k), (f, b, o, l) => f.Add(b.AsSpan(o, l))),
+
+            AssertSpanPathMatches("SetSketch", () => new SetSketch(64),
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
+
+            AssertSpanPathMatches("TupleSketch", () => new TupleSketch(256),
+                (s, k) => s.Add(k, 1.5), (s, b, o, l) => s.Add(b.AsSpan(o, l), 1.5)),
+
+            AssertSpanPathMatches("SublimeCountMinSketch",
+                () => new SublimeCountMinSketch(0.01, 0.5, 1.0),
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
+
+            // The two noisy sketches are seeded, so the noise either side of the seam
+            // is the same draw and a difference in the payload is a difference in the
+            // counts underneath it.
+            AssertSpanPathMatches("PrivateCountMinSketch",
+                () => new PrivateCountMinSketch(64, 4, 1.0, seed: 3),
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
+
+            AssertSpanPathMatches("DpswSketch",
+                () => new DpswSketch(
+                    window: 128, rho: 4.0, alpha: 0.6, width: 8, depth: 2, seed: 3),
+                (s, k) => s.Add(k), (s, b, o, l) => s.Add(b.AsSpan(o, l))),
+
+            AssertFixedWidthSpanPathMatches("InvertibleBloomLookupTable", 8,
+                () => new InvertibleBloomLookupTable(64, 8),
+                (t, k) => t.Add(k), (t, b, o, l) => t.Add(b.AsSpan(o, l))),
+            };
+
+            StructureRoster.AssertCoversEveryType(
+                "span equivalence", StructureRoster.WithSpanOverloads, covered,
+                (typeof(BinaryFuseFilter),
+                    "is built once from the whole key set and has no Add, so there are " +
+                    "no two feeding paths to compare. Its span surface is Test, which " +
+                    "TestSpanAndArrayQueriesAgree covers."),
+                (typeof(BloomierFilter),
+                    "likewise: built by Build and queried by TryGetValue, with nothing " +
+                    "to feed it incrementally."));
         }
 
         /// <summary>


### PR DESCRIPTION
Three findings from auditing the remaining hand-maintained rosters. One of them is outward-facing.

## FORMAT.md had drifted, and nothing checked it

FORMAT.md is the one artefact in this repo written for someone who does **not** have the library — it exists so a payload can be decoded from the bytes alone. That makes a gap in it worse than a gap in a test, and much harder to notice: nothing stops compiling, no assertion goes red.

It documented 30 of 33 structures.

- `SublimeCountMinSketch` (id 29) — no section; the name appeared nowhere in the document
- `TupleSketch` (id 31) — same
- `SetSketch` (id 30) — had `### SetSketch variants`, explaining the version-4 variant byte and why the asymmetry is deliberate, without ever giving the payload layout. A reader learnt that the sketch records which construction built it, and nothing about the registers.

All three now have payload sections in the house style, with the reader's refusals written down as the neighbouring sections do.

`TestFormatDocumentation` embeds FORMAT.md in the test assembly and holds it to `StructureId`: every structure has a section, and every section's heading names the id a reader will actually find in the envelope. A section under the **wrong** id is worse than a missing one, because someone decoding by hand gets an answer.

## The span sweep was short by six, and by eight

`TestSpanAndArrayPathsLeaveIdenticalState` reached 22 of the 28 structures offering span overloads. Added `SetSketch`, `TupleSketch`, `SublimeCountMinSketch`, both noisy sketches (seeded, so the noise either side of the seam is the same draw and a payload difference is a difference in the counts underneath), and `InvertibleBloomLookupTable`, which needed a fixed-width variant of the helper since it rejects a key of any other length.

The roster then caught two the audit had missed: `BinaryFuseFilter` and `BloomierFilter` are built once from a whole key set and have no `Add`, so there are no two feeding paths to compare. Both are exempt with that reason — their span surface is a query, already covered by `TestSpanAndArrayQueriesAgree` further down the same file. I initially added duplicate coverage for them before noticing it was already there.

## A count in a comment

`PersistenceFormat.DefaultVersion` said two filters write version 2 and *"the other eleven"* version 1. True at thirteen structures; wrong from the next release onward, and wrong twice over now that three non-default versions exist. The number is gone rather than corrected — the versions are named constants, and the compiler keeps their users true in a way a comment cannot.

## Verification

Five probes, each with the build exit checked so a probe that failed to compile could not be misread as a result:

- dropping `TupleSketch`'s FORMAT heading → killed, named
- documenting `SetSketch` under id 29 → killed, `documents SetSketch under id 29`
- dropping `SetSketch` from the span sweep → killed, named
- blanking the `BinaryFuseFilter` exemption reason → killed
- **adding a member to `StructureId`** → fails the documentation sweep, so a new structure cannot ship undocumented

Clean `dotnet build -c Release -warnaserror`, exit 0 unpiped. 906 tests passing, up 2.

## Not done here

`TestSpanAndArrayQueriesAgree` covers 5 of the 20 structures with span *query* overloads. That is a real gap of the same family, but a materially bigger piece of work — several of those methods (`TestAndAdd`, `TestAndRemove`) mutate, so "the queries agree" needs a different shape than the pure ones. Left for its own change rather than folded in here.